### PR TITLE
Fix frame zoom behavior

### DIFF
--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -44,6 +44,11 @@ export class BoardBuilder {
     this.frame = frame;
   }
 
+  /** Retrieve the current frame used for new items, if any. */
+  public getFrame(): Frame | undefined {
+    return this.frame;
+  }
+
   /**
    * Find a free area on the board that can fit the given dimensions.
    * This uses the built-in `findEmptySpace` API starting from the
@@ -85,27 +90,12 @@ export class BoardBuilder {
     return frame;
   }
 
-  /** Move the viewport to show provided bounds. */
-  public async zoomTo(bounds: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }): Promise<void> {
+  /** Move the viewport to show the provided frame or widgets. */
+  public async zoomTo(
+    target: Frame | Array<BaseItem | Group>
+  ): Promise<void> {
     this.ensureBoard();
-    if (miro.board.viewport?.set) {
-      await miro.board.viewport.set({ viewport: bounds });
-    } else if (miro.board.viewport?.zoomTo) {
-      const temp = await miro.board.createFrame({
-        title: '',
-        x: bounds.x,
-        y: bounds.y,
-        width: bounds.width,
-        height: bounds.height,
-      });
-      await miro.board.viewport.zoomTo(temp);
-      await (temp as any).remove();
-    }
+    await miro.board.viewport.zoomTo(target as any);
   }
 
   private async loadShapeCache(): Promise<void> {

--- a/src/GraphProcessor.ts
+++ b/src/GraphProcessor.ts
@@ -1,7 +1,7 @@
 import { loadGraph, defaultBuilder, GraphData } from './graph';
 import { BoardBuilder } from './BoardBuilder';
 import { layoutGraph, LayoutResult } from './elk-layout';
-import type { BaseItem, Group } from '@mirohq/websdk-types';
+import type { BaseItem, Group, Frame } from '@mirohq/websdk-types';
 
 /**
  * High level orchestrator that loads graph data, runs layout and
@@ -86,8 +86,9 @@ export class GraphProcessor {
     const spot = await this.builder.findSpace(frameWidth, frameHeight);
 
     const useFrame = options.createFrame !== false;
+    let frame: Frame | undefined;
     if (useFrame) {
-      await this.builder.createFrame(
+      frame = await this.builder.createFrame(
         frameWidth,
         frameHeight,
         spot.x,
@@ -158,12 +159,11 @@ export class GraphProcessor {
       edgeHints
     );
     await this.builder.syncAll([...Object.values(nodeMap), ...connectors]);
-    await this.builder.zoomTo({
-      x: spot.x,
-      y: spot.y,
-      width: frameWidth,
-      height: frameHeight,
-    });
+    if (frame) {
+      await this.builder.zoomTo(frame);
+    } else {
+      await this.builder.zoomTo(Object.values(nodeMap));
+    }
   }
 
   /** Ensure the graph object has the expected shape. */

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -85,4 +85,49 @@ describe('GraphProcessor', () => {
       'Invalid graph'
     );
   });
+
+  it('positions frame at space center', async () => {
+    const simpleGraph = { nodes: [{ id: 'n1', label: 'A', type: 'Role' }], edges: [] };
+    // Mock layout with a single node to make dimensions deterministic
+    jest.spyOn(require('../src/elk-layout'), 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
+
+    await processor.processGraph(simpleGraph as any);
+
+    const createArgs = (global.miro.board.createFrame as jest.Mock).mock.calls[0][0];
+    expect(createArgs.width).toBe(210);
+    expect(createArgs.height).toBe(210);
+    expect(createArgs.x).toBe(0);
+    expect(createArgs.y).toBe(0);
+
+    const offset = (processor as any).calculateOffset(
+      { x: 0, y: 0 },
+      210,
+      210,
+      { minX: 0, minY: 0 },
+      100
+    );
+    expect(offset.offsetX).toBe(-5);
+    expect(offset.offsetY).toBe(-5);
+
+    expect(global.miro.board.viewport.zoomTo).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'f1' })
+    );
+  });
+
+  it('zooms to shapes when no frame created', async () => {
+    const simpleGraph = { nodes: [{ id: 'n1', label: 'A', type: 'Role' }], edges: [] };
+    jest.spyOn(require('../src/elk-layout'), 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
+
+    await processor.processGraph(simpleGraph as any, { createFrame: false });
+
+    expect(global.miro.board.viewport.zoomTo).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 's1' }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- adjust BoardBuilder.zoomTo to use viewport.zoomTo directly
- zoom to frame when present, otherwise zoom to created shapes
- expand processor tests for new zoom logic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850ee975738832b84123d64d62d645d