### PR TITLE
Refactor CardProcessor for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ This project demonstrates how to import a JSON description of a graph and build 
 
 1. In the panel choose **Cards** mode.
 2. Select a `.json` file containing an object with a `cards` array.
-3. Each entry should provide the card `title` and optional `description`, `tags`, `style` and `fields` values. Matching tags are looked up on the board.
+3. Each entry should provide an optional `id` to update existing cards along with
+   the card `title` and optional `description`, `tags`, `style` and `fields`
+   values. Matching tags are looked up on the board.
 4. See [`sample-cards.json`](sample-cards.json) for an example format.
 
 ## ELK Layout

--- a/sample-cards.json
+++ b/sample-cards.json
@@ -1,6 +1,7 @@
 {
   "cards": [
     {
+      "id": "card-1",
       "title": "Design Task",
       "description": "Initial UX mocks",
       "tags": ["design"],
@@ -8,6 +9,7 @@
       "fields": { "Status": "Backlog" }
     },
     {
+      "id": "card-2",
       "title": "Implement Feature",
       "description": "Add card import support",
       "tags": ["dev"],

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -2,6 +2,8 @@ import type { CardField, CardStyle } from '@mirohq/websdk-types';
 import { readFileAsText, validateFile } from './file-utils';
 
 export interface CardData {
+  /** Optional unique identifier for updating existing cards. */
+  id?: string;
   title: string;
   description?: string;
   tags?: string[];

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -4,9 +4,10 @@ import * as cardModule from '../src/cards';
 declare const global: any;
 
 describe('CardProcessor', () => {
-  const processor = new CardProcessor();
+  let processor: CardProcessor;
 
   beforeEach(() => {
+    processor = new CardProcessor();
     global.miro = {
       board: {
         get: jest.fn().mockResolvedValue([]),
@@ -25,7 +26,13 @@ describe('CardProcessor', () => {
           }),
           zoomTo: jest.fn(),
         },
-        createCard: jest.fn().mockResolvedValue({ sync: jest.fn(), id: 'c1' }),
+        createCard: jest
+          .fn()
+          .mockResolvedValue({
+            sync: jest.fn(),
+            id: 'c1',
+            setMetadata: jest.fn(),
+          }),
         createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
       },
     };
@@ -52,6 +59,15 @@ describe('CardProcessor', () => {
     expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
   });
 
+  test('sets identifier metadata when creating', async () => {
+    await processor.processCards([{ id: 'x', title: 'A' }]);
+    const card = await (global.miro.board.createCard as jest.Mock).mock
+      .results[0].value;
+    expect(card.setMetadata).toHaveBeenCalledWith('app.miro.cards', {
+      id: 'x',
+    });
+  });
+
   test('maps tag names to ids', async () => {
     (global.miro.board.get as jest.Mock).mockResolvedValue([
       { id: '1', title: 'alpha' },
@@ -59,6 +75,29 @@ describe('CardProcessor', () => {
     await processor.processCards([{ title: 'A', tags: ['alpha'] }]);
     const args = (global.miro.board.createCard as jest.Mock).mock.calls[0][0];
     expect(args.tagIds).toEqual(['1']);
+  });
+
+  test('updates card when id matches', async () => {
+    const existing = {
+      id: 'c2',
+      title: 'old',
+      getMetadata: jest.fn().mockResolvedValue({ id: 'match' }),
+      setMetadata: jest.fn(),
+      sync: jest.fn(),
+    } as any;
+    (global.miro.board.get as jest.Mock).mockImplementation(
+      async ({ type }) => {
+        if (type === 'tag') return [];
+        if (type === 'card') return [existing];
+        return [];
+      },
+    );
+    await processor.processCards([{ id: 'match', title: 'new' }]);
+    expect(global.miro.board.createCard).not.toHaveBeenCalled();
+    expect(existing.title).toBe('new');
+    expect(existing.setMetadata).toHaveBeenCalledWith('app.miro.cards', {
+      id: 'match',
+    });
   });
 
   test('skips frame creation when disabled', async () => {


### PR DESCRIPTION
## Summary
- restructure card layout logic for readability
- add helper methods for layout and frame creation
- document new constants and methods
- support identifier-based card updates

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685285962058832bb34e06e2352a06cc