### PR TITLE
Refine parseGraph typing

### DIFF
--- a/src/logic/indexHelpers.ts
+++ b/src/logic/indexHelpers.ts
@@ -14,7 +14,7 @@ export async function processJson(json: unknown) {
     if (typeof json !== 'object' || json === null) {
       throw new Error('Input must be an object');
     }
-    const graph = parseGraph(json as Record<string, unknown>);
+    const graph = parseGraph(json);
     const layout = await runLayout(graph);
     const widgets = await renderNodes(layout.nodes);
     await renderEdges(layout.edges, widgets);

--- a/src/logic/inputParser.ts
+++ b/src/logic/inputParser.ts
@@ -72,7 +72,7 @@ export function validateEdges(edges: unknown[]): GraphEdge[] {
  * @returns Parsed graph structure.
  * @throws If the input does not contain valid `nodes` and `edges` arrays.
  */
-export function parseGraph(json: any): GraphInput {
+export function parseGraph(json: unknown): GraphInput {
   if (typeof json !== 'object' || json === null) {
     throw new Error('Input must be an object');
   }
@@ -83,7 +83,7 @@ export function parseGraph(json: any): GraphInput {
     throw new Error('Input must contain nodes[] and edges[]');
   }
   return {
-    nodes: validateNodes(nodes),
-    edges: validateEdges(edges),
+    nodes: validateNodes(nodes as unknown[]),
+    edges: validateEdges(edges as unknown[]),
   };
 }


### PR DESCRIPTION
## Summary
- make `parseGraph` accept `unknown` instead of `any`
- update callers to use the new type

## Testing
- `yarn prettier:check`
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68495a74da34832ba5fa321adbffebf4