### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,5 +1,8 @@
 name: Prettier
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fenrick/MiroDiagraming/security/code-scanning/4](https://github.com/fenrick/MiroDiagraming/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
