### PR TITLE
Load templates for node shapes

### DIFF
--- a/src/logic/inputParser.ts
+++ b/src/logic/inputParser.ts
@@ -1,6 +1,7 @@
 export interface GraphNode {
   id: string;
   label?: string;
+  type?: string;
 }
 
 export interface GraphEdge {
@@ -31,6 +32,9 @@ export function parseGraph(json: any): GraphInput {
   nodes.forEach((n) => {
     if (typeof (n as any).id !== 'string') {
       throw new Error('Node id must be a string');
+    }
+    if ((n as any).type !== undefined && typeof (n as any).type !== 'string') {
+      throw new Error('Node type must be a string if provided');
     }
   });
   edges.forEach((e) => {

--- a/src/logic/layoutEngine.ts
+++ b/src/logic/layoutEngine.ts
@@ -39,6 +39,7 @@ export async function runLayout(graph: GraphInput): Promise<{
     (n: ElkNode) => ({
       id: n.id,
       label: graph.nodes.find((nd) => nd.id === n.id)?.label,
+      type: graph.nodes.find((nd) => nd.id === n.id)?.type,
       x: n.x ?? 0,
       y: n.y ?? 0,
       width: n.width ?? 0,

--- a/src/logic/shapeRenderer.ts
+++ b/src/logic/shapeRenderer.ts
@@ -1,10 +1,10 @@
-import { Shape } from '@mirohq/websdk-types';
+import { Shape, ShapeType } from '@mirohq/websdk-types';
 import { PositionedNode } from './layoutEngine';
 import { attachShapeMetadata } from './metadata';
 import shapeTemplates from '../../templates/shapeTemplates.json';
 
 interface ShapeTemplate {
-  shape: string;
+  shape: ShapeType;
   fillColor?: string;
   textColor?: string;
   width?: number;

--- a/src/logic/shapeRenderer.ts
+++ b/src/logic/shapeRenderer.ts
@@ -1,6 +1,20 @@
 import { Shape } from '@mirohq/websdk-types';
 import { PositionedNode } from './layoutEngine';
 import { attachShapeMetadata } from './metadata';
+import shapeTemplates from '../../templates/shapeTemplates.json';
+
+interface ShapeTemplate {
+  shape: string;
+  fillColor?: string;
+  textColor?: string;
+  width?: number;
+  height?: number;
+}
+
+const templates: Record<string, ShapeTemplate> = shapeTemplates as Record<
+  string,
+  ShapeTemplate
+>;
 
 export interface WidgetMap {
   [nodeId: string]: Shape;
@@ -12,13 +26,18 @@ export interface WidgetMap {
 export async function renderNodes(nodes: PositionedNode[]): Promise<WidgetMap> {
   const map: WidgetMap = {};
   for (const node of nodes) {
+    const template = templates[node.type || ''] || { shape: 'rectangle' };
     const widget = await miro.board.createShape({
-      shape: 'rectangle',
+      shape: template.shape,
       x: node.x,
       y: node.y,
-      width: node.width,
-      height: node.height,
+      width: template.width ?? node.width,
+      height: template.height ?? node.height,
       content: node.label || '',
+      style:
+        template.fillColor || template.textColor
+          ? { fillColor: template.fillColor, textColor: template.textColor }
+          : undefined,
     });
     attachShapeMetadata(widget, { type: 'node', nodeId: node.id });
     map[node.id] = widget;

--- a/src/logic/shapeRenderer.ts
+++ b/src/logic/shapeRenderer.ts
@@ -6,7 +6,7 @@ import shapeTemplates from '../../templates/shapeTemplates.json';
 interface ShapeTemplate {
   shape: ShapeType;
   fillColor?: string;
-  textColor?: string;
+  color?: string;
   width?: number;
   height?: number;
 }
@@ -35,8 +35,8 @@ export async function renderNodes(nodes: PositionedNode[]): Promise<WidgetMap> {
       height: template.height ?? node.height,
       content: node.label || '',
       style:
-        template.fillColor || template.textColor
-          ? { fillColor: template.fillColor, textColor: template.textColor }
+        template.fillColor || template.color
+          ? { fillColor: template.fillColor, color: template.color }
           : undefined,
     });
     attachShapeMetadata(widget, { type: 'node', nodeId: node.id });

--- a/templates/shapeTemplates.json
+++ b/templates/shapeTemplates.json
@@ -1,6 +1,6 @@
 {
   "BusinessService": {
-    "shape": "rounded_rectangle",
+    "shape": "round_rectangle",
     "fillColor": "#FFEECC",
     "textColor": "#000000",
     "width": 150,

--- a/templates/shapeTemplates.json
+++ b/templates/shapeTemplates.json
@@ -1,0 +1,9 @@
+{
+  "BusinessService": {
+    "shape": "rounded_rectangle",
+    "fillColor": "#FFEECC",
+    "textColor": "#000000",
+    "width": 150,
+    "height": 80
+  }
+}


### PR DESCRIPTION
## Summary
- allow optional `type` on `GraphNode`
- propagate node type through layout engine
- load shape template definitions from `templates/shapeTemplates.json`
- apply template styling when rendering nodes
- add initial `BusinessService` template

## Testing
- `yarn install`
- `yarn test`
- `yarn prettier:check`

------
https://chatgpt.com/codex/tasks/task_e_6849074f71ac832badbdce5f5f0bfd20