### PR TITLE
Add DiagramApp tests

### DIFF
--- a/tests/diagram-app.test.ts
+++ b/tests/diagram-app.test.ts
@@ -1,0 +1,28 @@
+import { DiagramApp } from '../src/DiagramApp';
+
+declare const global: any;
+
+/**
+ * Tests for the DiagramApp singleton and initialization logic.
+ */
+describe('DiagramApp', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (global as any).miro;
+  });
+
+  test('getInstance returns the same object', () => {
+    const app1 = DiagramApp.getInstance();
+    const app2 = DiagramApp.getInstance();
+    expect(app1).toBe(app2);
+  });
+
+  test('init registers click handler and opens panel', async () => {
+    const openPanel = jest.fn().mockResolvedValue(undefined);
+    const on = jest.fn((_e: string, cb: () => Promise<void>) => cb());
+    global.miro = { board: { ui: { on, openPanel } } };
+    await DiagramApp.getInstance().init();
+    expect(on).toHaveBeenCalledWith('icon:click', expect.any(Function));
+    expect(openPanel).toHaveBeenCalledWith({ url: 'app.html' });
+  });
+});


### PR DESCRIPTION
## Summary
- add DiagramApp test suite ensuring `init` registers handler and opens the panel
- verify singleton behavior of `DiagramApp.getInstance`

## Testing
- `npm test --silent`
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run prettier --silent tests/diagram-app.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6852b1e86d3c832b8d17d1c8dd96892d