### PR TITLE
Improve accessibility and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ A small example is provided in [sample-graph.json](sample-graph.json):
 }
 ```
 
+## Accessibility
+
+The import panel is keyboard accessible. The drop area includes an ARIA label
+and hidden instructions so screen readers announce how to operate it. Focus the
+area with the Tab key and press **Enter** to open the file picker. The mode
+selection radios are grouped with a descriptive label.
+
 ## Setup
 
 - [Miro Web SDK](https://developers.miro.com/docs/web-sdk-reference)

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -113,7 +113,11 @@ export const App: React.FC = () => {
 
   return (
     <div className="dnd-container">
-      <div style={{ marginBottom: '8px' }}>
+      <div
+        style={{ marginBottom: '8px' }}
+        role="radiogroup"
+        aria-label="Import mode"
+      >
         <label>
           <input
             type="radio"
@@ -137,8 +141,15 @@ export const App: React.FC = () => {
         Select the JSON file to import{' '}
         {mode === 'diagram' ? 'a diagram' : 'a list of cards'}
       </p>
-      <div {...dropzone.getRootProps({ style })}>
-        <input data-testid="file-input" {...dropzone.getInputProps()} />
+      <div
+        {...dropzone.getRootProps({ style })}
+        aria-label="File drop area"
+        aria-describedby="dropzone-instructions"
+      >
+        <input
+          data-testid="file-input"
+          {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
+        />
         {dropzone.isDragAccept ? (
           <p className="dnd-text">Drop your JSON file here</p>
         ) : (
@@ -155,6 +166,10 @@ export const App: React.FC = () => {
           </>
         )}
       </div>
+      <p id="dropzone-instructions" className="visually-hidden">
+        Press Enter to open the file picker or drop a JSON file on the area
+        above.
+      </p>
       {files.length > 0 && (
         <>
           <ul className="dropped-files">

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -67,3 +67,15 @@ img {
 .button {
   text-decoration: none;
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/layout-utils.ts
+++ b/src/layout-utils.ts
@@ -1,3 +1,11 @@
+/**
+ * Calculate the position of a point relative to a node rectangle.
+ *
+ * @param node - The node rectangle with absolute coordinates and size.
+ * @param pt - The absolute point to convert.
+ * @returns Normalized coordinates where `(0,0)` is the top-left of the node and
+ * `(1,1)` is the bottom-right.
+ */
 export function relativePosition(
   node: { x: number; y: number; width: number; height: number },
   pt: { x: number; y: number },
@@ -13,6 +21,16 @@ export interface EdgeHint {
   endPosition?: { x: number; y: number };
 }
 
+/**
+ * Derive layout hints for edges using a processed ELK layout.
+ *
+ * Each hint contains the relative start and end positions of the connector so
+ * that links can be recreated consistently on undo.
+ *
+ * @param graph - Source graph describing edge connections.
+ * @param layout - Absolute coordinates computed by the layout engine.
+ * @returns Array of relative start/end positions per edge.
+ */
 export function computeEdgeHints(
   graph: { edges: Array<{ from: string; to: string }> },
   layout: {

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -68,6 +68,14 @@ describe('App UI integration', () => {
     ).toBeInTheDocument();
   });
 
+  test('dropzone has accessibility attributes', () => {
+    render(React.createElement(App));
+    const zone = screen.getByLabelText(/file drop area/i);
+    expect(zone).toHaveAttribute('aria-describedby', 'dropzone-instructions');
+    const input = screen.getByLabelText(/json file input/i);
+    expect(input).toBeInTheDocument();
+  });
+
   test('shows error notification', async () => {
     const error = new Error('fail');
     jest.spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- document `relativePosition` and `computeEdgeHints`
- add ARIA labels and instructions for keyboard use
- provide screen-reader friendly CSS helper
- describe accessibility support in README
- test that accessibility attributes exist

## Testing
- `npm run prettier --silent`
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685377a82258832b84065db90f1b5e52