### PR TITLE
Fix diagramming spelling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "miro-diagraming",
+  "name": "miro-diagramming",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "miro-diagraming",
+      "name": "miro-diagramming",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "miro-diagraming",
+  "name": "miro-diagramming",
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "Miro diagraming plugin template",
+  "description": "Miro diagramming plugin template",
   "keywords": [
     "Mirotone",
     "React",


### PR DESCRIPTION
## Summary
- rename package to `miro-diagramming`
- update lockfile to match new name

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850f12fcab4832b9ee416a5992a604c