### PR TITLE
Fix unsound type guards

### DIFF
--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -90,8 +90,8 @@ export class BoardBuilder {
 
   /** Lookup an existing widget with matching metadata. */
   public async findNode(
-    type: string,
-    label: string,
+    type: unknown,
+    label: unknown,
   ): Promise<BaseItem | Group | undefined> {
     if (typeof type !== 'string' || typeof label !== 'string') {
       throw new Error('Invalid search parameters');
@@ -103,8 +103,8 @@ export class BoardBuilder {
 
   /** Find a connector with matching metadata if it exists on the board. */
   public async findConnector(
-    from: string,
-    to: string,
+    from: unknown,
+    to: unknown,
   ): Promise<Connector | undefined> {
     if (typeof from !== 'string' || typeof to !== 'string') {
       throw new Error('Invalid search parameters');
@@ -119,28 +119,34 @@ export class BoardBuilder {
 
   /** Create or update a node widget from a template. */
   public async createNode(
-    node: NodeData,
+    node: unknown,
     pos: PositionedNode,
   ): Promise<BaseItem | Group> {
-    if (!node || typeof node !== 'object') {
-      throw new Error('Invalid node');
-    }
     if (!pos || typeof pos.x !== 'number' || typeof pos.y !== 'number') {
       throw new Error('Invalid position');
     }
-    const templateDef = templateManager.getTemplate(node.type);
-    if (!templateDef) {
-      throw new Error(`Template '${node.type}' not found`);
+    if (
+      !node ||
+      typeof node !== 'object' ||
+      typeof (node as any).type !== 'string' ||
+      typeof (node as any).label !== 'string'
+    ) {
+      throw new Error('Invalid node');
     }
-    const existing = await this.findNode(node.type, node.label);
+    const nodeData = node as NodeData;
+    const templateDef = templateManager.getTemplate(nodeData.type);
+    if (!templateDef) {
+      throw new Error(`Template '${nodeData.type}' not found`);
+    }
+    const existing = await this.findNode(nodeData.type, nodeData.label);
     if (existing) {
       return this.updateExistingNode(
         existing as BaseItem | Group,
         templateDef,
-        node,
+        nodeData,
       );
     }
-    return this.createNewNode(node, pos);
+    return this.createNewNode(nodeData, pos);
   }
 
   /** Create connectors with labels, metadata and optional snap hints. */

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -40,8 +40,8 @@ export class FileUtils {
   }
 
   /** Ensure the provided object is a valid `File`. */
-  public validateFile(file: File): void {
-    if (!file || typeof file !== 'object' || typeof file.name !== 'string') {
+  public validateFile(file: unknown): void {
+    if (!file || typeof (file as { name?: unknown }).name !== 'string') {
       throw new Error('Invalid file');
     }
   }


### PR DESCRIPTION
## Summary
- handle unknown input to BoardBuilder search methods
- validate BoardBuilder positions before node data
- relax FileUtils validation param type

## Testing
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6853e8a9cdb8832bb041c5876f2d2da6