### PR TITLE
Update connectors with hint positions

### DIFF
--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -320,7 +320,8 @@ export class BoardBuilder {
   private updateConnector(
     connector: Connector,
     edge: EdgeData,
-    template?: ConnectorTemplate
+    template?: ConnectorTemplate,
+    hint?: EdgeHint
   ): void {
     if (edge.label) {
       connector.captions = [
@@ -338,6 +339,18 @@ export class BoardBuilder {
       } as ConnectorStyle as any;
     }
     connector.shape = template?.shape ?? connector.shape;
+    if (hint?.startPosition) {
+      connector.start = {
+        ...(connector.start ?? {}),
+        position: hint.startPosition,
+      } as any;
+    }
+    if (hint?.endPosition) {
+      connector.end = {
+        ...(connector.end ?? {}),
+        position: hint.endPosition,
+      } as any;
+    }
   }
 
   private async createConnector(
@@ -395,7 +408,7 @@ export class BoardBuilder {
       );
       const existing = await this.findConnector(edge.from, edge.to);
       if (existing) {
-        this.updateConnector(existing, edge, template);
+        this.updateConnector(existing, edge, template, hints?.[i]);
         connectors.push(existing);
         continue;
       }

--- a/tests/edges.test.ts
+++ b/tests/edges.test.ts
@@ -54,4 +54,22 @@ describe('createEdges', () => {
     expect(connectors).toHaveLength(1);
     expect(global.miro.board.createConnector).not.toHaveBeenCalled();
   });
+
+  test('updates reused connectors with hint positions', async () => {
+    const existing = {
+      getMetadata: jest.fn().mockResolvedValue({ from: 'n1', to: 'n2' }),
+      sync: jest.fn(),
+      id: 'cExisting',
+      start: { item: 'a', position: { x: 0, y: 0 } },
+      end: { item: 'b', position: { x: 0, y: 0 } },
+    };
+    (global.miro.board.get as jest.Mock).mockResolvedValueOnce([existing]);
+    const edges = [{ from: 'n1', to: 'n2' }];
+    const nodeMap = { n1: { id: 'a' }, n2: { id: 'b' } } as any;
+    const hint = { startPosition: { x: 0.1, y: 0.2 }, endPosition: { x: 0.9, y: 1 } };
+    const connectors = await createEdges(edges as any, nodeMap, [hint as any]);
+    expect(connectors[0]).toBe(existing);
+    expect(existing.start.position).toEqual(hint.startPosition);
+    expect(existing.end.position).toEqual(hint.endPosition);
+  });
 });


### PR DESCRIPTION
## Summary
- update connector start/end positions when hints are provided
- forward hint when reusing connectors
- test updating reused connectors

## Testing
- `npm run typecheck --silent`
- `npm run test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850f5401628832ba436f8ca166ff197