### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fenrick/MiroDiagraming/security/code-scanning/5](https://github.com/fenrick/MiroDiagraming/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow does not require any write permissions, we can set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` used by the workflow has only read access to the repository contents, reducing the risk of unauthorized write operations.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
