### PR TITLE
Implement card layout with wrapping

### DIFF
--- a/src/card-area.ts
+++ b/src/card-area.ts
@@ -1,0 +1,65 @@
+/**
+ * Coordinates for a laid out card.
+ */
+export interface CardPosition {
+  x: number;
+  y: number;
+}
+
+/**
+ * Layout options controlling the number of columns or the maximum width
+ * available for a row of cards. Either `columns` or `maxWidth` may be
+ * provided. The card dimensions and margin can also be customised.
+ */
+export interface AreaOptions {
+  columns?: number;
+  maxWidth?: number;
+  cardWidth?: number;
+  cardHeight?: number;
+  margin?: number;
+}
+
+/**
+ * Determine overall area dimensions and card positions.
+ *
+ * The returned positions are relative to the area centre so callers can
+ * translate them to an absolute board location easily.
+ */
+export function prepareArea(
+  count: number,
+  options: AreaOptions = {},
+): { width: number; height: number; positions: CardPosition[] } {
+  if (count <= 0) {
+    return { width: 0, height: 0, positions: [] };
+  }
+
+  const cardWidth = options.cardWidth ?? 300;
+  const cardHeight = options.cardHeight ?? 200;
+  const margin = options.margin ?? 50;
+
+  let columns = options.columns ?? 0;
+  if (!columns && options.maxWidth) {
+    columns = Math.floor((options.maxWidth - margin * 2) / cardWidth);
+  }
+  if (columns <= 0 || columns > count) {
+    columns = count;
+  }
+
+  const rows = Math.ceil(count / columns);
+  const width = columns * cardWidth + margin * 2;
+  const height = rows * cardHeight + margin * 2;
+
+  const positions: CardPosition[] = [];
+  const startX = -width / 2 + margin + cardWidth / 2;
+  const startY = -height / 2 + margin + cardHeight / 2;
+  for (let i = 0; i < count; i++) {
+    const row = Math.floor(i / columns);
+    const col = i % columns;
+    positions.push({
+      x: startX + col * cardWidth,
+      y: startY + row * cardHeight,
+    });
+  }
+
+  return { width, height, positions };
+}

--- a/tests/card-area.test.ts
+++ b/tests/card-area.test.ts
@@ -1,0 +1,21 @@
+import { prepareArea } from '../src/card-area';
+
+describe('prepareArea', () => {
+  test('calculates positions with explicit columns', () => {
+    const result = prepareArea(3, { columns: 2 });
+    expect(result.width).toBe(700);
+    expect(result.height).toBe(500);
+    expect(result.positions).toHaveLength(3);
+    expect(result.positions[0]).toEqual({ x: -150, y: -100 });
+    expect(result.positions[1]).toEqual({ x: 150, y: -100 });
+    expect(result.positions[2]).toEqual({ x: -150, y: 100 });
+  });
+
+  test('calculates columns from max width', () => {
+    const result = prepareArea(4, { maxWidth: 650 });
+    // With maxWidth < 650, only one column fits
+    expect(result.width).toBe(400);
+    expect(result.height).toBe(900);
+    expect(result.positions[3].y).toBe(300);
+  });
+});

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -52,6 +52,18 @@ describe('CardProcessor', () => {
     expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
   });
 
+  test('positions wrap across rows', async () => {
+    await processor.processCards(
+      [{ title: 'A' }, { title: 'B' }, { title: 'C' }],
+      { columns: 2 },
+    );
+    const calls = (global.miro.board.createCard as jest.Mock).mock.calls;
+    expect(calls[0][0].x).toBe(-150);
+    expect(calls[0][0].y).toBe(-100);
+    expect(calls[2][0].x).toBe(-150);
+    expect(calls[2][0].y).toBe(100);
+  });
+
   test('maps tag names to ids', async () => {
     (global.miro.board.get as jest.Mock).mockResolvedValue([
       { id: '1', title: 'alpha' },


### PR DESCRIPTION
## Summary
- add `prepareArea` helper for card layout calculations
- support columns or max row width when placing cards
- layout cards with wrapping across rows
- test the new layout logic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_685289f37308832baf2928cc964b885b