### PR TITLE
Add plugin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ yarn build
 ```
 
 The generated files will appear in the `dist` directory. Host these files on a static server and configure the URL in your Miro app settings to deploy the plugin.
+
+## Manifest
+
+The plugin manifest resides at `public/manifest.json`. Adjust the fields such as
+`name`, `permissions`, or `icon` when registering the application in your Miro
+developer dashboard.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Miro Structured Graph Generator",
+  "description": "Import JSON graphs, lay them out with ELK and render the result on a Miro board.",
+  "icon": "../src/assets/welcome.png",
+  "permissions": ["boards:read", "boards:write"],
+  "sdkUri": "index.html",
+  "sdkVersion": "2"
+}


### PR DESCRIPTION
## Summary
- add manifest.json for Miro plugin with name, icon and permissions
- mention the manifest location in the README

## Testing
- `yarn prettier`
- `yarn prettier:check`
- `CI=true yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684911166e54832b8217b4d24139aba8