### PR TITLE
Fix Miro error message length

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { useDropzone } from 'react-dropzone';
 import { GraphProcessor } from './GraphProcessor';
 import { CardProcessor } from './CardProcessor';
+import { showError } from './notifications';
 
 // UI
 const dropzoneStyles = {
@@ -75,7 +76,7 @@ export const App: React.FC = () => {
       } catch (e) {
         const msg = String(e);
         setError(msg);
-        miro.board.notifications.showError(msg);
+        showError(msg);
       }
     }
     setFiles([]);

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -1,0 +1,15 @@
+/**
+ * Utility wrappers around the Miro notification API.
+ */
+
+/**
+ * Display an error message via Miro's notification system. Messages
+ * longer than 80 characters are truncated to satisfy SDK validation
+ * requirements.
+ *
+ * @param message - The text to display.
+ */
+export function showError(message: string): void {
+  const trimmed = message.length > 80 ? `${message.slice(0, 77)}...` : message;
+  miro.board.notifications.showError(trimmed);
+}

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -1,0 +1,30 @@
+import { showError } from '../src/notifications';
+
+declare const global: any;
+
+describe('showError', () => {
+  beforeEach(() => {
+    global.miro = { board: { notifications: { showError: jest.fn() } } };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  test('passes through short messages', () => {
+    showError('fail');
+    expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
+      'fail',
+    );
+  });
+
+  test('truncates long messages', () => {
+    const long = 'a'.repeat(90);
+    showError(long);
+    const arg = (global.miro.board.notifications.showError as jest.Mock).mock
+      .calls[0][0];
+    expect(arg.length).toBeLessThanOrEqual(80);
+    expect(arg.endsWith('...')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Miro notifications never exceed 80 characters
- cover new notification helper with tests
- use helper in the app

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68534de8e6a4832bbb0caa253bd98787