### PR TITLE
Add ArchiMate 3.1 sample and templates

### DIFF
--- a/sample-graph.json
+++ b/sample-graph.json
@@ -1,28 +1,30 @@
 {
   "nodes": [
-    { "id": "n1", "label": "Customer", "type": "Role" },
-    { "id": "n2", "label": "Sales Process", "type": "BusinessProcess" },
-    { "id": "n3", "label": "Order Service", "type": "BusinessService" },
-    { "id": "n4", "label": "CRM Application", "type": "ApplicationComponent" },
-    { "id": "n5", "label": "Auth Service", "type": "ApplicationComponent" },
-    { "id": "n6", "label": "Order Database", "type": "DataObject" },
-    { "id": "n7", "label": "Web Server", "type": "Device" },
-    { "id": "n8", "label": "Database Server", "type": "Device" },
-    { "id": "n9", "label": "Order Entry", "type": "BusinessProcess" },
-    { "id": "n10", "label": "Customer Support", "type": "BusinessProcess" }
+    { "id": "n1", "label": "Customer", "type": "BusinessActor" },
+    { "id": "n2", "label": "Sales Rep", "type": "Role" },
+    { "id": "n3", "label": "Order Management", "type": "BusinessProcess" },
+    { "id": "n4", "label": "Order Service", "type": "BusinessService" },
+    { "id": "n5", "label": "CRM Application", "type": "ApplicationComponent" },
+    { "id": "n6", "label": "Auth Service", "type": "ApplicationService" },
+    { "id": "n7", "label": "Order Data", "type": "DataObject" },
+    { "id": "n8", "label": "Web Server", "type": "Device" },
+    { "id": "n9", "label": "Database Server", "type": "Node" },
+    { "id": "n10", "label": "Database Service", "type": "TechnologyService" },
+    { "id": "n11", "label": "Migration Project", "type": "WorkPackage" },
+    { "id": "n12", "label": "Increase Sales", "type": "Goal" }
   ],
   "edges": [
-    { "from": "n1", "to": "n2", "label": "triggers" },
-    { "from": "n2", "to": "n3", "label": "requires" },
-    { "from": "n3", "to": "n4", "label": "realized by" },
-    { "from": "n4", "to": "n6", "label": "reads" },
-    { "from": "n4", "to": "n5", "label": "authenticates via" },
-    { "from": "n5", "to": "n6", "label": "writes to" },
-    { "from": "n6", "to": "n8", "label": "hosted on" },
-    { "from": "n4", "to": "n7", "label": "deployed on" },
-    { "from": "n2", "to": "n9", "label": "decomposes" },
-    { "from": "n2", "to": "n10", "label": "decomposes" },
-    { "from": "n9", "to": "n4", "label": "uses" },
-    { "from": "n10", "to": "n5", "label": "uses" }
+    { "from": "n1", "to": "n3", "label": "triggers", "metadata": { "template": "flow" } },
+    { "from": "n2", "to": "n3", "label": "assigned to", "metadata": { "template": "assignment" } },
+    { "from": "n3", "to": "n4", "label": "realizes", "metadata": { "template": "realization" } },
+    { "from": "n4", "to": "n1", "label": "serves" },
+    { "from": "n3", "to": "n6", "label": "uses", "metadata": { "template": "access" } },
+    { "from": "n6", "to": "n5", "label": "realized by", "metadata": { "template": "realization" } },
+    { "from": "n5", "to": "n7", "label": "writes", "metadata": { "template": "access" } },
+    { "from": "n5", "to": "n8", "label": "deployed on", "metadata": { "template": "assignment" } },
+    { "from": "n7", "to": "n9", "label": "stored on", "metadata": { "template": "assignment" } },
+    { "from": "n9", "to": "n10", "label": "realizes", "metadata": { "template": "realization" } },
+    { "from": "n11", "to": "n5", "label": "implements", "metadata": { "template": "realization" } },
+    { "from": "n12", "to": "n11", "label": "influences", "metadata": { "template": "influence" } }
   ]
 }

