### PR TITLE
Improve card typing and guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Before committing changes run `npm install` to ensure dependencies are up to dat
 npm run typecheck --silent
 npm test --silent
 npm run lint --silent
+npm run prettier --silent
 ```
 
 Exported functions and complex logic should include documentation comments to

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ This project demonstrates how to import a JSON description of a graph and build 
 2. Select a `.json` file containing `nodes` and `edges`.
 3. After the file uploads the ELK layout engine positions the elements and the board is populated with the resulting shapes.
 
+## Importing Cards from JSON
+
+1. In the panel choose **Cards** mode.
+2. Select a `.json` file containing an object with a `cards` array.
+3. Each entry should provide the card `title` and optional `description`, `tags`, `style` and `fields` values. Matching tags are looked up on the board.
+4. See [`sample-cards.json`](sample-cards.json) for an example format.
+
 ## ELK Layout
 
 The layout step leverages the ELK algorithm to compute positions for all nodes. You can provide layout hints in each node's metadata to influence spacing or layering. The engine runs automatically when a graph is uploaded.

--- a/sample-cards.json
+++ b/sample-cards.json
@@ -1,0 +1,18 @@
+{
+  "cards": [
+    {
+      "title": "Design Task",
+      "description": "Initial UX mocks",
+      "tags": ["design"],
+      "style": { "backgroundColor": "#f5cd79" },
+      "fields": { "Status": "Backlog" }
+    },
+    {
+      "title": "Implement Feature",
+      "description": "Add card import support",
+      "tags": ["dev"],
+      "style": { "backgroundColor": "#dff9fb" },
+      "fields": { "Status": "To Do" }
+    }
+  ]
+}

--- a/src/CardProcessor.ts
+++ b/src/CardProcessor.ts
@@ -1,0 +1,106 @@
+import { BoardBuilder } from './BoardBuilder';
+import { loadCards, CardData } from './cards';
+import type { Frame, Tag, Card, CardStyle } from '@mirohq/websdk-types';
+
+export interface CardProcessOptions {
+  createFrame?: boolean;
+  frameTitle?: string;
+}
+
+/**
+ * Helper that places cards from a data set onto the board.
+ */
+export class CardProcessor {
+  constructor(private builder: BoardBuilder = new BoardBuilder()) {}
+
+  private async getBoardTags(): Promise<Tag[]> {
+    return (await miro.board.get({ type: 'tag' })) as Tag[];
+  }
+
+  private tagIds(names: string[] | undefined, tags: Tag[]): string[] {
+    return (names ?? [])
+      .map((name) => tags.find((t) => t.title === name)?.id)
+      .filter((id): id is string => !!id);
+  }
+
+  private async createCardWidget(
+    def: CardData,
+    x: number,
+    y: number,
+    tags: Tag[]
+  ): Promise<Card> {
+    const tagIds = this.tagIds(def.tags, tags);
+    const card = (await miro.board.createCard({
+      title: def.title,
+      description: def.description,
+      tagIds,
+      fields: def.fields,
+      style: def.style as CardStyle,
+      x,
+      y,
+    })) as Card;
+    return card;
+  }
+
+  /** Load cards from a file and create them on the board. */
+  public async processFile(
+    file: File,
+    options: CardProcessOptions = {}
+  ): Promise<void> {
+    const cards = await loadCards(file);
+    await this.processCards(cards, options);
+  }
+
+  /**
+   * Create cards on the board according to the provided definitions.
+   */
+  public async processCards(
+    cards: CardData[],
+    options: CardProcessOptions = {}
+  ): Promise<void> {
+    if (!Array.isArray(cards)) {
+      throw new Error('Invalid cards');
+    }
+
+    const cardWidth = 300;
+    const cardHeight = 200;
+    const totalWidth = cardWidth * cards.length + 100;
+    const totalHeight = cardHeight + 100;
+
+    const spot = await this.builder.findSpace(totalWidth, totalHeight);
+
+    const useFrame = options.createFrame !== false;
+    let frame: Frame | undefined;
+    if (useFrame) {
+      frame = await this.builder.createFrame(
+        totalWidth,
+        totalHeight,
+        spot.x,
+        spot.y,
+        options.frameTitle
+      );
+    } else {
+      this.builder.setFrame(undefined);
+    }
+
+    const boardTags = await this.getBoardTags();
+
+    const startX = spot.x - totalWidth / 2 + 50 + cardWidth / 2;
+    const y = spot.y - totalHeight / 2 + 50 + cardHeight / 2;
+
+    const created = await Promise.all(
+      cards.map((def, i) =>
+        this.createCardWidget(def, startX + i * cardWidth, y, boardTags)
+      )
+    );
+    created.forEach((c) => frame?.add(c));
+
+    await this.builder.syncAll(created);
+
+    if (frame) {
+      await this.builder.zoomTo(frame);
+    } else {
+      await this.builder.zoomTo(created as any);
+    }
+  }
+}

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1,0 +1,40 @@
+import type { CardField, CardStyle } from '@mirohq/websdk-types';
+
+export interface CardData {
+  title: string;
+  description?: string;
+  tags?: string[];
+  style?: CardStyle & Record<string, unknown>;
+  fields?: CardField[];
+}
+
+export interface CardFile {
+  cards: CardData[];
+}
+
+const readFile = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      if (!e.target) {
+        reject('Failed to load file');
+        return;
+      }
+      resolve(e.target.result as string);
+    };
+    reader.onerror = () => reject('Failed to load file');
+    reader.readAsText(file, 'utf-8');
+  });
+
+/** Load and parse card data from an uploaded file. */
+export async function loadCards(file: File): Promise<CardData[]> {
+  if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
+    throw new Error('Invalid file');
+  }
+  const text = await readFile(file);
+  const data = JSON.parse(text) as unknown;
+  if (!data || !Array.isArray((data as any).cards)) {
+    throw new Error('Invalid card data');
+  }
+  return (data as CardFile).cards;
+}

--- a/tests/card-load.test.ts
+++ b/tests/card-load.test.ts
@@ -1,0 +1,53 @@
+import { loadCards } from '../src/cards';
+
+describe('loadCards', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as any).FileReader;
+  });
+
+  test('parses valid file', async () => {
+    class FR {
+      onload: ((e: any) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        this.onload &&
+          this.onload({ target: { result: '{"cards":[{"title":"t"}]}' } });
+      }
+    }
+    (global as any).FileReader = FR;
+    const data = await loadCards({ name: 'c.json' } as any);
+    expect(data).toEqual([{ title: 't' }]);
+  });
+
+  test('throws on invalid file object', async () => {
+    await expect(loadCards(null as any)).rejects.toThrow('Invalid file');
+  });
+
+  test('throws on invalid data', async () => {
+    class FR {
+      onload: ((e: any) => void) | null = null;
+      readAsText() {
+        this.onload && this.onload({ target: { result: '[]' } });
+      }
+    }
+    (global as any).FileReader = FR;
+    await expect(loadCards({ name: 'x.json' } as any)).rejects.toThrow(
+      'Invalid card data'
+    );
+  });
+
+  test('rejects when file load fails', async () => {
+    class FR {
+      onload: ((e: any) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        this.onload && this.onload({});
+      }
+    }
+    (global as any).FileReader = FR;
+    await expect(loadCards({ name: 'bad.json' } as any)).rejects.toBe(
+      'Failed to load file'
+    );
+  });
+});

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -1,0 +1,75 @@
+import { CardProcessor } from '../src/CardProcessor';
+import * as cardModule from '../src/cards';
+
+declare const global: any;
+
+describe('CardProcessor', () => {
+  const processor = new CardProcessor();
+
+  beforeEach(() => {
+    global.miro = {
+      board: {
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest.fn().mockResolvedValue({
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 100,
+        }),
+        viewport: {
+          get: jest.fn().mockResolvedValue({
+            x: 0,
+            y: 0,
+            width: 1000,
+            height: 1000,
+          }),
+          zoomTo: jest.fn(),
+        },
+        createCard: jest.fn().mockResolvedValue({ sync: jest.fn(), id: 'c1' }),
+        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+      },
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  test('processFile loads and processes', async () => {
+    jest.spyOn(cardModule, 'loadCards').mockResolvedValue([{ title: 't' }]);
+    const spy = jest
+      .spyOn(processor, 'processCards')
+      .mockResolvedValue(undefined);
+    await processor.processFile({ name: 'cards.json' } as any);
+    expect(cardModule.loadCards).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith([{ title: 't' }], {});
+  });
+
+  test('processCards creates cards', async () => {
+    await processor.processCards([{ title: 'A', tags: [] }]);
+    expect(global.miro.board.createCard).toHaveBeenCalled();
+    expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
+  });
+
+  test('maps tag names to ids', async () => {
+    (global.miro.board.get as jest.Mock).mockResolvedValue([
+      { id: '1', title: 'alpha' },
+    ]);
+    await processor.processCards([{ title: 'A', tags: ['alpha'] }]);
+    const args = (global.miro.board.createCard as jest.Mock).mock.calls[0][0];
+    expect(args.tagIds).toEqual(['1']);
+  });
+
+  test('skips frame creation when disabled', async () => {
+    await processor.processCards([{ title: 'A' }], { createFrame: false });
+    expect(global.miro.board.createFrame).not.toHaveBeenCalled();
+    expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
+  });
+
+  test('throws on invalid input', async () => {
+    await expect(processor.processCards(null as any)).rejects.toThrow(
+      'Invalid cards'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- update development guidelines to run Prettier before committing
- type card style and fields using Miro SDK types
- pass typed fields into the card creation logic
- format sample card data with Prettier

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6852612ed58c832b916aaaf54141f3ad