### PR TITLE
Implement board item caching

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   collectCoverage: true,
-  testMatch: ['**/tests/**/*.test.ts']
+  testMatch: ['**/tests/**/*.test.ts'],
+  maxWorkers: 1
 };

--- a/tests/edges.test.ts
+++ b/tests/edges.test.ts
@@ -1,4 +1,4 @@
-import { createEdges } from '../src/graph';
+import { createEdges, resetBoardCache } from '../src/graph';
 
 declare const global: any;
 
@@ -9,6 +9,7 @@ describe('createEdges', () => {
         get: jest.fn().mockResolvedValue([]),
         createConnector: jest.fn().mockResolvedValue({
           setMetadata: jest.fn(),
+          getMetadata: jest.fn(),
           sync: jest.fn(),
           id: 'c1'
         })
@@ -16,7 +17,10 @@ describe('createEdges', () => {
     };
   });
 
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    jest.restoreAllMocks();
+    resetBoardCache();
+  });
 
   test('skips missing nodes', async () => {
     const edges = [{ from: 'n1', to: 'n2' }];

--- a/tests/node.test.ts
+++ b/tests/node.test.ts
@@ -1,4 +1,4 @@
-import { createNode } from '../src/graph';
+import { createNode, resetBoardCache } from '../src/graph';
 import * as templateModule from '../src/templates';
 
 declare const global: any;
@@ -13,13 +13,17 @@ describe('createNode', () => {
     jest.spyOn(templateModule, 'createFromTemplate').mockResolvedValue({
       type: 'shape',
       setMetadata: jest.fn(),
+      getMetadata: jest.fn(),
       getItems: jest.fn().mockResolvedValue([]),
       sync: jest.fn(),
       id: 's1'
     } as any);
   });
 
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    jest.restoreAllMocks();
+    resetBoardCache();
+  });
 
   const node = { id: 'n1', label: 'L', type: 'Role' } as any;
   const pos = { x: 0, y: 0, width: 10, height: 10 };

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -1,4 +1,5 @@
 import { GraphProcessor } from '../src/GraphProcessor';
+import { resetBoardCache } from '../src/graph';
 import * as templateModule from '../src/templates';
 import sample from '../sample-graph.json';
 
@@ -13,17 +14,20 @@ describe('GraphProcessor', () => {
         get: jest.fn().mockResolvedValue([]),
         createConnector: jest.fn().mockResolvedValue({
           setMetadata: jest.fn(),
+          getMetadata: jest.fn(),
           sync: jest.fn(),
           id: 'c1'
         }),
         createShape: jest.fn().mockResolvedValue({
           setMetadata: jest.fn(),
+          getMetadata: jest.fn(),
           sync: jest.fn(),
           id: 's1',
           type: 'shape'
         }),
         createText: jest.fn().mockResolvedValue({
           setMetadata: jest.fn(),
+          getMetadata: jest.fn(),
           sync: jest.fn(),
           id: 't1',
           type: 'text'
@@ -37,9 +41,11 @@ describe('GraphProcessor', () => {
         })
       }
     };
+    resetBoardCache();
     jest.spyOn(templateModule, 'createFromTemplate').mockResolvedValue({
       type: 'shape',
       setMetadata: jest.fn(),
+      getMetadata: jest.fn(),
       getItems: jest.fn(),
       sync: jest.fn(),
       id: 's1'
@@ -48,10 +54,11 @@ describe('GraphProcessor', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+    resetBoardCache();
   });
 
   it('processGraph runs without throwing and syncs items', async () => {
-    await expect(processor.processGraph(sample as any)).resolves.not.toThrow();
+    await processor.processGraph(sample as any);
   });
   it('throws on invalid graph', async () => {
     await expect(processor.processGraph({} as any)).rejects.toThrow('Invalid graph');


### PR DESCRIPTION
## Summary
- add simple caches for shapes and connectors to cut down redundant board lookups
- keep group searches uncached and handle invalid results defensively
- reset caches in unit tests
- run Jest tests sequentially

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850b30e5868832b8b4d4e11037e6544