--- a/templates/connectorTemplates.json
+++ b/templates/connectorTemplates.json
@@ -10,5 +10,55 @@
     },
     "shape": "curved",
     "caption": { "position": 0.5, "textAlignVertical": "middle" }
+  },
+  "flow": {
+    "style": {
+      "strokeColor": "#000000",
+      "strokeStyle": "dashed",
+      "startStrokeCap": "none",
+      "endStrokeCap": "arrow"
+    },
+    "shape": "curved",
+    "caption": { "position": 0.5, "textAlignVertical": "middle" }
+  },
+  "assignment": {
+    "style": {
+      "strokeColor": "#000000",
+      "strokeStyle": "normal",
+      "startStrokeCap": "none",
+      "endStrokeCap": "arrow"
+    },
+    "shape": "curved",
+    "caption": { "position": 0.5, "textAlignVertical": "middle" }
+  },
+  "realization": {
+    "style": {
+      "strokeColor": "#000000",
+      "strokeStyle": "dashed",
+      "startStrokeCap": "none",
+      "endStrokeCap": "arrow"
+    },
+    "shape": "curved",
+    "caption": { "position": 0.5, "textAlignVertical": "middle" }
+  },
+  "access": {
+    "style": {
+      "strokeColor": "#000000",
+      "strokeStyle": "normal",
+      "startStrokeCap": "none",
+      "endStrokeCap": "arrow"
+    },
+    "shape": "curved",
+    "caption": { "position": 0.5, "textAlignVertical": "middle" }
+  },
+  "influence": {
+    "style": {
+      "strokeColor": "#000000",
+      "strokeStyle": "dotted",
+      "startStrokeCap": "none",
+      "endStrokeCap": "arrow"
+    },
+    "shape": "curved",
+    "caption": { "position": 0.5, "textAlignVertical": "middle" }
   }
 }

--- a/templates/shapeTemplates.json
+++ b/templates/shapeTemplates.json
@@ -65,5 +65,71 @@
         "text": "{{label}}"
       }
     ]
+  },
+  "BusinessActor": {
+    "elements": [
+      {
+        "shape": "ellipse",
+        "width": 160,
+        "height": 60,
+        "style": { "fillColor": "#FCE5CD" },
+        "text": "{{label}}"
+      }
+    ]
+  },
+  "ApplicationService": {
+    "elements": [
+      {
+        "shape": "round_rectangle",
+        "width": 160,
+        "height": 60,
+        "style": { "fillColor": "#D9EAFD" },
+        "text": "{{label}}"
+      }
+    ]
+  },
+  "Node": {
+    "elements": [
+      {
+        "shape": "rectangle",
+        "width": 160,
+        "height": 60,
+        "style": { "fillColor": "#E0E0E0" },
+        "text": "{{label}}"
+      }
+    ]
+  },
+  "TechnologyService": {
+    "elements": [
+      {
+        "shape": "round_rectangle",
+        "width": 160,
+        "height": 60,
+        "style": { "fillColor": "#E0F2FF" },
+        "text": "{{label}}"
+      }
+    ]
+  },
+  "WorkPackage": {
+    "elements": [
+      {
+        "shape": "round_rectangle",
+        "width": 160,
+        "height": 60,
+        "style": { "fillColor": "#F8CCE8" },
+        "text": "{{label}}"
+      }
+    ]
+  },
+  "Goal": {
+    "elements": [
+      {
+        "shape": "round_rectangle",
+        "width": 160,
+        "height": 60,
+        "style": { "fillColor": "#F4CCCC" },
+        "text": "{{label}}"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- expand sample graph with ArchiMate 3.1 elements and relationships
- add connector styles for standard ArchiMate relations
- add shape templates for additional ArchiMate elements

## Testing
- `npm run typecheck --silent` *(fails: Cannot find module '@mirohq/websdk-types')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850ce93d4b0832b8cd8141ca9b7ed09