### PR TITLE
Refactor graph validation

### DIFF
--- a/src/logic/inputParser.ts
+++ b/src/logic/inputParser.ts
@@ -28,6 +28,44 @@ export interface GraphInput {
 }
 
 /**
+ * Validate an array of raw nodes and return typed {@link GraphNode} objects.
+ *
+ * @param nodes - Unknown values representing nodes.
+ * @returns Validated nodes cast to {@link GraphNode[]}.
+ * @throws If any node is missing a string `id` or has an invalid `type`.
+ */
+export function validateNodes(nodes: unknown[]): GraphNode[] {
+  nodes.forEach((n) => {
+    if (typeof (n as any).id !== 'string') {
+      throw new Error('Node id must be a string');
+    }
+    if ((n as any).type !== undefined && typeof (n as any).type !== 'string') {
+      throw new Error('Node type must be a string if provided');
+    }
+  });
+  return nodes as GraphNode[];
+}
+
+/**
+ * Validate an array of raw edges and return typed {@link GraphEdge} objects.
+ *
+ * @param edges - Unknown values representing edges.
+ * @returns Validated edges cast to {@link GraphEdge[]}.
+ * @throws If any edge lacks string `source` or `target` identifiers.
+ */
+export function validateEdges(edges: unknown[]): GraphEdge[] {
+  edges.forEach((e) => {
+    if (
+      typeof (e as any).source !== 'string' ||
+      typeof (e as any).target !== 'string'
+    ) {
+      throw new Error('Edges must have source and target');
+    }
+  });
+  return edges as GraphEdge[];
+}
+
+/**
  * Validate and parse user provided JSON into a typed {@link GraphInput}.
  *
  * @param json - Raw data describing nodes and edges.
@@ -44,21 +82,8 @@ export function parseGraph(json: any): GraphInput {
   if (!Array.isArray(nodes) || !Array.isArray(edges)) {
     throw new Error('Input must contain nodes[] and edges[]');
   }
-  nodes.forEach((n) => {
-    if (typeof (n as any).id !== 'string') {
-      throw new Error('Node id must be a string');
-    }
-    if ((n as any).type !== undefined && typeof (n as any).type !== 'string') {
-      throw new Error('Node type must be a string if provided');
-    }
-  });
-  edges.forEach((e) => {
-    if (
-      typeof (e as any).source !== 'string' ||
-      typeof (e as any).target !== 'string'
-    ) {
-      throw new Error('Edges must have source and target');
-    }
-  });
-  return { nodes: nodes as GraphNode[], edges: edges as GraphEdge[] };
+  return {
+    nodes: validateNodes(nodes),
+    edges: validateEdges(edges),
+  };
 }

--- a/tests/inputParser.test.ts
+++ b/tests/inputParser.test.ts
@@ -1,4 +1,8 @@
-import { parseGraph } from '../src/logic/inputParser';
+import {
+  parseGraph,
+  validateNodes,
+  validateEdges,
+} from '../src/logic/inputParser';
 
 describe('parseGraph', () => {
   test('throws for non-object input', () => {
@@ -29,5 +33,37 @@ describe('parseGraph', () => {
     const graph = parseGraph(json);
     expect(graph.nodes[0].id).toBe('n1');
     expect(graph.edges[0].source).toBe('n1');
+  });
+});
+
+describe('validateNodes', () => {
+  test('throws when node id is not string', () => {
+    expect(() => validateNodes([{ id: 1 } as any])).toThrow(
+      'Node id must be a string'
+    );
+  });
+
+  test('throws when node type is invalid', () => {
+    expect(() => validateNodes([{ id: 'a', type: 5 } as any])).toThrow(
+      'Node type must be a string if provided'
+    );
+  });
+
+  test('returns nodes array for valid input', () => {
+    const nodes = [{ id: 'n1' }];
+    expect(validateNodes(nodes)).toBe(nodes as any);
+  });
+});
+
+describe('validateEdges', () => {
+  test('throws when edge is missing endpoints', () => {
+    expect(() => validateEdges([{ id: 'e1', source: 'a' } as any])).toThrow(
+      'Edges must have source and target'
+    );
+  });
+
+  test('returns edges array for valid input', () => {
+    const edges = [{ id: 'e1', source: 'a', target: 'b' }];
+    expect(validateEdges(edges)).toBe(edges as any);
   });
 });


### PR DESCRIPTION
## Summary
- extract `validateNodes` and `validateEdges` helpers
- refactor `parseGraph` to use them
- expand unit tests for new helpers

## Testing
- `yarn prettier`
- `yarn prettier:check`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684915df56c0832b8bd1b9c1a2287828