### PR TITLE
Remove globalThis casts and add global types

### DIFF
--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -32,7 +32,7 @@ export class BoardBuilder {
   }
 
   private ensureBoard(): void {
-    if (!(globalThis as any).miro?.board) {
+    if (typeof miro === 'undefined' || !miro?.board) {
       throw new Error('Miro board not initialized');
     }
   }

--- a/src/DiagramApp.ts
+++ b/src/DiagramApp.ts
@@ -15,7 +15,7 @@ export class DiagramApp {
 
   /** Register UI handlers with the Miro board. */
   public async init(): Promise<void> {
-    if (!(globalThis as any).miro?.board?.ui) {
+    if (typeof miro === 'undefined' || !miro?.board?.ui) {
       throw new Error('Miro SDK not available');
     }
     miro.board.ui.on('icon:click', async () => {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,2 @@
+import type { Miro } from '@mirohq/websdk-types';
+declare const miro: Miro;


### PR DESCRIPTION
## Summary
- declare `miro` global in `src/global.d.ts`
- update `BoardBuilder` and `DiagramApp` to check for undefined `miro`
- drop `(globalThis as any)` casts

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6852b399a54c832bb627dc4ebad37888