### PR TITLE
Add graph layout logic and side panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miro Structured Graph Generator
 
-The **Miro Structured Graph Generator** plugin demonstrates how to import structured graph data in JSON format, lay it out with the [ELK](https://www.eclipse.org/elk/) layout engine, and render the result directly to a Miro board.  It is built with [Preact](https://preactjs.com/) and TypeScript and can serve as a starting point for your own Miro app development.
+The **Miro Structured Graph Generator** plugin demonstrates how to import structured graph data in JSON format, lay it out with the [ELK](https://www.eclipse.org/elk/) layout engine, and render the result directly to a Miro board. It is built with [Preact](https://preactjs.com/) and TypeScript and can serve as a starting point for your own Miro app development.
 
 ## Prerequisites
 
@@ -48,4 +48,3 @@ yarn build
 ```
 
 The generated files will appear in the `dist` directory. Host these files on a static server and configure the URL in your Miro app settings to deploy the plugin.
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,46 +1,34 @@
 import '/assets/style.css';
+import { useEffect } from 'preact/hooks';
+import SidePanel from './ui/SidePanel';
+import { parseGraph } from './logic/inputParser';
+import { runLayout } from './logic/layoutEngine';
+import { renderNodes } from './logic/shapeRenderer';
+import { renderEdges } from './logic/edgeRenderer';
 
-import { Component } from 'preact';
+const sampleData = {
+  nodes: [
+    { id: 'n1', label: 'Node 1' },
+    { id: 'n2', label: 'Node 2' },
+  ],
+  edges: [{ id: 'e1', source: 'n1', target: 'n2', label: 'Edge 1' }],
+};
 
-async function addSticky() {
-  const stickyNote = await miro.board.createStickyNote({
-    content: 'Hello, World!',
-  });
-
-  await miro.board.viewport.zoomTo(stickyNote);
+async function main() {
+  const graph = parseGraph(sampleData);
+  const layout = await runLayout(graph);
+  const widgets = await renderNodes(layout.nodes);
+  await renderEdges(layout.edges, widgets);
 }
 
-export default class App extends Component {
-  componentDidMount() {
-    addSticky();
-  }
+export default function App() {
+  useEffect(() => {
+    main();
+  }, []);
 
-  render() {
-    return (
-      <div id="root">
-        <div className="grid container">
-          <div className="cs1 ce12">
-            <img src="/assets/congratulations.png" alt="congratulations" />
-          </div>
-          <div className="cs1 ce12">
-            <h1>Congratulations!</h1>
-            <p>You've just created your first Miro app!</p>
-            <p>
-              To explore more and build your own app, see the Miro Developer
-              Platform documentation.
-            </p>
-          </div>
-          <div className="cs1 ce12">
-            <a
-              className="button button-primary"
-              target="_blank"
-              href="https://developers.miro.com"
-            >
-              Read the documentation
-            </a>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  return (
+    <div id="root">
+      <SidePanel />
+    </div>
+  );
 }

--- a/src/logic/edgeRenderer.ts
+++ b/src/logic/edgeRenderer.ts
@@ -1,0 +1,31 @@
+import { RoutedEdge } from './layoutEngine';
+import { WidgetMap } from './shapeRenderer';
+import { attachMetadata } from './metadata';
+
+/**
+ * Draw connectors between widgets using the layout information.
+ */
+export async function renderEdges(
+  edges: RoutedEdge[],
+  widgets: WidgetMap
+): Promise<any[]> {
+  const connectors: any[] = [];
+  for (const edge of edges) {
+    const start = widgets[edge.source];
+    const end = widgets[edge.target];
+    if (!start || !end) continue;
+    const connector = await miro.board.createConnector({
+      startWidgetId: start.id,
+      endWidgetId: end.id,
+      captions: edge.label ? [{ position: 0.5, text: edge.label }] : undefined,
+    });
+    attachMetadata(connector, {
+      type: 'edge',
+      edgeId: edge.id,
+      source: edge.source,
+      target: edge.target,
+    });
+    connectors.push(connector);
+  }
+  return connectors;
+}

--- a/src/logic/inputParser.ts
+++ b/src/logic/inputParser.ts
@@ -1,0 +1,45 @@
+export interface GraphNode {
+  id: string;
+  label?: string;
+}
+
+export interface GraphEdge {
+  id?: string;
+  source: string;
+  target: string;
+  label?: string;
+}
+
+export interface GraphInput {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+/**
+ * Validate and parse user provided JSON into a GraphInput structure.
+ */
+export function parseGraph(json: unknown): GraphInput {
+  if (typeof json !== 'object' || json === null) {
+    throw new Error('Input must be an object');
+  }
+  const data = json as Record<string, unknown>;
+  const nodes = data.nodes;
+  const edges = data.edges;
+  if (!Array.isArray(nodes) || !Array.isArray(edges)) {
+    throw new Error('Input must contain nodes[] and edges[]');
+  }
+  nodes.forEach((n) => {
+    if (typeof (n as any).id !== 'string') {
+      throw new Error('Node id must be a string');
+    }
+  });
+  edges.forEach((e) => {
+    if (
+      typeof (e as any).source !== 'string' ||
+      typeof (e as any).target !== 'string'
+    ) {
+      throw new Error('Edges must have source and target');
+    }
+  });
+  return { nodes: nodes as GraphNode[], edges: edges as GraphEdge[] };
+}

--- a/src/logic/layoutEngine.ts
+++ b/src/logic/layoutEngine.ts
@@ -1,0 +1,58 @@
+import ELK from 'elkjs/lib/elk.bundled.js';
+import { GraphInput, GraphNode, GraphEdge } from './inputParser';
+
+export interface PositionedNode extends GraphNode {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface RoutedEdge extends GraphEdge {
+  sections?: {
+    startPoint: { x: number; y: number };
+    endPoint: { x: number; y: number };
+    bendPoints?: { x: number; y: number }[];
+  }[];
+}
+
+/**
+ * Run ELK layout algorithm for fixed-size nodes.
+ */
+export async function runLayout(graph: GraphInput): Promise<{
+  nodes: PositionedNode[];
+  edges: RoutedEdge[];
+}> {
+  const elk = new ELK();
+  const elkGraph: any = {
+    id: 'root',
+    layoutOptions: { 'elk.algorithm': 'layered' },
+    children: graph.nodes.map((n) => ({ id: n.id, width: 150, height: 80 })),
+    edges: graph.edges.map((e) => ({
+      id: e.id || `${e.source}-${e.target}`,
+      sources: [e.source],
+      targets: [e.target],
+    })),
+  };
+  const result = await elk.layout(elkGraph);
+  const positionedNodes: PositionedNode[] = (result.children || []).map(
+    (n: any) => ({
+      id: n.id,
+      label: graph.nodes.find((nd) => nd.id === n.id)?.label,
+      x: n.x,
+      y: n.y,
+      width: n.width,
+      height: n.height,
+    })
+  );
+  const positionedEdges: RoutedEdge[] = (result.edges || []).map((e: any) => ({
+    id: e.id,
+    source: e.sources[0],
+    target: e.targets[0],
+    label: graph.edges.find(
+      (ed) => (ed.id || `${ed.source}-${ed.target}`) === e.id
+    )?.label,
+    sections: e.sections,
+  }));
+  return { nodes: positionedNodes, edges: positionedEdges };
+}

--- a/src/logic/metadata.ts
+++ b/src/logic/metadata.ts
@@ -1,0 +1,14 @@
+/**
+ * Attach structured graph metadata under the namespace 'app.miro.structgraph'.
+ */
+export function attachMetadata(widget: any, data: unknown) {
+  if (!widget.metadata) {
+    widget.metadata = {} as any;
+  }
+  widget.metadata['app.miro.structgraph'] = data;
+  // Widgets must be updated to persist metadata
+  if (miro && miro.board && miro.board.widgets && miro.board.widgets.update) {
+    return miro.board.widgets.update(widget);
+  }
+  return widget;
+}

--- a/src/logic/shapeRenderer.ts
+++ b/src/logic/shapeRenderer.ts
@@ -1,0 +1,26 @@
+import { PositionedNode } from './layoutEngine';
+import { attachMetadata } from './metadata';
+
+export interface WidgetMap {
+  [nodeId: string]: any;
+}
+
+/**
+ * Draw widgets for each node and return a mapping from node id to widget.
+ */
+export async function renderNodes(nodes: PositionedNode[]): Promise<WidgetMap> {
+  const map: WidgetMap = {};
+  for (const node of nodes) {
+    const widget = await miro.board.createShape({
+      shape: 'rectangle',
+      x: node.x,
+      y: node.y,
+      width: node.width,
+      height: node.height,
+      content: node.label || '',
+    });
+    attachMetadata(widget, { type: 'node', nodeId: node.id });
+    map[node.id] = widget;
+  }
+  return map;
+}

--- a/src/ui/SidePanel.tsx
+++ b/src/ui/SidePanel.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'preact/hooks';
+
+export default function SidePanel() {
+  const [metadata, setMetadata] = useState<any>(null);
+
+  useEffect(() => {
+    async function handleSelection() {
+      const selection = await miro.board.getSelection();
+      if (selection.length > 0) {
+        setMetadata(selection[0].metadata?.['app.miro.structgraph'] || null);
+      } else {
+        setMetadata(null);
+      }
+    }
+
+    miro.board.ui.on('selection:update', handleSelection);
+    handleSelection();
+    return () => miro.board.ui.off('selection:update', handleSelection);
+  }, []);
+
+  return (
+    <div className="side-panel">
+      <h3>Selected Metadata</h3>
+      <pre>{metadata ? JSON.stringify(metadata, null, 2) : 'No selection'}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add parsing and layout modules
- add renderer modules for nodes and edges with metadata support
- expose layout flow in `index.tsx`
- show widget metadata in new `SidePanel` component
- apply prettier formatting

## Testing
- `yarn prettier:check`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6847fa473ffc832bbadb0b776d6554b3