### PR TITLE
Validate edge node references

### DIFF
--- a/src/logic/inputParser.ts
+++ b/src/logic/inputParser.ts
@@ -70,7 +70,8 @@ export function validateEdges(edges: unknown[]): GraphEdge[] {
  *
  * @param json - Raw data describing nodes and edges.
  * @returns Parsed graph structure.
- * @throws If the input does not contain valid `nodes` and `edges` arrays.
+ * @throws If the input does not contain valid `nodes` and `edges` arrays or if
+ * edges reference unknown node ids.
  */
 export function parseGraph(json: any): GraphInput {
   if (typeof json !== 'object' || json === null) {
@@ -82,8 +83,19 @@ export function parseGraph(json: any): GraphInput {
   if (!Array.isArray(nodes) || !Array.isArray(edges)) {
     throw new Error('Input must contain nodes[] and edges[]');
   }
+
+  const parsedNodes = validateNodes(nodes);
+  const parsedEdges = validateEdges(edges);
+
+  const idSet = new Set(parsedNodes.map((n) => n.id));
+  parsedEdges.forEach((e) => {
+    if (!idSet.has(e.source) || !idSet.has(e.target)) {
+      throw new Error('Edges must reference existing node ids');
+    }
+  });
+
   return {
-    nodes: validateNodes(nodes),
-    edges: validateEdges(edges),
+    nodes: parsedNodes,
+    edges: parsedEdges,
   };
 }

--- a/tests/inputParser.test.ts
+++ b/tests/inputParser.test.ts
@@ -25,6 +25,16 @@ describe('parseGraph', () => {
     expect(() => parseGraph(data)).toThrow('Edges must have source and target');
   });
 
+  test('throws when edge references unknown nodes', () => {
+    const data = {
+      nodes: [{ id: 'a' }],
+      edges: [{ id: 'e1', source: 'a', target: 'b' }],
+    };
+    expect(() => parseGraph(data)).toThrow(
+      'Edges must reference existing node ids'
+    );
+  });
+
   test('returns parsed graph for valid input', () => {
     const json = {
       nodes: [{ id: 'n1' }],


### PR DESCRIPTION
## Summary
- validate that edges reference defined node IDs
- test error cases for unknown edge endpoints

## Testing
- `yarn test`
- `yarn build`
- `yarn prettier`
- `yarn prettier:check`


------
https://chatgpt.com/codex/tasks/task_e_68495a92a808832bb90e6b2c43f3a30d