### PR TITLE
Add shape template loader and graph rendering

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,53 @@
+import { getTemplate, ShapeTemplate } from './templates';
+
+export interface GraphNode {
+  template: string;
+  children?: GraphNode[];
+}
+
+async function createShapeFromTemplate(
+  template: ShapeTemplate,
+  x: number,
+  y: number
+) {
+  return miro.board.createShape({
+    content: template.name,
+    x,
+    y,
+    shape: template.shape as any,
+    width: template.width,
+    height: template.height,
+    style: {
+      fillColor: template.fillColor,
+      color: template.color,
+    },
+  });
+}
+
+async function renderNode(node: GraphNode, x: number, y: number) {
+  const tmpl = getTemplate(node.template);
+  if (!tmpl) {
+    throw new Error(`Template ${node.template} not found`);
+  }
+
+  const shape = await createShapeFromTemplate(tmpl, x, y);
+  let items = [shape];
+
+  if (node.children && node.children.length) {
+    let offsetY = y + tmpl.height + 40;
+    for (const child of node.children) {
+      const childItems = await renderNode(child, x + tmpl.width + 40, offsetY);
+      items.push(...childItems);
+      offsetY += tmpl.height + 40;
+    }
+  }
+
+  return items;
+}
+
+export async function renderGraph(root: GraphNode, x: number, y: number) {
+  const items = await renderNode(root, x, y);
+  if (items.length > 1) {
+    await miro.board.createGroup({ items });
+  }
+}

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,21 @@
+import shapeTemplates from '../templates/shapeTemplates.json';
+
+export interface ShapeTemplate {
+  name: string;
+  shape: string;
+  fillColor: string;
+  color: string;
+  width: number;
+  height: number;
+}
+
+export interface ShapeTemplateCollection {
+  elements: ShapeTemplate[];
+}
+
+export const templates: ShapeTemplateCollection =
+  shapeTemplates as ShapeTemplateCollection;
+
+export function getTemplate(name: string): ShapeTemplate | undefined {
+  return templates.elements.find((el) => el.name === name);
+}

--- a/templates/shapeTemplates.json
+++ b/templates/shapeTemplates.json
@@ -1,37 +1,44 @@
 {
-  "Strategy": {
-    "shape": "round_rectangle",
-    "fillColor": "#939598",
-    "color": "#000000",
-    "width": 180,
-    "height": 110
-  },
-  "Motivation": {
-    "shape": "round_rectangle",
-    "fillColor": "#939598",
-    "color": "#000000",
-    "width": 180,
-    "height": 110
-  },
-  "Business": {
-    "shape": "round_rectangle",
-    "fillColor": "#939598",
-    "color": "#000000",
-    "width": 180,
-    "height": 110
-  },
-  "Application": {
-    "shape": "round_rectangle",
-    "fillColor": "#939598",
-    "color": "#000000",
-    "width": 180,
-    "height": 110
-  },
-  "Technology": {
-    "shape": "round_rectangle",
-    "fillColor": "#939598",
-    "color": "#000000",
-    "width": 180,
-    "height": 110
-  }
+  "elements": [
+    {
+      "name": "Strategy",
+      "shape": "round_rectangle",
+      "fillColor": "#939598",
+      "color": "#000000",
+      "width": 180,
+      "height": 110
+    },
+    {
+      "name": "Motivation",
+      "shape": "round_rectangle",
+      "fillColor": "#939598",
+      "color": "#000000",
+      "width": 180,
+      "height": 110
+    },
+    {
+      "name": "Business",
+      "shape": "round_rectangle",
+      "fillColor": "#939598",
+      "color": "#000000",
+      "width": 180,
+      "height": 110
+    },
+    {
+      "name": "Application",
+      "shape": "round_rectangle",
+      "fillColor": "#939598",
+      "color": "#000000",
+      "width": 180,
+      "height": 110
+    },
+    {
+      "name": "Technology",
+      "shape": "round_rectangle",
+      "fillColor": "#939598",
+      "color": "#000000",
+      "width": 180,
+      "height": 110
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- restructure `shapeTemplates.json` to use the `elements[]` format
- add `templates.ts` helper for loading templates
- implement new `graph.ts` for creating shapes based on templates

## Testing
- `npx prettier src/graph.ts src/templates.ts templates/shapeTemplates.json --check`

------
https://chatgpt.com/codex/tasks/task_e_684f830243ac832b98f5e585128f44be