### PR TITLE
Implement metadata-based shape lookup

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,44 @@
+import type { Shape } from '@mirohq/websdk-types';
+
+export async function getShapeByMetadata(
+  type: string,
+  label: string
+): Promise<Shape | undefined> {
+  const items = await miro.board.get({
+    type: 'shape',
+    metadata: { type, label },
+  });
+
+  return (items[0] as Shape) ?? undefined;
+}
+
+export interface CreateNodeOptions {
+  type: string;
+  label: string;
+  x?: number;
+  y?: number;
+  shape?: string;
+  fillColor?: string;
+  color?: string;
+  width?: number;
+  height?: number;
+}
+
+export async function createNode(options: CreateNodeOptions): Promise<Shape> {
+  const existing = await getShapeByMetadata(options.type, options.label);
+  if (existing) return existing;
+
+  const shape = await miro.board.createShape({
+    content: options.label,
+    x: options.x ?? 0,
+    y: options.y ?? 0,
+    shape: options.shape ?? 'round_rectangle',
+    fillColor: options.fillColor,
+    color: options.color,
+    width: options.width,
+    height: options.height,
+    metadata: { type: options.type, label: options.label },
+  });
+
+  return shape as Shape;
+}


### PR DESCRIPTION
## Summary
- add graph utility for retrieving shapes based on metadata
- expose `createNode` helper that reuses an existing node id

## Testing
- `npm run build`
- `npm run prettier:check` *(fails: Code style issues found in 8 files)*

------
https://chatgpt.com/codex/tasks/task_e_684f831a2d0c832baeb9d540f7e9e34b