### PR TITLE
Optimize file reading and metadata searches

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{js,json,yml}]
+[*.{js,ts,tsx,json,yml}]
 charset = utf-8
 indent_style = space
 indent_size = 2

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,7 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "all",
+  "printWidth": 80,
+  "arrowParens": "avoid"
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,20 +1,32 @@
 import tseslint from '@typescript-eslint/eslint-plugin';
 import parser from '@typescript-eslint/parser';
+import react from 'eslint-plugin-react';
 
 export default [
   {
     ignores: ['node_modules/**', 'dist/**'],
   },
   ...tseslint.configs['flat/recommended'],
+  react.configs.flat.recommended,
   {
     files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
       parser,
       ecmaVersion: 'latest',
       sourceType: 'module',
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
+    settings: {
+      react: {
+        version: 'detect',
+      },
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'warn',
+      'react/react-in-jsx-scope': 'off',
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@typescript-eslint/parser": "^8.34.1",
         "@vitejs/plugin-react": "^4.5.2",
         "eslint": "^9.29.0",
+        "eslint-plugin-react": "^7.37.5",
         "jest": "^30.0.0",
         "prettier": "^3.5.3",
         "ts-jest": "^29.1.0",
@@ -3106,12 +3107,160 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -3120,6 +3269,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-jest": {
@@ -3312,6 +3477,56 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -3661,6 +3876,60 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -3711,6 +3980,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties/node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -3719,6 +4034,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -3785,6 +4128,193 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract/node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -3910,6 +4440,73 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/eslint-scope": {
@@ -4309,6 +4906,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4348,6 +4961,47 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4368,6 +5022,31 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4376,6 +5055,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -4389,6 +5082,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -4435,6 +5146,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -4459,6 +5200,19 @@
         "vinyl": "^2.1.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -4467,6 +5221,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/html-escaper": {
@@ -4573,12 +5398,162 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -4588,6 +5563,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -4610,6 +5601,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4623,6 +5633,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4631,6 +5667,71 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -4644,6 +5745,103 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/isarray": {
@@ -4728,6 +5926,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/jackspeak": {
@@ -5455,6 +6671,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5579,6 +6811,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/merge-stream": {
@@ -5753,11 +6995,109 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
       "license": "MIT"
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.assign/node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -5801,6 +7141,34 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/own-keys/node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/p-limit": {
@@ -5913,6 +7281,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
@@ -6035,6 +7410,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -6258,6 +7643,50 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -6281,6 +7710,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -6404,11 +7851,80 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-array-concat/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6435,6 +7951,55 @@
         "node": ">=10"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6456,6 +8021,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6540,6 +8181,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/string_decoder": {
@@ -6649,6 +8304,104 @@
         "node": ">=8"
       }
     },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -6733,6 +8486,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/synckit": {
@@ -7008,6 +8774,84 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -7020,6 +8864,25 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/undici-types": {
@@ -7270,6 +9133,102 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@typescript-eslint/parser": "^8.34.1",
     "@vitejs/plugin-react": "^4.5.2",
     "eslint": "^9.29.0",
+    "eslint-plugin-react": "^7.37.5",
     "jest": "^30.0.0",
     "prettier": "^3.5.3",
     "ts-jest": "^29.1.0",

--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -112,6 +112,10 @@ export class BoardBuilder {
     }
   }
 
+  /**
+   * Search cached shapes for metadata that matches the given type and label.
+   * Returns the corresponding item if found.
+   */
   private async searchShapes(
     type: string,
     label: string
@@ -130,6 +134,10 @@ export class BoardBuilder {
     return undefined;
   }
 
+  /**
+   * Search all groups on the board for an item whose metadata matches
+   * the provided type and label.
+   */
   private async searchGroups(
     type: string,
     label: string

--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -58,7 +58,7 @@ export class BoardBuilder {
    */
   public async findSpace(
     width: number,
-    height: number
+    height: number,
   ): Promise<{ x: number; y: number }> {
     this.ensureBoard();
     const vp = await miro.board.viewport.get();
@@ -78,7 +78,7 @@ export class BoardBuilder {
     height: number,
     x: number,
     y: number,
-    title?: string
+    title?: string,
   ): Promise<Frame> {
     this.ensureBoard();
     const frame = (await miro.board.createFrame({
@@ -120,10 +120,10 @@ export class BoardBuilder {
    */
   private async findByMetadata<T extends BaseItem | Group | Connector>(
     items: T[],
-    predicate: (meta: any, item: T) => boolean
+    predicate: (meta: any, item: T) => boolean,
   ): Promise<T | undefined> {
     const metas = await Promise.all(
-      items.map((i) => (i as any).getMetadata(META_KEY))
+      items.map(i => (i as any).getMetadata(META_KEY)),
     );
     for (let i = 0; i < items.length; i++) {
       if (predicate(metas[i], items[i])) {
@@ -139,11 +139,11 @@ export class BoardBuilder {
    */
   private async searchShapes(
     type: string,
-    label: string
+    label: string,
   ): Promise<BaseItem | Group | undefined> {
     await this.loadShapeCache();
     const shapes = this.shapeCache ?? [];
-    return this.findByMetadata(shapes, (meta) => {
+    return this.findByMetadata(shapes, meta => {
       const data = meta as NodeMetadata | undefined;
       return data?.type === type && data.label === label;
     });
@@ -155,20 +155,20 @@ export class BoardBuilder {
    */
   private async searchGroups(
     type: string,
-    label: string
+    label: string,
   ): Promise<BaseItem | Group | undefined> {
     this.ensureBoard();
     const groups = (await miro.board.get({ type: 'group' })) as Group[];
     const matches = await Promise.all(
-      groups.map(async (group) => {
+      groups.map(async group => {
         const items = await group.getItems();
         if (!Array.isArray(items)) return undefined;
-        const found = await this.findByMetadata(items as BaseItem[], (meta) => {
+        const found = await this.findByMetadata(items as BaseItem[], meta => {
           const data = meta as NodeMetadata | undefined;
           return data?.type === type && data.label === label;
         });
         return found ? group : undefined;
-      })
+      }),
     );
     return matches.find(Boolean);
   }
@@ -176,7 +176,7 @@ export class BoardBuilder {
   /** Lookup an existing widget with matching metadata. */
   public async findNode(
     type: string,
-    label: string
+    label: string,
   ): Promise<BaseItem | Group | undefined> {
     if (typeof type !== 'string' || typeof label !== 'string') {
       throw new Error('Invalid search parameters');
@@ -189,14 +189,14 @@ export class BoardBuilder {
   /** Find a connector with matching metadata if it exists on the board. */
   public async findConnector(
     from: string,
-    to: string
+    to: string,
   ): Promise<Connector | undefined> {
     if (typeof from !== 'string' || typeof to !== 'string') {
       throw new Error('Invalid search parameters');
     }
     await this.loadConnectorCache();
     const connectors = this.connectorCache ?? [];
-    return this.findByMetadata(connectors, (meta) => {
+    return this.findByMetadata(connectors, meta => {
       const data = meta as EdgeMetadata | undefined;
       return data?.from === from && data.to === to;
     });
@@ -205,7 +205,7 @@ export class BoardBuilder {
   private applyShapeElement(
     item: BaseItem,
     el: TemplateElement,
-    label: string
+    label: string,
   ): void {
     if (el.shape) (item as any).shape = el.shape;
     if (el.rotation !== undefined) (item as any).rotation = el.rotation;
@@ -213,7 +213,7 @@ export class BoardBuilder {
     if (el.height) (item as any).height = el.height;
     (item as any).content = (el.text ?? '{{label}}').replace(
       '{{label}}',
-      label
+      label,
     );
     const existing = (item as any).style ?? {};
     const style: Record<string, unknown> = {
@@ -229,11 +229,11 @@ export class BoardBuilder {
   private applyTextElement(
     item: BaseItem,
     el: TemplateElement,
-    label: string
+    label: string,
   ): void {
     (item as any).content = (el.text ?? '{{label}}').replace(
       '{{label}}',
-      label
+      label,
     );
     if (el.style) {
       (item as any).style = {
@@ -246,7 +246,7 @@ export class BoardBuilder {
   private applyElementToItem(
     item: BaseItem,
     el: TemplateElement,
-    label: string
+    label: string,
   ): void {
     if (item.type === 'shape') {
       this.applyShapeElement(item, el, label);
@@ -258,7 +258,7 @@ export class BoardBuilder {
   private async updateExistingNode(
     existing: BaseItem | Group,
     def: TemplateDefinition,
-    node: NodeData
+    node: NodeData,
   ): Promise<BaseItem | Group> {
     if ((existing as Group).type === 'group') {
       const items = await (existing as Group).getItems();
@@ -267,13 +267,13 @@ export class BoardBuilder {
           this.applyElementToItem(
             item as BaseItem,
             def.elements[i],
-            node.label
+            node.label,
           );
           return item.setMetadata(META_KEY, {
             type: node.type,
             label: node.label,
           });
-        })
+        }),
       );
       return existing as Group;
     }
@@ -287,21 +287,21 @@ export class BoardBuilder {
 
   private async createNewNode(
     node: NodeData,
-    pos: PositionedNode
+    pos: PositionedNode,
   ): Promise<BaseItem | Group> {
     const widget = await createFromTemplate(
       node.type,
       node.label,
       pos.x,
       pos.y,
-      this.frame
+      this.frame,
     );
     if ((widget as Group).type === 'group') {
       const items = await (widget as Group).getItems();
       await Promise.all(
-        items.map((item) =>
-          item.setMetadata(META_KEY, { type: node.type, label: node.label })
-        )
+        items.map(item =>
+          item.setMetadata(META_KEY, { type: node.type, label: node.label }),
+        ),
       );
       return widget as Group;
     }
@@ -318,7 +318,7 @@ export class BoardBuilder {
   /** Create or update a node widget from a template. */
   public async createNode(
     node: NodeData,
-    pos: PositionedNode
+    pos: PositionedNode,
   ): Promise<BaseItem | Group> {
     if (!node || typeof node !== 'object') {
       throw new Error('Invalid node');
@@ -335,7 +335,7 @@ export class BoardBuilder {
       return this.updateExistingNode(
         existing as BaseItem | Group,
         templateDef,
-        node
+        node,
       );
     }
     return this.createNewNode(node, pos);
@@ -345,7 +345,7 @@ export class BoardBuilder {
     connector: Connector,
     edge: EdgeData,
     template?: ConnectorTemplate,
-    hint?: EdgeHint
+    hint?: EdgeHint,
   ): void {
     if (edge.label) {
       connector.captions = [
@@ -382,7 +382,7 @@ export class BoardBuilder {
     from: BaseItem | Group,
     to: BaseItem | Group,
     hint: EdgeHint | undefined,
-    template?: ConnectorTemplate
+    template?: ConnectorTemplate,
   ): Promise<Connector> {
     const connector = await miro.board.createConnector({
       start: { item: from.id, position: hint?.startPosition },
@@ -413,7 +413,7 @@ export class BoardBuilder {
   public async createEdges(
     edges: EdgeData[],
     nodeMap: Record<string, BaseItem | Group>,
-    hints?: EdgeHint[]
+    hints?: EdgeHint[],
   ): Promise<Connector[]> {
     if (!Array.isArray(edges)) {
       throw new Error('Invalid edges');
@@ -427,7 +427,7 @@ export class BoardBuilder {
         const to = nodeMap[edge.to];
         if (!from || !to) return undefined;
         const template = getConnectorTemplate(
-          (edge.metadata as any)?.template || 'default'
+          (edge.metadata as any)?.template || 'default',
         );
         const existing = await this.findConnector(edge.from, edge.to);
         if (existing) {
@@ -435,19 +435,19 @@ export class BoardBuilder {
           return existing;
         }
         return this.createConnector(edge, from, to, hints?.[i], template);
-      })
+      }),
     );
     return created.filter(Boolean) as Connector[];
   }
 
   /** Call `.sync()` on each widget if the method exists. */
   public async syncAll(
-    items: Array<BaseItem | Group | Connector>
+    items: Array<BaseItem | Group | Connector>,
   ): Promise<void> {
     await Promise.all(
       items
-        .filter((i) => typeof (i as any).sync === 'function')
-        .map((i) => (i as any).sync())
+        .filter(i => typeof (i as any).sync === 'function')
+        .map(i => (i as any).sync()),
     );
   }
 }

--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -117,11 +117,14 @@ export class BoardBuilder {
     label: string
   ): Promise<BaseItem | Group | undefined> {
     await this.loadShapeCache();
-    for (const item of this.shapeCache ?? []) {
-      const raw = await item.getMetadata('app.miro.structgraph');
-      const meta = raw as unknown as NodeMetadata | undefined;
+    const shapes = this.shapeCache ?? [];
+    const metas = await Promise.all(
+      shapes.map((s) => s.getMetadata('app.miro.structgraph'))
+    );
+    for (let i = 0; i < shapes.length; i++) {
+      const meta = metas[i] as unknown as NodeMetadata | undefined;
       if (meta?.type === type && meta.label === label) {
-        return item as BaseItem;
+        return shapes[i] as BaseItem;
       }
     }
     return undefined;
@@ -136,9 +139,11 @@ export class BoardBuilder {
     for (const group of groups) {
       const items = await group.getItems();
       if (!Array.isArray(items)) continue;
-      for (const item of items) {
-        const raw = await item.getMetadata('app.miro.structgraph');
-        const meta = raw as unknown as NodeMetadata | undefined;
+      const metas = await Promise.all(
+        items.map((i) => i.getMetadata('app.miro.structgraph'))
+      );
+      for (let i = 0; i < items.length; i++) {
+        const meta = metas[i] as unknown as NodeMetadata | undefined;
         if (meta?.type === type && meta.label === label) {
           return group as Group;
         }
@@ -169,11 +174,14 @@ export class BoardBuilder {
       throw new Error('Invalid search parameters');
     }
     await this.loadConnectorCache();
-    for (const conn of this.connectorCache ?? []) {
-      const raw = await conn.getMetadata('app.miro.structgraph');
-      const meta = raw as unknown as EdgeMetadata | undefined;
+    const connectors = this.connectorCache ?? [];
+    const metas = await Promise.all(
+      connectors.map((c) => c.getMetadata('app.miro.structgraph'))
+    );
+    for (let i = 0; i < connectors.length; i++) {
+      const meta = metas[i] as unknown as EdgeMetadata | undefined;
       if (meta?.from === from && meta.to === to) {
-        return conn as Connector;
+        return connectors[i] as Connector;
       }
     }
     return undefined;

--- a/src/CardProcessor.ts
+++ b/src/CardProcessor.ts
@@ -19,7 +19,7 @@ export class CardProcessor {
 
   private tagIds(names: string[] | undefined, tags: Tag[]): string[] {
     return (names ?? [])
-      .map((name) => tags.find((t) => t.title === name)?.id)
+      .map(name => tags.find(t => t.title === name)?.id)
       .filter((id): id is string => !!id);
   }
 
@@ -27,7 +27,7 @@ export class CardProcessor {
     def: CardData,
     x: number,
     y: number,
-    tags: Tag[]
+    tags: Tag[],
   ): Promise<Card> {
     const tagIds = this.tagIds(def.tags, tags);
     const card = (await miro.board.createCard({
@@ -45,7 +45,7 @@ export class CardProcessor {
   /** Load cards from a file and create them on the board. */
   public async processFile(
     file: File,
-    options: CardProcessOptions = {}
+    options: CardProcessOptions = {},
   ): Promise<void> {
     const cards = await loadCards(file);
     await this.processCards(cards, options);
@@ -56,7 +56,7 @@ export class CardProcessor {
    */
   public async processCards(
     cards: CardData[],
-    options: CardProcessOptions = {}
+    options: CardProcessOptions = {},
   ): Promise<void> {
     if (!Array.isArray(cards)) {
       throw new Error('Invalid cards');
@@ -77,7 +77,7 @@ export class CardProcessor {
         totalHeight,
         spot.x,
         spot.y,
-        options.frameTitle
+        options.frameTitle,
       );
     } else {
       this.builder.setFrame(undefined);
@@ -90,10 +90,10 @@ export class CardProcessor {
 
     const created = await Promise.all(
       cards.map((def, i) =>
-        this.createCardWidget(def, startX + i * cardWidth, y, boardTags)
-      )
+        this.createCardWidget(def, startX + i * cardWidth, y, boardTags),
+      ),
     );
-    created.forEach((c) => frame?.add(c));
+    created.forEach(c => frame?.add(c));
 
     await this.builder.syncAll(created);
 

--- a/src/GraphProcessor.ts
+++ b/src/GraphProcessor.ts
@@ -1,4 +1,10 @@
-import { loadGraph, defaultBuilder, GraphData } from './graph';
+import {
+  loadGraph,
+  defaultBuilder,
+  GraphData,
+  PositionedNode,
+  EdgeHint,
+} from './graph';
 import { BoardBuilder } from './BoardBuilder';
 import { layoutGraph, LayoutResult } from './elk-layout';
 import { validateFile } from './file-utils';
@@ -32,7 +38,7 @@ export class GraphProcessor {
     let minY = Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
-    Object.values(layout.nodes).forEach((n) => {
+    Object.values(layout.nodes).forEach(n => {
       minX = Math.min(minX, n.x);
       minY = Math.min(minY, n.y);
       maxX = Math.max(maxX, n.x + n.width);
@@ -49,19 +55,41 @@ export class GraphProcessor {
     frameWidth: number,
     frameHeight: number,
     bounds: { minX: number; minY: number },
-    margin: number
+    margin: number,
   ): { offsetX: number; offsetY: number } {
     return {
       offsetX: spot.x - frameWidth / 2 + margin - bounds.minX,
       offsetY: spot.y - frameHeight / 2 + margin - bounds.minY,
     };
   }
+
+  /**
+   * Compute connector orientation hints from the raw layout result.
+   */
+  private computeEdgeHints(graph: GraphData, layout: LayoutResult): EdgeHint[] {
+    const orient = (
+      node: PositionedNode,
+      pt: { x: number; y: number },
+    ): { x: number; y: number } => ({
+      x: (pt.x - node.x) / node.width,
+      y: (pt.y - node.y) / node.height,
+    });
+
+    return layout.edges.map((edge, i) => {
+      const src = layout.nodes[graph.edges[i].from];
+      const tgt = layout.nodes[graph.edges[i].to];
+      return {
+        startPosition: orient(src, edge.startPoint),
+        endPosition: orient(tgt, edge.endPoint),
+      };
+    });
+  }
   /**
    * Load a JSON graph file and process it.
    */
   public async processFile(
     file: File,
-    options: ProcessOptions = {}
+    options: ProcessOptions = {},
   ): Promise<void> {
     validateFile(file);
     const graph = await loadGraph(file);
@@ -73,7 +101,7 @@ export class GraphProcessor {
    */
   public async processGraph(
     graph: GraphData,
-    options: ProcessOptions = {}
+    options: ProcessOptions = {},
   ): Promise<void> {
     this.validateGraph(graph);
     const layout = await layoutGraph(graph);
@@ -92,7 +120,7 @@ export class GraphProcessor {
         frameHeight,
         spot.x,
         spot.y,
-        options.frameTitle
+        options.frameTitle,
       );
     } else {
       this.builder.setFrame(undefined);
@@ -103,7 +131,7 @@ export class GraphProcessor {
       frameWidth,
       frameHeight,
       { minX: bounds.minX, minY: bounds.minY },
-      margin
+      margin,
     );
 
     const nodeMap: Record<string, BaseItem | Group> = {};
@@ -118,44 +146,12 @@ export class GraphProcessor {
       nodeMap[node.id] = widget;
     }
 
-    const adjustedEdges = layout.edges.map((edge) => ({
-      startPoint: {
-        x: edge.startPoint.x + offsetX,
-        y: edge.startPoint.y + offsetY,
-      },
-      endPoint: {
-        x: edge.endPoint.x + offsetX,
-        y: edge.endPoint.y + offsetY,
-      },
-      bendPoints: edge.bendPoints?.map((pt) => ({
-        x: pt.x + offsetX,
-        y: pt.y + offsetY,
-      })),
-    }));
-    // Derive connector orientation hints from ELK edge routes
-    const edgeHints = adjustedEdges.map((e, i) => {
-      const src = layout.nodes[graph.edges[i].from];
-      const tgt = layout.nodes[graph.edges[i].to];
-
-      const orient = (
-        node: typeof src,
-        pt: { x: number; y: number }
-      ): { x: number; y: number } => {
-        const px = (pt.x - (node.x + offsetX)) / node.width;
-        const py = (pt.y - (node.y + offsetY)) / node.height;
-        return { x: px, y: py };
-      };
-
-      return {
-        startPosition: orient(src, e.startPoint),
-        endPosition: orient(tgt, e.endPoint),
-      };
-    });
+    const edgeHints = this.computeEdgeHints(graph, layout);
 
     const connectors = await this.builder.createEdges(
       graph.edges,
       nodeMap,
-      edgeHints
+      edgeHints,
     );
     await this.builder.syncAll([...Object.values(nodeMap), ...connectors]);
     if (frame) {
@@ -177,7 +173,7 @@ export class GraphProcessor {
       throw new Error('Invalid graph format');
     }
 
-    const nodeIds = new Set(graph.nodes.map((n) => n.id));
+    const nodeIds = new Set(graph.nodes.map(n => n.id));
     for (const edge of graph.edges) {
       if (!nodeIds.has(edge.from)) {
         throw new Error(`Edge references missing node: ${edge.from}`);

--- a/src/GraphProcessor.ts
+++ b/src/GraphProcessor.ts
@@ -1,6 +1,7 @@
 import { loadGraph, defaultBuilder, GraphData } from './graph';
 import { BoardBuilder } from './BoardBuilder';
 import { layoutGraph, LayoutResult } from './elk-layout';
+import { validateFile } from './file-utils';
 import type { BaseItem, Group, Frame } from '@mirohq/websdk-types';
 
 /**
@@ -62,9 +63,7 @@ export class GraphProcessor {
     file: File,
     options: ProcessOptions = {}
   ): Promise<void> {
-    if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
-      throw new Error('Invalid file');
-    }
+    validateFile(file);
     const graph = await loadGraph(file);
     await this.processGraph(graph, options);
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -126,7 +126,7 @@ const App: React.FC = () => {
             <input
               type="checkbox"
               checked={withFrame}
-              onChange={(e) => setWithFrame(e.target.checked)}
+              onChange={e => setWithFrame(e.target.checked)}
             />
             Wrap items in frame
           </label>
@@ -135,7 +135,7 @@ const App: React.FC = () => {
               type="text"
               placeholder="Frame title"
               value={frameTitle}
-              onChange={(e) => setFrameTitle(e.target.value)}
+              onChange={e => setFrameTitle(e.target.value)}
               style={{ marginTop: '4px', width: '100%' }}
             />
           )}

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -50,7 +50,7 @@ const App: React.FC = () => {
           });
         }
       } catch (e) {
-        console.error(e);
+        miro.board.notifications.showError(String(e));
       }
     }
     setFiles([]);

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1,5 +1,5 @@
 import type { CardField, CardStyle } from '@mirohq/websdk-types';
-import { readFileAsText } from './file-utils';
+import { readFileAsText, validateFile } from './file-utils';
 
 export interface CardData {
   title: string;
@@ -15,9 +15,7 @@ export interface CardFile {
 
 /** Load and parse card data from an uploaded file. */
 export async function loadCards(file: File): Promise<CardData[]> {
-  if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
-    throw new Error('Invalid file');
-  }
+  validateFile(file);
   const text = await readFileAsText(file);
   const data = JSON.parse(text) as unknown;
   if (!data || !Array.isArray((data as any).cards)) {

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1,4 +1,5 @@
 import type { CardField, CardStyle } from '@mirohq/websdk-types';
+import { readFileAsText } from './file-utils';
 
 export interface CardData {
   title: string;
@@ -12,26 +13,12 @@ export interface CardFile {
   cards: CardData[];
 }
 
-const readFile = (file: File): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      if (!e.target) {
-        reject('Failed to load file');
-        return;
-      }
-      resolve(e.target.result as string);
-    };
-    reader.onerror = () => reject('Failed to load file');
-    reader.readAsText(file, 'utf-8');
-  });
-
 /** Load and parse card data from an uploaded file. */
 export async function loadCards(file: File): Promise<CardData[]> {
   if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
     throw new Error('Invalid file');
   }
-  const text = await readFile(file);
+  const text = await readFileAsText(file);
   const data = JSON.parse(text) as unknown;
   if (!data || !Array.isArray((data as any).cards)) {
     throw new Error('Invalid card data');

--- a/src/elk-layout.ts
+++ b/src/elk-layout.ts
@@ -55,9 +55,9 @@ export const layoutGraph = async (data: GraphData): Promise<LayoutResult> => {
       'elk.layered.cycleBreaking.strategy': 'GREEDY',
     },
     // Each node uses its template dimensions unless overridden by metadata
-    children: data.nodes.map((n) => {
+    children: data.nodes.map(n => {
       const tpl = getTemplate(n.type);
-      const dims = tpl?.elements.find((e) => e.width && e.height);
+      const dims = tpl?.elements.find(e => e.width && e.height);
       // istanbul ignore next: fall back to template or default dimensions
       const width = (n as any).metadata?.width ?? dims?.width ?? DEFAULT_WIDTH;
       // istanbul ignore next: fall back to template or default dimensions

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -10,7 +10,7 @@ export const readFileAsText = (file: File): Promise<string> => {
   }
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = (e) => {
+    reader.onload = e => {
       if (!e.target) {
         reject('Failed to load file');
         return;

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -21,3 +21,10 @@ export const readFileAsText = (file: File): Promise<string> => {
     reader.readAsText(file, 'utf-8');
   });
 };
+
+/** Ensure the provided object is a valid `File`. */
+export function validateFile(file: File): void {
+  if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
+    throw new Error('Invalid file');
+  }
+}

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,0 +1,14 @@
+/** Utility to read a file as UTF-8 text. */
+export const readFileAsText = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      if (!e.target) {
+        reject('Failed to load file');
+        return;
+      }
+      resolve(e.target.result as string);
+    };
+    reader.onerror = () => reject('Failed to load file');
+    reader.readAsText(file, 'utf-8');
+  });

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -1,6 +1,14 @@
-/** Utility to read a file as UTF-8 text. */
-export const readFileAsText = (file: File): Promise<string> =>
-  new Promise((resolve, reject) => {
+/**
+ * Read the contents of a `File` as UTF-8 text.
+ *
+ * Uses `file.text()` when available and falls back to `FileReader`
+ * for broader compatibility.
+ */
+export const readFileAsText = (file: File): Promise<string> => {
+  if (typeof (file as any).text === 'function') {
+    return (file as any).text();
+  }
+  return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = (e) => {
       if (!e.target) {
@@ -12,3 +20,4 @@ export const readFileAsText = (file: File): Promise<string> =>
     reader.onerror = () => reject('Failed to load file');
     reader.readAsText(file, 'utf-8');
   });
+};

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -60,30 +60,30 @@ export function resetBoardCache(): void {
 /** Wrapper to search for an existing node. */
 export const findNode = (
   type: string,
-  label: string
+  label: string,
 ): Promise<BaseItem | Group | undefined> =>
   defaultBuilder.findNode(type, label);
 
 /** Wrapper to search for an existing connector. */
 export const findConnector = (
   from: string,
-  to: string
+  to: string,
 ): Promise<Connector | undefined> => defaultBuilder.findConnector(from, to);
 
 /** Wrapper to create or update a node widget. */
 export const createNode = (
   node: NodeData,
-  pos: PositionedNode
+  pos: PositionedNode,
 ): Promise<BaseItem | Group> => defaultBuilder.createNode(node, pos);
 
 /** Wrapper to create or update connectors. */
 export const createEdges = (
   edges: EdgeData[],
   nodeMap: Record<string, BaseItem | Group>,
-  hints?: EdgeHint[]
+  hints?: EdgeHint[],
 ): Promise<Connector[]> => defaultBuilder.createEdges(edges, nodeMap, hints);
 
 /** Proxy to sync multiple widgets. */
 export const syncAll = (
-  items: Array<BaseItem | Group | Connector>
+  items: Array<BaseItem | Group | Connector>,
 ): Promise<void> => defaultBuilder.syncAll(items);

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,6 +1,6 @@
 import type { BaseItem, Group, Connector } from '@mirohq/websdk-types';
 import { BoardBuilder } from './BoardBuilder';
-import { readFileAsText } from './file-utils';
+import { readFileAsText, validateFile } from './file-utils';
 
 export interface NodeData {
   id: string;
@@ -35,9 +35,7 @@ export interface EdgeHint {
 
 /** Load and parse JSON graph data from a file. */
 export async function loadGraph(file: File): Promise<GraphData> {
-  if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
-    throw new Error('Invalid file');
-  }
+  validateFile(file);
   const text = await readFileAsText(file);
   const data = JSON.parse(text) as unknown;
   if (

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,5 +1,6 @@
 import type { BaseItem, Group, Connector } from '@mirohq/websdk-types';
 import { BoardBuilder } from './BoardBuilder';
+import { readFileAsText } from './file-utils';
 
 export interface NodeData {
   id: string;
@@ -32,26 +33,12 @@ export interface EdgeHint {
   endPosition?: { x: number; y: number };
 }
 
-const readFile = (file: File): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      if (!e.target) {
-        reject('Failed to load file');
-        return;
-      }
-      resolve(e.target.result as string);
-    };
-    reader.onerror = () => reject('Failed to load file');
-    reader.readAsText(file, 'utf-8');
-  });
-
 /** Load and parse JSON graph data from a file. */
 export async function loadGraph(file: File): Promise<GraphData> {
   if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
     throw new Error('Invalid file');
   }
-  const text = await readFile(file);
+  const text = await readFileAsText(file);
   const data = JSON.parse(text) as unknown;
   if (
     !data ||

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -56,7 +56,7 @@ export function getTemplate(name: string): TemplateDefinition | undefined {
 
 /** Retrieve a connector styling template by name. */
 export function getConnectorTemplate(
-  name: string
+  name: string,
 ): ConnectorTemplate | undefined {
   const tpl = connectorTemplates[name];
   if (!tpl) return undefined;
@@ -71,7 +71,7 @@ export async function createFromTemplate(
   label: string,
   x: number,
   y: number,
-  frame?: Frame
+  frame?: Frame,
 ): Promise<GroupableItem | Group> {
   const template = getTemplate(name);
   if (!template) {

--- a/tests/boardbuilder-branches.test.ts
+++ b/tests/boardbuilder-branches.test.ts
@@ -26,8 +26,8 @@ describe('BoardBuilder branch coverage', () => {
     };
     const builder = new BoardBuilder();
     // Expect the builder to return the matching group
-    const res = await builder.findNode('Role', 'A');
-    expect(res).toBe(group);
+    const result = await builder.findNode('Role', 'A');
+    expect(result).toBe(group);
   });
 
   test('createNode applies fill color when style missing', async () => {

--- a/tests/boardbuilder-cache.test.ts
+++ b/tests/boardbuilder-cache.test.ts
@@ -18,8 +18,8 @@ describe('BoardBuilder caches and connector updates', () => {
       board: { get: jest.fn().mockResolvedValue([shape]) },
     };
     const builder = new BoardBuilder();
-    const res = await builder.findNode('Role', 'B');
-    expect(res).toBe(shape);
+    const result = await builder.findNode('Role', 'B');
+    expect(result).toBe(shape);
   });
 
   test('createEdges caches new connector', async () => {

--- a/tests/boardbuilder-cache.test.ts
+++ b/tests/boardbuilder-cache.test.ts
@@ -1,0 +1,65 @@
+import { BoardBuilder } from '../src/BoardBuilder';
+
+/**
+ * Additional tests exercising caching and connector styling logic.
+ */
+
+describe('BoardBuilder caches and connector updates', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as any).miro;
+  });
+
+  test('findNode retrieves shape from cache', async () => {
+    const shape = {
+      getMetadata: jest.fn().mockResolvedValue({ type: 'Role', label: 'B' }),
+    } as any;
+    (global as any).miro = {
+      board: { get: jest.fn().mockResolvedValue([shape]) },
+    };
+    const builder = new BoardBuilder();
+    const res = await builder.findNode('Role', 'B');
+    expect(res).toBe(shape);
+  });
+
+  test('createEdges caches new connector', async () => {
+    const board = {
+      get: jest.fn().mockResolvedValue([]),
+      createConnector: jest.fn().mockResolvedValue({
+        setMetadata: jest.fn(),
+        getMetadata: jest.fn(),
+        sync: jest.fn(),
+        id: 'c1',
+      }),
+    };
+    (global as any).miro = { board };
+    const builder = new BoardBuilder();
+    const edges = [{ from: 'n1', to: 'n2' }];
+    const nodeMap = { n1: { id: 'a' }, n2: { id: 'b' } } as any;
+
+    await builder.createEdges(edges as any, nodeMap);
+    const calls = board.get.mock.calls.length;
+    await builder.findConnector('n1', 'n2');
+    expect(board.get.mock.calls.length).toBe(calls);
+  });
+
+  test('updateConnector merges style from template', async () => {
+    const existing = {
+      getMetadata: jest.fn().mockResolvedValue({ from: 'n1', to: 'n2' }),
+      sync: jest.fn(),
+      id: 'cExisting',
+      style: {},
+    } as any;
+    const board = {
+      get: jest.fn().mockResolvedValueOnce([existing]),
+      createConnector: jest.fn(),
+    };
+    (global as any).miro = { board };
+    const builder = new BoardBuilder();
+    const edges = [{ from: 'n1', to: 'n2', metadata: { template: 'flow' } }];
+    const nodeMap = { n1: { id: 'a' }, n2: { id: 'b' } } as any;
+
+    await builder.createEdges(edges as any, nodeMap);
+    expect(existing.style.strokeStyle).toBe('dashed');
+  });
+});

--- a/tests/boardbuilder-extra.test.ts
+++ b/tests/boardbuilder-extra.test.ts
@@ -15,7 +15,7 @@ describe('BoardBuilder additional cases', () => {
     const builder = new BoardBuilder();
     // Without a miro global the builder should reject
     await expect(builder.findSpace(1, 1)).rejects.toThrow(
-      'Miro board not initialized'
+      'Miro board not initialized',
     );
   });
 
@@ -31,7 +31,7 @@ describe('BoardBuilder additional cases', () => {
     const builder = new BoardBuilder();
     // Non-string type should cause a validation error
     await expect(builder.findNode(1 as any, 'a')).rejects.toThrow(
-      'Invalid search parameters'
+      'Invalid search parameters',
     );
   });
 
@@ -39,7 +39,7 @@ describe('BoardBuilder additional cases', () => {
     const builder = new BoardBuilder();
     // Null id should trigger validation error
     await expect(builder.findConnector('a', null as any)).rejects.toThrow(
-      'Invalid search parameters'
+      'Invalid search parameters',
     );
   });
 
@@ -47,10 +47,10 @@ describe('BoardBuilder additional cases', () => {
     const builder = new BoardBuilder();
     // Guard against invalid parameters
     await expect(
-      builder.createNode(null as any, { x: 0, y: 0, width: 1, height: 1 })
+      builder.createNode(null as any, { x: 0, y: 0, width: 1, height: 1 }),
     ).rejects.toThrow('Invalid node');
     await expect(builder.createNode({} as any, null as any)).rejects.toThrow(
-      'Invalid position'
+      'Invalid position',
     );
     // Unknown template results in an error
     jest.spyOn(templates, 'getTemplate').mockReturnValue(undefined);
@@ -60,7 +60,7 @@ describe('BoardBuilder additional cases', () => {
         y: 0,
         width: 1,
         height: 1,
-      })
+      }),
     ).rejects.toThrow("Template 'unknown' not found");
   });
 
@@ -79,8 +79,8 @@ describe('BoardBuilder additional cases', () => {
     jest.spyOn(builder, 'findNode').mockResolvedValue(undefined);
     const node = { id: 'n1', label: 'A', type: 'multi' } as any;
     const pos = { x: 0, y: 0, width: 1, height: 1 };
-    const res = await builder.createNode(node, pos);
-    expect(res.type).toBe('group');
+    const result = await builder.createNode(node, pos);
+    expect(result.type).toBe('group');
     // Metadata should be written to child items
     expect(items[0].setMetadata).toHaveBeenCalled();
   });
@@ -102,9 +102,9 @@ describe('BoardBuilder additional cases', () => {
       .mockReturnValue({ elements: [{ shape: 's' }, { text: 't' }] });
     const node = { id: 'n', label: 'L', type: 'Role' } as any;
     const pos = { x: 0, y: 0, width: 1, height: 1 };
-    const res = await builder.createNode(node, pos);
+    const result = await builder.createNode(node, pos);
     // The existing group is returned and updated
-    expect(res).toBe(group);
+    expect(result).toBe(group);
     expect(itemMocks[0].setMetadata).toHaveBeenCalled();
   });
 
@@ -112,11 +112,11 @@ describe('BoardBuilder additional cases', () => {
     const builder = new BoardBuilder();
     // Invalid edges array
     await expect(builder.createEdges(null as any, {} as any)).rejects.toThrow(
-      'Invalid edges'
+      'Invalid edges',
     );
     // Invalid node map
     await expect(builder.createEdges([], null as any)).rejects.toThrow(
-      'Invalid node map'
+      'Invalid node map',
     );
   });
 

--- a/tests/card-load.test.ts
+++ b/tests/card-load.test.ts
@@ -33,7 +33,7 @@ describe('loadCards', () => {
     }
     (global as any).FileReader = FR;
     await expect(loadCards({ name: 'x.json' } as any)).rejects.toThrow(
-      'Invalid card data'
+      'Invalid card data',
     );
   });
 
@@ -47,7 +47,7 @@ describe('loadCards', () => {
     }
     (global as any).FileReader = FR;
     await expect(loadCards({ name: 'bad.json' } as any)).rejects.toBe(
-      'Failed to load file'
+      'Failed to load file',
     );
   });
 });

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -69,7 +69,7 @@ describe('CardProcessor', () => {
 
   test('throws on invalid input', async () => {
     await expect(processor.processCards(null as any)).rejects.toThrow(
-      'Invalid cards'
+      'Invalid cards',
     );
   });
 });

--- a/tests/file-utils.test.ts
+++ b/tests/file-utils.test.ts
@@ -1,0 +1,35 @@
+import { readFileAsText, validateFile } from '../src/file-utils';
+
+describe('file utils', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as any).FileReader;
+  });
+
+  test('readFileAsText uses text method when available', async () => {
+    const file = {
+      name: 'file.txt',
+      text: jest.fn().mockResolvedValue('abc'),
+    } as any;
+    const result = await readFileAsText(file);
+    expect(result).toBe('abc');
+    expect(file.text).toHaveBeenCalled();
+  });
+
+  test('readFileAsText falls back to FileReader', async () => {
+    class FR {
+      onload: ((e: any) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        this.onload && this.onload({ target: { result: 'def' } });
+      }
+    }
+    (global as any).FileReader = FR;
+    const result = await readFileAsText({ name: 'f.txt' } as any);
+    expect(result).toBe('def');
+  });
+
+  test('validateFile throws on invalid object', () => {
+    expect(() => validateFile(null as any)).toThrow('Invalid file');
+  });
+});

--- a/tests/graph-load.test.ts
+++ b/tests/graph-load.test.ts
@@ -45,7 +45,7 @@ describe('loadGraph', () => {
     }
     (global as any).FileReader = FR;
     await expect(loadGraph({ name: 'a.json' } as any)).rejects.toThrow(
-      'Invalid graph data'
+      'Invalid graph data',
     );
   });
 
@@ -59,7 +59,7 @@ describe('loadGraph', () => {
     }
     (global as any).FileReader = FR;
     await expect(loadGraph({ name: 'bad.json' } as any)).rejects.toBe(
-      'Failed to load file'
+      'Failed to load file',
     );
   });
 });

--- a/tests/graph-wrappers.test.ts
+++ b/tests/graph-wrappers.test.ts
@@ -23,9 +23,9 @@ describe('graph wrapper functions', () => {
       .spyOn(defaultBuilder, 'findNode')
       .mockResolvedValue('x' as any);
     // Call wrapper and verify delegation
-    const res = await findNode('t', 'l');
+    const result = await findNode('t', 'l');
     expect(spy).toHaveBeenCalledWith('t', 'l');
-    expect(res).toBe('x');
+    expect(result).toBe('x');
   });
 
   test('findConnector delegates to default builder', async () => {
@@ -33,9 +33,9 @@ describe('graph wrapper functions', () => {
       .spyOn(defaultBuilder, 'findConnector')
       .mockResolvedValue('c' as any);
     // Wrapper should forward parameters to builder
-    const res = await findConnector('a', 'b');
+    const result = await findConnector('a', 'b');
     expect(spy).toHaveBeenCalledWith('a', 'b');
-    expect(res).toBe('c');
+    expect(result).toBe('c');
   });
 
   test('createNode delegates to default builder', async () => {
@@ -43,24 +43,24 @@ describe('graph wrapper functions', () => {
       .spyOn(defaultBuilder, 'createNode')
       .mockResolvedValue('n' as any);
     // Pass-through call should return builder result
-    const res = await createNode({} as any, {
+    const result = await createNode({} as any, {
       x: 0,
       y: 0,
       width: 1,
       height: 1,
     });
     expect(spy).toHaveBeenCalled();
-    expect(res).toBe('n');
+    expect(result).toBe('n');
   });
 
   test('createEdges delegates to default builder', async () => {
     const spy = jest
       .spyOn(defaultBuilder, 'createEdges')
       .mockResolvedValue(['e'] as any);
-    const res = await createEdges([] as any, {} as any);
+    const result = await createEdges([] as any, {} as any);
     // Should simply return value from builder
     expect(spy).toHaveBeenCalled();
-    expect(res[0]).toBe('e');
+    expect(result[0]).toBe('e');
   });
 
   test('syncAll delegates to default builder', async () => {

--- a/tests/layout-branches.test.ts
+++ b/tests/layout-branches.test.ts
@@ -58,10 +58,10 @@ test('layoutGraph uses defaults when layout values missing', async () => {
     edges: [],
   } as any);
   const graph = { nodes: [{ id: 'n2', label: 'B', type: 'Role' }], edges: [] };
-  const res = await layoutGraph(graph as any);
+  const result = await layoutGraph(graph as any);
   // Defaults populate width and position
-  expect(res.nodes.n2.width).toBeGreaterThan(0);
-  expect(res.nodes.n2.x).toBe(0);
+  expect(result.nodes.n2.width).toBeGreaterThan(0);
+  expect(result.nodes.n2.x).toBe(0);
   layoutSpy.mockRestore();
 });
 

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -9,8 +9,8 @@ const graph = {
 };
 
 test('layoutGraph returns positions for all nodes', async () => {
-  const res = await layoutGraph(graph as any);
-  expect(res.nodes.n1).toBeDefined();
-  expect(res.nodes.n2).toBeDefined();
-  expect(Array.isArray(res.edges)).toBe(true);
+  const result = await layoutGraph(graph as any);
+  expect(result.nodes.n1).toBeDefined();
+  expect(result.nodes.n2).toBeDefined();
+  expect(Array.isArray(result.edges)).toBe(true);
 });

--- a/tests/node.test.ts
+++ b/tests/node.test.ts
@@ -29,8 +29,8 @@ describe('createNode', () => {
   const pos = { x: 0, y: 0, width: 10, height: 10 };
 
   test('creates new node', async () => {
-    const res = await createNode(node, pos);
-    expect(res).toBeDefined();
+    const result = await createNode(node, pos);
+    expect(result).toBeDefined();
   });
 
   test('updates existing node', async () => {
@@ -43,8 +43,8 @@ describe('createNode', () => {
       id: 'sExisting',
     } as any;
     (global.miro.board.get as jest.Mock).mockResolvedValueOnce([existing]);
-    const res = await createNode(node, pos);
-    expect(res).toBe(existing);
+    const result = await createNode(node, pos);
+    expect(result).toBe(existing);
     expect(existing.style.fillColor).toBe('#FDE9D9');
   });
 });

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -83,7 +83,7 @@ describe('GraphProcessor', () => {
 
   it('throws on invalid graph', async () => {
     await expect(processor.processGraph({} as any)).rejects.toThrow(
-      'Invalid graph format'
+      'Invalid graph format',
     );
   });
 
@@ -112,13 +112,13 @@ describe('GraphProcessor', () => {
       210,
       210,
       { minX: 0, minY: 0 },
-      100
+      100,
     );
     expect(offset.offsetX).toBe(-5);
     expect(offset.offsetY).toBe(-5);
 
     expect(global.miro.board.viewport.zoomTo).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'f1' })
+      expect.objectContaining({ id: 'f1' }),
     );
   });
 
@@ -145,7 +145,7 @@ describe('GraphProcessor', () => {
       edges: [{ from: 'n2', to: 'n1' }],
     };
     await expect(processor.processGraph(graph as any)).rejects.toThrow(
-      'Edge references missing node: n2'
+      'Edge references missing node: n2',
     );
   });
 
@@ -155,7 +155,7 @@ describe('GraphProcessor', () => {
       edges: [{ from: 'n1', to: 'n2' }],
     };
     await expect(processor.processGraph(graph as any)).rejects.toThrow(
-      'Edge references missing node: n2'
+      'Edge references missing node: n2',
     );
   });
 });

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -40,7 +40,7 @@ describe('createFromTemplate', () => {
       'Role',
       'Label',
       0,
-      0
+      0,
     );
     expect(widget.type).toBe('shape');
     const args = (global.miro.board.createShape as jest.Mock).mock.calls[0][0];
@@ -60,7 +60,7 @@ describe('createFromTemplate', () => {
       'multi',
       'Label',
       0,
-      0
+      0,
     );
     expect(widget.type).toBe('group');
     expect(global.miro.board.createShape).toHaveBeenCalled();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ dns.setDefaultResultOrder('verbatim');
 // make sure vite picks up all html files in root, needed for vite build
 const allHtmlEntries = fs
   .readdirSync('.')
-  .filter((file) => path.extname(file) === '.html')
+  .filter(file => path.extname(file) === '.html')
   .reduce((acc: Record<string, string>, file) => {
     acc[path.basename(file, '.html')] = path.resolve(__dirname, file);
 


### PR DESCRIPTION
## Summary
- add `readFileAsText` helper to share file loading
- refactor `loadCards` and `loadGraph` to use the helper
- parallelize metadata lookups in `BoardBuilder`

## Testing
- `npm install`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6852739f57f0832b896ecb04417b0f18