### PR TITLE
Increase test coverage and refactor App helpers

### DIFF
--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -2,7 +2,7 @@
 import React from 'react';
 import { render, fireEvent, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { App } from '../src/app';
+import { App, getDropzoneStyle, undoLastImport } from '../src/app';
 import { GraphProcessor } from '../src/GraphProcessor';
 import { CardProcessor } from '../src/CardProcessor';
 
@@ -108,5 +108,24 @@ describe('App UI integration', () => {
       createFrame: true,
       frameTitle: 'Frame A',
     });
+  });
+
+  test('undoLastImport helper calls undo and clears state', () => {
+    const proc = { undoLast: jest.fn() } as any;
+    let cleared = false;
+    undoLastImport(proc, () => {
+      cleared = true;
+    });
+    expect(proc.undoLast).toHaveBeenCalled();
+    expect(cleared).toBe(true);
+  });
+
+  test('getDropzoneStyle computes colours', () => {
+    const base = getDropzoneStyle(false, false);
+    expect(base.borderColor).toBe('rgba(41, 128, 185, 0.5)');
+    const accept = getDropzoneStyle(true, false);
+    expect(accept.borderColor).toBe('rgba(41, 128, 185, 1.0)');
+    const reject = getDropzoneStyle(false, true);
+    expect(reject.borderColor).toBe('rgba(192, 57, 43,1.0)');
   });
 });

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -80,6 +80,23 @@ describe('createFromTemplate', () => {
     expect(widget.type).toBe('text');
   });
 
+  test('apply fill property when style lacks fillColor', async () => {
+    (templateManager as any).templates.fillStyle = {
+      elements: [{ shape: 'rect', fill: '#fff', style: {} }],
+    };
+    const widget = await templateManager.createFromTemplate(
+      'fillStyle',
+      'L',
+      0,
+      0,
+    );
+    const args = (
+      global.miro.board.createShape as jest.Mock
+    ).mock.calls.pop()[0];
+    expect(args.style.fillColor).toBe('#fff');
+    expect(widget.type).toBe('shape');
+  });
+
   test('throws when template missing', async () => {
     await expect(
       templateManager.createFromTemplate('missing', 'L', 0, 0),


### PR DESCRIPTION
## Summary
- add `undoLastImport` and `getDropzoneStyle` helpers
- test helper functions and undo logic
- expand BoardBuilder branch tests
- cover TemplateManager fill-color branch

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685375502908832ba647a78f27436297