### PR TITLE
Improve graph validation messaging

### DIFF
--- a/src/GraphProcessor.ts
+++ b/src/GraphProcessor.ts
@@ -166,15 +166,25 @@ export class GraphProcessor {
     }
   }
 
-  /** Ensure the graph object has the expected shape. */
+  /**
+   * Ensure the provided graph data is valid.
+   *
+   * @throws {Error} If the graph does not have the expected top level format or
+   *   if any edge references a non-existent node. The thrown error message
+   *   provides details about the specific problem.
+   */
   private validateGraph(graph: GraphData): void {
     if (!graph || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
-      throw new Error('Invalid graph');
+      throw new Error('Invalid graph format');
     }
+
     const nodeIds = new Set(graph.nodes.map((n) => n.id));
     for (const edge of graph.edges) {
-      if (!nodeIds.has(edge.from) || !nodeIds.has(edge.to)) {
-        throw new Error('Invalid graph');
+      if (!nodeIds.has(edge.from)) {
+        throw new Error(`Edge references missing node: ${edge.from}`);
+      }
+      if (!nodeIds.has(edge.to)) {
+        throw new Error(`Edge references missing node: ${edge.to}`);
       }
     }
   }

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -83,7 +83,7 @@ describe('GraphProcessor', () => {
 
   it('throws on invalid graph', async () => {
     await expect(processor.processGraph({} as any)).rejects.toThrow(
-      'Invalid graph'
+      'Invalid graph format'
     );
   });
 
@@ -145,7 +145,7 @@ describe('GraphProcessor', () => {
       edges: [{ from: 'n2', to: 'n1' }],
     };
     await expect(processor.processGraph(graph as any)).rejects.toThrow(
-      'Invalid graph'
+      'Edge references missing node: n2'
     );
   });
 
@@ -155,7 +155,7 @@ describe('GraphProcessor', () => {
       edges: [{ from: 'n1', to: 'n2' }],
     };
     await expect(processor.processGraph(graph as any)).rejects.toThrow(
-      'Invalid graph'
+      'Edge references missing node: n2'
     );
   });
 });


### PR DESCRIPTION
## Summary
- refine graph validation to throw specific errors
- update processor tests for new error messages

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850f550faf8832b881d00e85aa10fd7