### PR TITLE
Switch to JSON diagrams with ELK layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Miro CSV to Mind Map App
+# Miro JSON Diagram App
 
-This app shows how to import data from a CSV file and create a mind map on a Miro board.
+This app shows how to import a graph from a JSON file and render it on a Miro board using automatic layout.
 
 # 👨🏻‍💻 App Demo
 
@@ -8,7 +8,7 @@ This app shows how to import data from a CSV file and create a mind map on a Mir
 
 # 📒 Table of Contents
 
-- [Miro CSV to Mind Map App](#miro-csv-to-mind-map-app)
+- [Miro JSON Diagram App](#miro-json-diagram-app)
 - [👨🏻‍💻 App Demo](#-app-demo)
 - [📒 Table of Contents](#-table-of-contents)
 - [📹 Associated Video ](#-associated-video-)
@@ -53,8 +53,7 @@ Watch the short video (48 seconds) below to gain a quick overview of using the a
 
 # 📖 Associated Developer Tutorial <a name="tutorial"></a>
 
-> To view a more in depth developer tutorial
-> of this app (including code explanations) see the [Create mind map from CSV tutorial](https://developers.miro.com/docs/create-mind-map-from-csv) on Miro's Developer documentation.
+See the Miro documentation for details on building diagramming apps.
 
 # 🏃🏽‍♂️ Run the app locally <a name="run"></a>
 
@@ -69,7 +68,7 @@ Watch the short video (48 seconds) below to gain a quick overview of using the a
 
 ```yaml
 # See https://developers.miro.com/docs/app-manifest on how to use this
-appName: CSV to Mindmap
+appName: JSON Diagram
 sdkVersion: SDK_V2
 sdkUri: http://localhost:3000
 scopes:
@@ -85,7 +84,7 @@ https://github.com/miroapp/app-examples/assets/10428517/1e6862de-8617-46ef-b265-
 
 5. Go to your developer team, and open your boards.
 6. Click on the plus icon from the bottom section of your left sidebar. If you hover over it, it will say `More apps`.
-7. Search for your app `CSV to Mind Map` or whatever you chose to name it. Click on your app to use it, as shown in the video below. <b>In the video we search for a different app, but the process is the same regardless of the app.</b>
+7. Search for your app `JSON Diagram` or whatever you chose to name it. Click on your app to use it, as shown in the video below. <b>In the video we search for a different app, but the process is the same regardless of the app.</b>
 
 https://github.com/horeaporutiu/app-examples-template/assets/10428517/b23d9c4c-e785-43f9-a72e-fa5d82c7b019
 
@@ -94,12 +93,11 @@ https://github.com/horeaporutiu/app-examples-template/assets/10428517/b23d9c4c-e
 ```
 .
 ├── src
-|  ├── example-data // Example CSV data
 │  ├── assets
 │  │  └── style.css
 │  ├── app.tsx     // The code for the app lives here
 │  ├── index.ts    // The code for the app entry point lives here
-│  └── utils.ts    // Utilities for loading CSV files
+│  └── graph.ts    // JSON graph loading helpers
 ├── app.html       // The app itself. It's loaded on the board inside the 'appContainer'
 └── index.html     // The app entry point. This is what you specify in the 'App URL' box in the Miro app settings
 ```

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "d3-dsv": "^3.0.1",
+    "elkjs": "^0.10.0",
     "mirotone": "4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,27 +1,27 @@
-import * as React from "react";
-import { createRoot } from "react-dom/client";
-import { useDropzone } from "react-dropzone";
-import { parseCsv } from "./csv-utils";
-import { createMindmap } from "./mindmap";
+import * as React from 'react';
+import { createRoot } from 'react-dom/client';
+import { useDropzone } from 'react-dropzone';
+import { loadGraph } from './graph';
+import { layoutGraph } from './elk-layout';
 
 // UI
 const dropzoneStyles = {
-  display: "flex",
-  height: "100%",
-  flexDirection: "column",
-  justifyContent: "center",
-  textAlign: "center",
-  border: "3px dashed rgba(41, 128, 185, 0.5)",
-  color: "rgba(41, 128, 185, 1.0)",
-  fontWeight: "bold",
-  fontSize: "1.2em",
+  display: 'flex',
+  height: '100%',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  textAlign: 'center',
+  border: '3px dashed rgba(41, 128, 185, 0.5)',
+  color: 'rgba(41, 128, 185, 1.0)',
+  fontWeight: 'bold',
+  fontSize: '1.2em',
 } as const;
 
 const App: React.FC = () => {
   const [files, setFiles] = React.useState<File[]>([]);
   const dropzone = useDropzone({
     accept: {
-      "text/csv": [".csv"],
+      'application/json': ['.json'],
     },
     maxFiles: 1,
     onDrop: (droppedFiles) => {
@@ -30,13 +30,35 @@ const App: React.FC = () => {
   });
 
   const handleCreate = async () => {
-    const failed = [];
     for (const file of files) {
       try {
-        const contents = await parseCsv(file);
-        await createMindmap(contents);
+        const graph = await loadGraph(file);
+        const positions = await layoutGraph(graph);
+
+        const created: Record<string, string> = {};
+        for (const node of graph.nodes) {
+          const pos = positions[node.id];
+          const shape = await miro.board.createShape({
+            content: node.label,
+            x: pos.x,
+            y: pos.y,
+            width: pos.width,
+            height: pos.height,
+          });
+          created[node.id] = shape.id;
+        }
+
+        for (const edge of graph.edges) {
+          const start = created[edge.source];
+          const end = created[edge.target];
+          if (start && end) {
+            await miro.board.createConnector({
+              start: { item: start },
+              end: { item: end },
+            });
+          }
+        }
       } catch (e) {
-        failed.push(file);
         console.error(e);
       }
     }
@@ -45,13 +67,13 @@ const App: React.FC = () => {
   };
 
   const style = React.useMemo(() => {
-    let borderColor = "rgba(41, 128, 185, 0.5)";
+    let borderColor = 'rgba(41, 128, 185, 0.5)';
     if (dropzone.isDragAccept) {
-      borderColor = "rgba(41, 128, 185, 1.0)";
+      borderColor = 'rgba(41, 128, 185, 1.0)';
     }
 
     if (dropzone.isDragReject) {
-      borderColor = "rgba(192, 57, 43,1.0)";
+      borderColor = 'rgba(192, 57, 43,1.0)';
     }
     return {
       ...dropzoneStyles,
@@ -61,11 +83,11 @@ const App: React.FC = () => {
 
   return (
     <div className="dnd-container">
-      <p>Select the CSV file to import and create a mind map</p>
+      <p>Select the JSON file to import and create a diagram</p>
       <div {...dropzone.getRootProps({ style })}>
         <input {...dropzone.getInputProps()} />
         {dropzone.isDragAccept ? (
-          <p className="dnd-text">Drop your CSV file here</p>
+          <p className="dnd-text">Drop your JSON file here</p>
         ) : (
           <>
             <div>
@@ -73,9 +95,9 @@ const App: React.FC = () => {
                 type="button"
                 className="button button-primary button-small"
               >
-                Select CSV file
+                Select JSON file
               </button>
-              <p className="dnd-text">Or drop your CSV file here</p>
+              <p className="dnd-text">Or drop your JSON file here</p>
             </div>
           </>
         )}
@@ -92,7 +114,7 @@ const App: React.FC = () => {
             onClick={handleCreate}
             className="button button-small button-primary"
           >
-            Create Mind Map
+            Create Diagram
           </button>
         </>
       )}
@@ -100,6 +122,6 @@ const App: React.FC = () => {
   );
 };
 
-const container = document.getElementById("root");
+const container = document.getElementById('root');
 const root = createRoot(container!);
 root.render(<App />);

--- a/src/elk-layout.ts
+++ b/src/elk-layout.ts
@@ -1,0 +1,46 @@
+import ELK from 'elkjs/lib/elk.bundled.js';
+import { GraphData } from './graph';
+
+export interface PositionedNode {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const DEFAULT_WIDTH = 180;
+const DEFAULT_HEIGHT = 110;
+
+export const layoutGraph = async (
+  data: GraphData
+): Promise<Record<string, PositionedNode>> => {
+  const elk = new ELK();
+  const elkGraph: any = {
+    id: 'root',
+    layoutOptions: { 'elk.algorithm': 'layered' },
+    children: data.nodes.map((n) => ({
+      id: n.id,
+      width: DEFAULT_WIDTH,
+      height: DEFAULT_HEIGHT,
+    })),
+    edges: data.edges.map((e, idx) => ({
+      id: `e${idx}`,
+      sources: [e.source],
+      targets: [e.target],
+    })),
+  };
+
+  const layouted: any = await elk.layout(elkGraph);
+  const result: Record<string, PositionedNode> = {};
+  for (const child of layouted.children || []) {
+    result[child.id] = {
+      id: child.id,
+      x: child.x || 0,
+      y: child.y || 0,
+      width: child.width || DEFAULT_WIDTH,
+      height: child.height || DEFAULT_HEIGHT,
+    };
+  }
+  return result;
+};

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,0 +1,34 @@
+export interface NodeData {
+  id: string;
+  label: string;
+  type?: string;
+}
+
+export interface EdgeData {
+  source: string;
+  target: string;
+}
+
+export interface GraphData {
+  nodes: NodeData[];
+  edges: EdgeData[];
+}
+
+const readFile = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      if (!e.target) {
+        reject('Failed to load file');
+        return;
+      }
+      resolve(e.target.result as string);
+    };
+    reader.onerror = () => reject('Failed to load file');
+    reader.readAsText(file, 'utf-8');
+  });
+
+export const loadGraph = async (file: File): Promise<GraphData> => {
+  const text = await readFile(file);
+  return JSON.parse(text) as GraphData;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 async function init() {
-  miro.board.ui.on("icon:click", async () => {
-    await miro.board.ui.openPanel({ url: "app.html" });
+  miro.board.ui.on('icon:click', async () => {
+    await miro.board.ui.openPanel({ url: 'app.html' });
   });
 }
 


### PR DESCRIPTION
## Summary
- switch from CSV import to JSON graph upload
- layout JSON graphs with `elkjs`
- create shapes and connectors from the positioned nodes
- adjust README for new JSON workflow

## Testing
- `npm run prettier`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f83022704832b9c5f07576b3f6fc7