### PR TITLE
Enforce JSON file type checks

### DIFF
--- a/src/logic/indexHelpers.ts
+++ b/src/logic/indexHelpers.ts
@@ -35,10 +35,12 @@ export function setupDragAndDrop() {
     if (file) {
       const fileName = file.name.toLowerCase();
       if (!fileName.endsWith('.json')) {
-        console.error('Unsupported file type', fileName);
+        console.error(
+          `Unsupported file type "${fileName}". Supported file types: .json`,
+          fileName
+        );
         return;
       }
-
       const text = await file.text();
       try {
         processJson(JSON.parse(text));
@@ -48,8 +50,16 @@ export function setupDragAndDrop() {
     }
   };
 
-  window.addEventListener('dragover', (e) => e.preventDefault());
+  const onDragOver = (e: DragEvent) => e.preventDefault();
+
+  window.addEventListener('dragover', onDragOver);
   window.addEventListener('drop', onDrop);
+
+  // Return a cleanup function as expected by the test
+  return () => {
+    window.removeEventListener('dragover', onDragOver);
+    window.removeEventListener('drop', onDrop);
+  };
 }
 
 /**
@@ -64,7 +74,10 @@ export function handleFileInput(e: Event) {
 
   const fileName = file.name.toLowerCase();
   if (!fileName.endsWith('.json')) {
-    console.error('Unsupported file type', fileName);
+    console.error(
+      `Unsupported file type "${fileName}". Supported file types: .json`,
+      fileName
+    );
     return;
   }
 

--- a/src/logic/indexHelpers.ts
+++ b/src/logic/indexHelpers.ts
@@ -26,15 +26,16 @@ export async function processJson(json: any) {
  * @returns Function to remove the registered event listeners.
  */
 export function setupDragAndDrop() {
-  const onDragOver = (e: DragEvent) => e.preventDefault();
   const onDrop = async (e: DragEvent) => {
     e.preventDefault();
     const file = e.dataTransfer?.files?.[0];
     if (file) {
-      if (file.type !== 'application/json') {
-        console.error('Unsupported file type', file.type);
+      const fileName = file.name.toLowerCase();
+      if (!fileName.endsWith('.json')) {
+        console.error('Unsupported file type', fileName);
         return;
       }
+
       const text = await file.text();
       try {
         processJson(JSON.parse(text));
@@ -43,12 +44,9 @@ export function setupDragAndDrop() {
       }
     }
   };
-  window.addEventListener('dragover', onDragOver);
+
+  window.addEventListener('dragover', (e) => e.preventDefault());
   window.addEventListener('drop', onDrop);
-  return () => {
-    window.removeEventListener('dragover', onDragOver);
-    window.removeEventListener('drop', onDrop);
-  };
 }
 
 /**
@@ -60,10 +58,13 @@ export function handleFileInput(e: Event) {
   const input = e.target as HTMLInputElement;
   const file = input.files?.[0];
   if (!file) return;
-  if (file.type !== 'application/json') {
-    console.error('Unsupported file type', file.type);
+
+  const fileName = file.name.toLowerCase();
+  if (!fileName.endsWith('.json')) {
+    console.error('Unsupported file type', fileName);
     return;
   }
+
   file
     .text()
     .then((text) => {

--- a/src/logic/indexHelpers.ts
+++ b/src/logic/indexHelpers.ts
@@ -31,6 +31,10 @@ export function setupDragAndDrop() {
     e.preventDefault();
     const file = e.dataTransfer?.files?.[0];
     if (file) {
+      if (file.type !== 'application/json') {
+        console.error('Unsupported file type', file.type);
+        return;
+      }
       const text = await file.text();
       try {
         processJson(JSON.parse(text));
@@ -56,6 +60,10 @@ export function handleFileInput(e: Event) {
   const input = e.target as HTMLInputElement;
   const file = input.files?.[0];
   if (!file) return;
+  if (file.type !== 'application/json') {
+    console.error('Unsupported file type', file.type);
+    return;
+  }
   file
     .text()
     .then((text) => {

--- a/tests/indexHelpers.test.ts
+++ b/tests/indexHelpers.test.ts
@@ -63,7 +63,7 @@ describe('handleFileInput', () => {
 
     expect(file.text).toHaveBeenCalled();
     expect(parser.parseGraph).toHaveBeenCalledWith({ nodes: [], edges: [] });
-    });
+  });
 
   test('ignores when no file is present', () => {
     const evt = { target: { files: [] } } as unknown as Event;
@@ -173,6 +173,5 @@ describe('setupDragAndDrop', () => {
     expect(dropEvt.preventDefault).toHaveBeenCalled();
     expect(file.text).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith('Unsupported file type', 'test.txt');
-    
   });
 });

--- a/tests/indexHelpers.test.ts
+++ b/tests/indexHelpers.test.ts
@@ -46,8 +46,11 @@ describe('processJson', () => {
 describe('handleFileInput', () => {
   test('reads file and triggers parsing', async () => {
     const file = {
-      text: jest.fn().mockResolvedValue('{"v":1}'),
+      text: jest.fn().mockResolvedValue('{"nodes":[],"edges":[]}'),
       type: 'application/json',
+      name: 'test.json',
+      lastModified: Date.now(),
+      size: 100,
     };
     const evt = { target: { files: [file] } } as unknown as Event;
     jest.spyOn(parser, 'parseGraph').mockReturnValue({} as any);
@@ -56,11 +59,11 @@ describe('handleFileInput', () => {
     jest.spyOn(edges, 'renderEdges').mockResolvedValue(undefined);
 
     await handleFileInput(evt);
-    await Promise.resolve();
+    await Promise.resolve(); // Ensure all promises resolve
 
     expect(file.text).toHaveBeenCalled();
-    expect(parser.parseGraph).toHaveBeenCalledWith({ v: 1 });
-  });
+    expect(parser.parseGraph).toHaveBeenCalledWith({ nodes: [], edges: [] });
+    });
 
   test('ignores when no file is present', () => {
     const evt = { target: { files: [] } } as unknown as Event;
@@ -71,8 +74,11 @@ describe('handleFileInput', () => {
 
   test('errors on unsupported file type', async () => {
     const file = {
-      text: jest.fn().mockResolvedValue('{"v":1}'),
-      type: 'text/plain',
+      text: jest.fn().mockResolvedValue('{"nodes":[],"edges":[]}'),
+      type: 'application/json',
+      name: 'test.json',
+      lastModified: Date.now(),
+      size: 100,
     };
     const evt = { target: { files: [file] } } as unknown as Event;
     const errorSpy = jest.spyOn(console, 'error');
@@ -123,8 +129,11 @@ describe('setupDragAndDrop', () => {
     expect(dragEvt.preventDefault).toHaveBeenCalled();
 
     const file = {
-      text: jest.fn().mockResolvedValue('{"x":1}'),
+      text: jest.fn().mockResolvedValue('{"nodes":[],"edges":[]}'),
       type: 'application/json',
+      name: 'test.json',
+      lastModified: Date.now(),
+      size: 100,
     };
     const dropEvt = {
       preventDefault: jest.fn(),
@@ -133,9 +142,8 @@ describe('setupDragAndDrop', () => {
     await listeners.drop(dropEvt);
     expect(dropEvt.preventDefault).toHaveBeenCalled();
     expect(file.text).toHaveBeenCalled();
-    expect(parser.parseGraph).toHaveBeenCalledWith({ x: 1 });
+    expect(parser.parseGraph).toHaveBeenCalledWith({ nodes: [], edges: [] });
 
-    cleanup();
     expect(removeEventListener).toHaveBeenCalledWith(
       'dragover',
       listeners.dragover
@@ -155,7 +163,7 @@ describe('setupDragAndDrop', () => {
     const cleanup = setupDragAndDrop();
 
     const errorSpy = jest.spyOn(console, 'error');
-    const file = { text: jest.fn(), type: 'text/plain' };
+    const file = { text: jest.fn(), type: 'text/plain', name: 'test.txt' };
     const dropEvt = {
       preventDefault: jest.fn(),
       dataTransfer: { files: [file] },
@@ -164,11 +172,7 @@ describe('setupDragAndDrop', () => {
     await listeners.drop(dropEvt);
     expect(dropEvt.preventDefault).toHaveBeenCalled();
     expect(file.text).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(
-      'Unsupported file type',
-      'text/plain'
-    );
-
-    cleanup();
+    expect(errorSpy).toHaveBeenCalledWith('Unsupported file type', 'test.txt');
+    
   });
 });

--- a/tests/indexHelpers.test.ts
+++ b/tests/indexHelpers.test.ts
@@ -74,20 +74,22 @@ describe('handleFileInput', () => {
 
   test('errors on unsupported file type', async () => {
     const file = {
-      text: jest.fn().mockResolvedValue('{"nodes":[],"edges":[]}'),
-      type: 'application/json',
-      name: 'test.json',
-      lastModified: Date.now(),
-      size: 100,
+      text: jest.fn(),
+      type: 'text/plain',
+      name: 'test.txt',
     };
-    const evt = { target: { files: [file] } } as unknown as Event;
+    const evt = {
+      target: { files: [file] },
+    } as unknown as Event;
+
     const errorSpy = jest.spyOn(console, 'error');
 
     await handleFileInput(evt);
-    expect(file.text).not.toHaveBeenCalled();
+
+    expect(file.text).not.toHaveBeenCalled(); // Ensure text() is not called
     expect(errorSpy).toHaveBeenCalledWith(
-      'Unsupported file type',
-      'text/plain'
+      'Unsupported file type "test.txt". Supported file types: .json',
+      'test.txt'
     );
   });
 });
@@ -144,6 +146,7 @@ describe('setupDragAndDrop', () => {
     expect(file.text).toHaveBeenCalled();
     expect(parser.parseGraph).toHaveBeenCalledWith({ nodes: [], edges: [] });
 
+    cleanup();
     expect(removeEventListener).toHaveBeenCalledWith(
       'dragover',
       listeners.dragover
@@ -172,6 +175,9 @@ describe('setupDragAndDrop', () => {
     await listeners.drop(dropEvt);
     expect(dropEvt.preventDefault).toHaveBeenCalled();
     expect(file.text).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith('Unsupported file type', 'test.txt');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unsupported file type "test.txt". Supported file types: .json',
+      'test.txt'
+    );
   });
 });

--- a/tests/indexHelpers.test.ts
+++ b/tests/indexHelpers.test.ts
@@ -45,7 +45,10 @@ describe('processJson', () => {
 
 describe('handleFileInput', () => {
   test('reads file and triggers parsing', async () => {
-    const file = { text: jest.fn().mockResolvedValue('{"v":1}') };
+    const file = {
+      text: jest.fn().mockResolvedValue('{"v":1}'),
+      type: 'application/json',
+    };
     const evt = { target: { files: [file] } } as unknown as Event;
     jest.spyOn(parser, 'parseGraph').mockReturnValue({} as any);
     jest.spyOn(layout, 'runLayout').mockResolvedValue({ nodes: [], edges: [] });
@@ -64,6 +67,22 @@ describe('handleFileInput', () => {
     const parseSpy = jest.spyOn(parser, 'parseGraph');
     handleFileInput(evt);
     expect(parseSpy).not.toHaveBeenCalled();
+  });
+
+  test('errors on unsupported file type', async () => {
+    const file = {
+      text: jest.fn().mockResolvedValue('{"v":1}'),
+      type: 'text/plain',
+    };
+    const evt = { target: { files: [file] } } as unknown as Event;
+    const errorSpy = jest.spyOn(console, 'error');
+
+    await handleFileInput(evt);
+    expect(file.text).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unsupported file type',
+      'text/plain'
+    );
   });
 });
 
@@ -103,7 +122,10 @@ describe('setupDragAndDrop', () => {
     listeners.dragover(dragEvt);
     expect(dragEvt.preventDefault).toHaveBeenCalled();
 
-    const file = { text: jest.fn().mockResolvedValue('{"x":1}') };
+    const file = {
+      text: jest.fn().mockResolvedValue('{"x":1}'),
+      type: 'application/json',
+    };
     const dropEvt = {
       preventDefault: jest.fn(),
       dataTransfer: { files: [file] },
@@ -119,5 +141,34 @@ describe('setupDragAndDrop', () => {
       listeners.dragover
     );
     expect(removeEventListener).toHaveBeenCalledWith('drop', listeners.drop);
+  });
+
+  test('errors when dropped file has wrong type', async () => {
+    const listeners: Record<string, any> = {};
+    globalThis.window = {
+      addEventListener: jest.fn((t: string, l: any) => {
+        listeners[t] = l;
+      }),
+      removeEventListener: jest.fn(),
+    } as any;
+
+    const cleanup = setupDragAndDrop();
+
+    const errorSpy = jest.spyOn(console, 'error');
+    const file = { text: jest.fn(), type: 'text/plain' };
+    const dropEvt = {
+      preventDefault: jest.fn(),
+      dataTransfer: { files: [file] },
+    } as unknown as DragEvent;
+
+    await listeners.drop(dropEvt);
+    expect(dropEvt.preventDefault).toHaveBeenCalled();
+    expect(file.text).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Unsupported file type',
+      'text/plain'
+    );
+
+    cleanup();
   });
 });


### PR DESCRIPTION
## Summary
- validate dropped/uploaded file types before reading JSON
- add error handling for incorrect file types
- test drag-and-drop and file input with valid and invalid types

## Testing
- `yarn prettier`
- `yarn prettier:check`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_684925c3110c832b94357e4a688ae4fb