### PR TITLE
Enhance card JSON handling

### DIFF
--- a/sample-cards.json
+++ b/sample-cards.json
@@ -8,7 +8,7 @@
       "tags": ["design"],
       "style": {
         "cardTheme": "#2d9bf0",
-        "fillBackground": "true"
+        "fillBackground": true
       },
       "fields": [
         {
@@ -29,7 +29,7 @@
       "tags": ["dev"],
       "style": {
         "cardTheme": "#2d9bf0",
-        "fillBackground": "true"
+        "fillBackground": true
       },
       "fields": [
         {

--- a/src/CardProcessor.ts
+++ b/src/CardProcessor.ts
@@ -125,6 +125,7 @@ export class CardProcessor {
       tagIds,
       fields: def.fields,
       style: def.style as CardStyle,
+      taskStatus: def.taskStatus,
       x,
       y,
     })) as Card;
@@ -147,6 +148,7 @@ export class CardProcessor {
     (card as any).tagIds = tagIds;
     (card as any).fields = def.fields;
     (card as any).style = def.style as CardStyle;
+    if (def.taskStatus) (card as any).taskStatus = def.taskStatus;
     if (def.id) {
       await (card as any).setMetadata(CardProcessor.META_KEY, { id: def.id });
     }

--- a/tests/card-load.test.ts
+++ b/tests/card-load.test.ts
@@ -11,13 +11,29 @@ describe('loadCards', () => {
       onload: ((e: any) => void) | null = null;
       onerror: (() => void) | null = null;
       readAsText() {
-        this.onload &&
-          this.onload({ target: { result: '{"cards":[{"title":"t"}]}' } });
+        const json = {
+          cards: [
+            {
+              title: 't',
+              taskStatus: 'done',
+              style: { cardTheme: '#fff', fillBackground: 'true', extra: 1 },
+              fields: [{ value: 'x' }],
+            },
+          ],
+        };
+        this.onload && this.onload({ target: { result: JSON.stringify(json) } });
       }
     }
     (global as any).FileReader = FR;
     const data = await cardLoader.loadCards({ name: 'c.json' } as any);
-    expect(data).toEqual([{ title: 't' }]);
+    expect(data).toEqual([
+      {
+        title: 't',
+        taskStatus: 'done',
+        style: { cardTheme: '#fff', fillBackground: true },
+        fields: [{ value: 'x' }],
+      },
+    ]);
   });
 
   test('getInstance creates singleton when missing', () => {

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -55,8 +55,20 @@ describe('CardProcessor', () => {
   });
 
   test('processCards creates cards', async () => {
-    await processor.processCards([{ title: 'A', tags: [] }]);
+    await processor.processCards([
+      {
+        title: 'A',
+        tags: [],
+        taskStatus: 'done',
+        style: { cardTheme: '#fff', fillBackground: true },
+        fields: [{ value: 'v' }],
+      },
+    ]);
     expect(global.miro.board.createCard).toHaveBeenCalled();
+    const args = (global.miro.board.createCard as jest.Mock).mock.calls[0][0];
+    expect(args.taskStatus).toBe('done');
+    expect(args.style).toEqual({ cardTheme: '#fff', fillBackground: true });
+    expect(args.fields).toEqual([{ value: 'v' }]);
     expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
   });
 
@@ -92,6 +104,8 @@ describe('CardProcessor', () => {
     const existing = {
       id: 'c2',
       title: 'old',
+      fields: [],
+      taskStatus: 'to-do',
       getMetadata: jest.fn().mockResolvedValue({ id: 'match' }),
       setMetadata: jest.fn(),
       sync: jest.fn(),
@@ -103,9 +117,20 @@ describe('CardProcessor', () => {
         return [];
       },
     );
-    await processor.processCards([{ id: 'match', title: 'new' }]);
+    await processor.processCards([
+      {
+        id: 'match',
+        title: 'new',
+        fields: [{ value: 'z' }],
+        style: { cardTheme: '#000', fillBackground: true },
+        taskStatus: 'in-progress',
+      },
+    ]);
     expect(global.miro.board.createCard).not.toHaveBeenCalled();
     expect(existing.title).toBe('new');
+    expect(existing.fields).toEqual([{ value: 'z' }]);
+    expect(existing.style).toEqual({ cardTheme: '#000', fillBackground: true });
+    expect(existing.taskStatus).toBe('in-progress');
     expect(existing.setMetadata).toHaveBeenCalledWith('app.miro.cards', {
       id: 'match',
     });


### PR DESCRIPTION
## Summary
- update sample cards to use boolean fillBackground
- extend card loader to normalize style, fields and task status
- allow card processor to set taskStatus on created and updated cards
- adjust tests for new card schema

## Testing
- `npm install` *(fails: command not found)*
- `npm run typecheck --silent` *(fails: command not found)*
- `npm test --silent` *(fails: command not found)*
- `npm run lint --silent` *(fails: command not found)*
- `npm run prettier --silent` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535398af24832b95375f0bb6d75869