### PR TITLE
Add console error logging

### DIFF
--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -3,13 +3,18 @@
  */
 
 /**
- * Display an error message via Miro's notification system. Messages
- * longer than 80 characters are truncated to satisfy SDK validation
- * requirements.
+ * Display an error message via Miro's notification system and log it to the
+ * console. Messages longer than 80 characters are truncated to satisfy SDK
+ * validation requirements before being sent to Miro's UI.
  *
  * @param message - The text to display.
  */
 export function showError(message: string): void {
   const trimmed = message.length > 80 ? `${message.slice(0, 77)}...` : message;
+  // Log the original message to the browser console for troubleshooting.
+  // The raw message is logged to preserve detail, while the trimmed version is
+  // passed to the Miro notification API.
+  // eslint-disable-next-line no-console
+  console.error(message);
   miro.board.notifications.showError(trimmed);
 }

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -5,6 +5,7 @@ declare const global: any;
 describe('showError', () => {
   beforeEach(() => {
     global.miro = { board: { notifications: { showError: jest.fn() } } };
+    jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -14,6 +15,7 @@ describe('showError', () => {
 
   test('passes through short messages', () => {
     showError('fail');
+    expect(console.error).toHaveBeenCalledWith('fail');
     expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
       'fail',
     );
@@ -22,6 +24,7 @@ describe('showError', () => {
   test('truncates long messages', () => {
     const long = 'a'.repeat(90);
     showError(long);
+    expect(console.error).toHaveBeenCalledWith(long);
     const arg = (global.miro.board.notifications.showError as jest.Mock).mock
       .calls[0][0];
     expect(arg.length).toBeLessThanOrEqual(80);


### PR DESCRIPTION
## Summary
- log error messages to the console before showing Miro notification
- check console logging in tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685350ee0418832bbf84fc0050e8604f