### PR TITLE
Refactor GraphProcessor for readability

### DIFF
--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -82,6 +82,28 @@ describe('GraphProcessor', () => {
     await processor.processGraph(sample as any);
   });
 
+  it('delegates work to helper methods', async () => {
+    const gp = new GraphProcessor();
+    const frameSpy = jest.spyOn(gp as any, 'createFrame');
+    const nodeSpy = jest.spyOn(gp as any, 'createNodes');
+    const connectorSpy = jest.spyOn(gp as any, 'createConnectorsAndZoom');
+
+    jest.spyOn(layoutEngine, 'layoutGraph').mockResolvedValue({
+      nodes: { n1: { x: 0, y: 0, width: 10, height: 10 } },
+      edges: [],
+    });
+
+    const simpleGraph = {
+      nodes: [{ id: 'n1', label: 'A', type: 'Role' }],
+      edges: [],
+    };
+    await gp.processGraph(simpleGraph as any);
+
+    expect(frameSpy).toHaveBeenCalled();
+    expect(nodeSpy).toHaveBeenCalled();
+    expect(connectorSpy).toHaveBeenCalled();
+  });
+
   it('throws on invalid graph', async () => {
     await expect(processor.processGraph({} as any)).rejects.toThrow(
       'Invalid graph format',


### PR DESCRIPTION
## Summary
- split `processGraph` into smaller helper methods
- add tests for new helpers

## Testing
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_6852b46f0e20832b8a32c134af718db9