### PR TITLE
Add Node engine requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A small example is provided in [sample-graph.json](sample-graph.json):
 - You have a [Miro account](https://miro.com/signup/).
 - You're [signed in to Miro](https://miro.com/login/).
 - Your Miro account has a [Developer team](https://developers.miro.com/docs/create-a-developer-team).
-- Your development environment includes [Node.js 14.13](https://nodejs.org/en/download) or a later version.
+- Your development environment includes [Node.js](https://nodejs.org/en/download) v14.13 or later.
 - All examples use `npm` as a package manager and `npx` as a package runner.
 
 ## 📖 Associated Developer Tutorial <a name="tutorial"></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
         "ts-jest": "^29.1.0",
         "typescript": "4.8.4",
         "vite": "3.2.8"
+      },
+      "engines": {
+        "node": ">=14.13"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "Vite"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=14.13"
+  },
   "scripts": {
     "start": "vite",
     "build": "vite build",


### PR DESCRIPTION
## Summary
- enforce minimum Node version with an `engines` field
- clarify Node requirement in the README

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850f532ec34832b9e57a393e50b4a9b