### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile || yarn install
+      - name: Run Prettier check
+        run: yarn prettier --check
+      - name: Run tests
+        run: yarn test
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
## Summary
- add a CI workflow that runs prettier, tests and build on pull requests to `main`

## Testing
- `yarn prettier --check` *(fails: No project found)*
- `yarn test` *(fails: No project found)*
- `yarn build` *(fails: No project found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b671281c832b93dc3559a83a1a6f