### PR TITLE
Fix license mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "Miro Web SDK",
     "Vite"
   ],
-  "license": "MIT",
+  "license": "Unlicense",
   "engines": {
     "node": ">=14.13"
   },


### PR DESCRIPTION
## Summary
- sync package.json license field with README and LICENSE

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850fa4cfa60832b8067dd2d4296dbed