### PR TITLE
Add tests for metadata helpers

### DIFF
--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -1,0 +1,30 @@
+import {
+  attachShapeMetadata,
+  attachConnectorMetadata,
+} from '../src/logic/metadata';
+
+describe('metadata helpers', () => {
+  test('attachShapeMetadata returns shape after setting metadata', () => {
+    const shape = { setMetadata: jest.fn(), sync: jest.fn() } as any;
+    const data = { key: 'value' };
+    const result = attachShapeMetadata(shape, data);
+    expect(result).toBe(shape);
+    expect(shape.setMetadata).toHaveBeenCalledWith(
+      'app.miro.structgraph',
+      data
+    );
+    expect(shape.sync).toHaveBeenCalled();
+  });
+
+  test('attachConnectorMetadata returns connector after setting metadata', () => {
+    const connector = { setMetadata: jest.fn(), sync: jest.fn() } as any;
+    const data = { key: 'value' };
+    const result = attachConnectorMetadata(connector, data);
+    expect(result).toBe(connector);
+    expect(connector.setMetadata).toHaveBeenCalledWith(
+      'app.miro.structgraph',
+      data
+    );
+    expect(connector.sync).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for attachShapeMetadata and attachConnectorMetadata

## Testing
- `yarn prettier`
- `yarn prettier:check`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684915a8d5b0832baeaf026fa0bfd7f4