### PR TITLE
Fix shape template color property

### DIFF
--- a/templates/shapeTemplates.json
+++ b/templates/shapeTemplates.json
@@ -2,7 +2,7 @@
   "BusinessService": {
     "shape": "round_rectangle",
     "fillColor": "#FFEECC",
-    "textColor": "#000000",
+    "color": "#000000",
     "width": 150,
     "height": 80
   }


### PR DESCRIPTION
## Summary
- update shape template to use `color` instead of `textColor`

## Testing
- `yarn prettier`
- `yarn prettier:check`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6849110e94e4832ba96fda8223e03aa2