### PR TITLE
Add configurable ELK layout options

### DIFF
--- a/src/GraphProcessor.ts
+++ b/src/GraphProcessor.ts
@@ -1,6 +1,7 @@
 import { graphService, GraphData } from './graph';
 import { BoardBuilder } from './BoardBuilder';
 import { layoutEngine, LayoutResult } from './elk-layout';
+import { UserLayoutOptions } from './elk-options';
 import { fileUtils } from './file-utils';
 import { computeEdgeHints } from './layout-utils';
 import type { BaseItem, Group, Frame, Connector } from '@mirohq/websdk-types';
@@ -15,6 +16,8 @@ export interface ProcessOptions {
   createFrame?: boolean;
   /** Optional title for the created frame. */
   frameTitle?: string;
+  /** Optional custom layout options. */
+  layout?: Partial<UserLayoutOptions>;
 }
 
 export class GraphProcessor {
@@ -79,7 +82,7 @@ export class GraphProcessor {
     options: ProcessOptions = {},
   ): Promise<void> {
     this.validateGraph(graph);
-    const layout = await layoutEngine.layoutGraph(graph);
+    const layout = await layoutEngine.layoutGraph(graph, options.layout);
 
     const bounds = this.layoutBounds(layout);
     const margin = 100;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,12 @@ import { useDropzone } from 'react-dropzone';
 import { GraphProcessor } from './GraphProcessor';
 import { CardProcessor } from './CardProcessor';
 import { showError } from './notifications';
+import {
+  ALGORITHMS,
+  DIRECTIONS,
+  DEFAULT_LAYOUT_OPTIONS,
+  UserLayoutOptions,
+} from './elk-options';
 
 // UI
 const dropzoneStyles = {
@@ -61,6 +67,9 @@ export const App: React.FC = () => {
   const [mode, setMode] = React.useState<'diagram' | 'cards'>('diagram');
   const [progress, setProgress] = React.useState<number>(0);
   const [error, setError] = React.useState<string | null>(null);
+  const [layoutOpts, setLayoutOpts] = React.useState<UserLayoutOptions>(
+    DEFAULT_LAYOUT_OPTIONS,
+  );
   const [lastProc, setLastProc] = React.useState<
     GraphProcessor | CardProcessor | undefined
   >(undefined);
@@ -88,6 +97,7 @@ export const App: React.FC = () => {
           await graphProcessor.processFile(file, {
             createFrame: withFrame,
             frameTitle: frameTitle || undefined,
+            layout: layoutOpts,
           });
         } else {
           setLastProc(cardProcessor);
@@ -194,6 +204,57 @@ export const App: React.FC = () => {
               style={{ marginTop: '4px', width: '100%' }}
             />
           )}
+
+          <label style={{ display: 'block', marginTop: '8px' }}>
+            Algorithm
+            <select
+              value={layoutOpts.algorithm}
+              onChange={e =>
+                setLayoutOpts({
+                  ...layoutOpts,
+                  algorithm: e.target.value as any,
+                })
+              }
+            >
+              {ALGORITHMS.map(a => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={{ display: 'block', marginTop: '4px' }}>
+            Direction
+            <select
+              value={layoutOpts.direction}
+              onChange={e =>
+                setLayoutOpts({
+                  ...layoutOpts,
+                  direction: e.target.value as any,
+                })
+              }
+            >
+              {DIRECTIONS.map(d => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label style={{ display: 'block', marginTop: '4px' }}>
+            Spacing
+            <input
+              type="number"
+              value={layoutOpts.spacing}
+              onChange={e =>
+                setLayoutOpts({
+                  ...layoutOpts,
+                  spacing: Number(e.target.value),
+                })
+              }
+              style={{ width: '100%' }}
+            />
+          </label>
 
           <button
             onClick={handleCreate}

--- a/src/elk-layout.ts
+++ b/src/elk-layout.ts
@@ -1,6 +1,7 @@
 import ELK from 'elkjs/lib/elk.bundled.js';
 import { GraphData } from './graph';
 import { templateManager } from './templates';
+import { UserLayoutOptions, validateLayoutOptions } from './elk-options';
 
 /**
  * Node with layout coordinates returned from ELK.
@@ -55,19 +56,26 @@ export class LayoutEngine {
   /**
    * Run the ELK layout engine on the provided graph data and
    * return positioned nodes and edges.
+   *
+   * @param data - Parsed graph data.
+   * @param opts - Optional layout customisation parameters.
    */
-  public async layoutGraph(data: GraphData): Promise<LayoutResult> {
+  public async layoutGraph(
+    data: GraphData,
+    opts: Partial<UserLayoutOptions> = {},
+  ): Promise<LayoutResult> {
+    const userOpts = validateLayoutOptions(opts);
     const elkGraph: any = {
       id: 'root',
       layoutOptions: {
         // Basic layered layout configuration
         'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
-        'elk.algorithm': 'mrtree',
+        'elk.algorithm': userOpts.algorithm,
         'elk.layered.nodePlacement.strategy': 'BRANDES_KOEPF',
         'elk.layered.mergeEdges': 'false',
-        'elk.direction': 'DOWN',
-        'elk.layered.spacing.nodeNodeBetweenLayers': '90',
-        'elk.spacing.nodeNode': 90,
+        'elk.direction': userOpts.direction,
+        'elk.layered.spacing.nodeNodeBetweenLayers': String(userOpts.spacing),
+        'elk.spacing.nodeNode': userOpts.spacing,
         'elk.layered.unnecessaryBendpoints': 'true',
         'elk.layered.cycleBreaking.strategy': 'GREEDY',
       },

--- a/src/elk-options.ts
+++ b/src/elk-options.ts
@@ -1,0 +1,46 @@
+export const ALGORITHMS = ['mrtree', 'layered', 'force'] as const;
+export type ElkAlgorithm = (typeof ALGORITHMS)[number];
+
+export const DIRECTIONS = ['DOWN', 'UP', 'LEFT', 'RIGHT'] as const;
+export type ElkDirection = (typeof DIRECTIONS)[number];
+
+/**
+ * User configurable layout options with constrained values.
+ */
+export interface UserLayoutOptions {
+  /** Layout algorithm used by ELK. */
+  algorithm: ElkAlgorithm;
+  /** Primary direction of the layout. */
+  direction: ElkDirection;
+  /** Spacing in pixels between nodes and layers. */
+  spacing: number;
+}
+
+/** Default layout options applied when none are provided. */
+export const DEFAULT_LAYOUT_OPTIONS: UserLayoutOptions = {
+  algorithm: 'mrtree',
+  direction: 'DOWN',
+  spacing: 90,
+};
+
+/**
+ * Validate partial user options and fall back to defaults for invalid values.
+ *
+ * @param opts - Partial options provided by the user.
+ * @returns Complete options with invalid values replaced by defaults.
+ */
+export function validateLayoutOptions(
+  opts: Partial<UserLayoutOptions>,
+): UserLayoutOptions {
+  const algorithm = ALGORITHMS.includes(opts.algorithm as ElkAlgorithm)
+    ? (opts.algorithm as ElkAlgorithm)
+    : DEFAULT_LAYOUT_OPTIONS.algorithm;
+  const direction = DIRECTIONS.includes(opts.direction as ElkDirection)
+    ? (opts.direction as ElkDirection)
+    : DEFAULT_LAYOUT_OPTIONS.direction;
+  const spacing =
+    typeof opts.spacing === 'number' && opts.spacing > 0
+      ? opts.spacing
+      : DEFAULT_LAYOUT_OPTIONS.spacing;
+  return { algorithm, direction, spacing };
+}

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -37,7 +37,10 @@ describe('App UI integration', () => {
     await act(async () => {
       fireEvent.click(button);
     });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(File),
+      expect.objectContaining({ layout: expect.any(Object) }),
+    );
   });
 
   test('toggles to cards mode and processes', async () => {
@@ -112,10 +115,14 @@ describe('App UI integration', () => {
     await act(async () => {
       fireEvent.click(button);
     });
-    expect(spy).toHaveBeenCalledWith(expect.any(File), {
-      createFrame: true,
-      frameTitle: 'Frame A',
-    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(File),
+      expect.objectContaining({
+        createFrame: true,
+        frameTitle: 'Frame A',
+        layout: expect.any(Object),
+      }),
+    );
   });
 
   test('undoLastImport helper calls undo and clears state', () => {

--- a/tests/elk-options.test.ts
+++ b/tests/elk-options.test.ts
@@ -1,0 +1,27 @@
+import {
+  validateLayoutOptions,
+  DEFAULT_LAYOUT_OPTIONS,
+} from '../src/elk-options';
+
+describe('validateLayoutOptions', () => {
+  test('returns defaults for invalid options', () => {
+    const result = validateLayoutOptions({
+      algorithm: 'bad' as any,
+      spacing: -1,
+    });
+    expect(result).toEqual(DEFAULT_LAYOUT_OPTIONS);
+  });
+
+  test('accepts valid options', () => {
+    const result = validateLayoutOptions({
+      algorithm: 'force',
+      direction: 'LEFT',
+      spacing: 50,
+    });
+    expect(result).toEqual({
+      algorithm: 'force',
+      direction: 'LEFT',
+      spacing: 50,
+    });
+  });
+});

--- a/tests/layout-engine.test.ts
+++ b/tests/layout-engine.test.ts
@@ -1,4 +1,5 @@
 import { LayoutEngine, layoutEngine } from '../src/elk-layout';
+import ELK from 'elkjs/lib/elk.bundled.js';
 
 /** Verify singleton behaviour and minimal layout handling. */
 describe('LayoutEngine', () => {
@@ -13,5 +14,27 @@ describe('LayoutEngine', () => {
     const result = await layoutEngine.layoutGraph(graph as any);
     expect(Object.keys(result.nodes)).toHaveLength(1);
     expect(result.edges).toHaveLength(0);
+  });
+
+  test('layoutGraph forwards options', async () => {
+    const spy = jest
+      .spyOn(ELK.prototype, 'layout')
+      .mockResolvedValue({ children: [], edges: [] } as any);
+    const graph = { nodes: [], edges: [] };
+    await layoutEngine.layoutGraph(graph as any, {
+      algorithm: 'force',
+      direction: 'LEFT',
+      spacing: 50,
+    });
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        layoutOptions: expect.objectContaining({
+          'elk.algorithm': 'force',
+          'elk.direction': 'LEFT',
+          'elk.spacing.nodeNode': 50,
+        }),
+      }),
+    );
+    spy.mockRestore();
   });
 });

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -104,6 +104,19 @@ describe('GraphProcessor', () => {
     expect(connectorSpy).toHaveBeenCalled();
   });
 
+  it('forwards layout options', async () => {
+    const spy = jest
+      .spyOn(layoutEngine, 'layoutGraph')
+      .mockResolvedValue({ nodes: {}, edges: [] } as any);
+    const simpleGraph = { nodes: [], edges: [] };
+    await processor.processGraph(simpleGraph as any, {
+      layout: { algorithm: 'force' },
+    });
+    expect(spy).toHaveBeenCalledWith(simpleGraph as any, {
+      algorithm: 'force',
+    });
+  });
+
   it('throws on invalid graph', async () => {
     await expect(processor.processGraph({} as any)).rejects.toThrow(
       'Invalid graph format',


### PR DESCRIPTION
## Summary
- expose layout parameters (algorithm, direction, spacing)
- hook layout options into LayoutEngine and GraphProcessor
- add UI controls for ELK options in the app
- validate options in new elk-options module
- update tests for new behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_685386875498832b9e68405ad52d6fa4