### PR TITLE
Fix lint errors

### DIFF
--- a/src/BoardBuilder.ts
+++ b/src/BoardBuilder.ts
@@ -10,6 +10,11 @@ import type {
   ConnectorStyle,
   Frame,
   Group,
+  Shape,
+  ShapeStyle,
+  Text,
+  TextStyle,
+  TextAlignVertical,
 } from '@mirohq/websdk-types';
 import type { EdgeData, EdgeHint, NodeData, PositionedNode } from './graph';
 
@@ -85,7 +90,10 @@ export class BoardBuilder {
   /** Move the viewport to show the provided frame or widgets. */
   public async zoomTo(target: Frame | Array<BaseItem | Group>): Promise<void> {
     this.ensureBoard();
-    await miro.board.viewport.zoomTo(target as any);
+    const items = Array.isArray(target)
+      ? (target as Array<BaseItem>)
+      : (target as BaseItem);
+    await miro.board.viewport.zoomTo(items);
   }
 
   /** Lookup an existing widget with matching metadata. */
@@ -160,9 +168,13 @@ export class BoardBuilder {
         const from = nodeMap[edge.from];
         const to = nodeMap[edge.to];
         if (!from || !to) return undefined;
-        const template = templateManager.getConnectorTemplate(
-          (edge.metadata as any)?.template || 'default',
-        );
+        const templateName =
+          edge.metadata &&
+          'template' in edge.metadata &&
+          typeof edge.metadata.template === 'string'
+            ? edge.metadata.template
+            : 'default';
+        const template = templateManager.getConnectorTemplate(templateName);
         const existing = await this.findConnector(edge.from, edge.to);
         if (existing) {
           this.updateConnector(existing, edge, template, hints?.[i]);
@@ -180,8 +192,10 @@ export class BoardBuilder {
   ): Promise<void> {
     await Promise.all(
       items
-        .filter(i => typeof (i as any).sync === 'function')
-        .map(i => (i as any).sync()),
+        .filter(
+          i => typeof (i as { sync?: () => Promise<void> }).sync === 'function',
+        )
+        .map(i => (i as { sync: () => Promise<void> }).sync()),
     );
   }
 
@@ -190,7 +204,9 @@ export class BoardBuilder {
     items: Array<BaseItem | Group | Connector | Frame>,
   ): Promise<void> {
     this.ensureBoard();
-    await Promise.all(items.map(i => miro.board.remove(i as any)));
+    await Promise.all(
+      items.map(item => miro.board.remove(item as unknown as BaseItem)),
+    );
   }
 
   private ensureBoard(): void {
@@ -219,13 +235,13 @@ export class BoardBuilder {
    * Find an item whose metadata satisfies the provided predicate.
    * Metadata for all items is loaded concurrently for efficiency.
    */
-  private async findByMetadata<T extends BaseItem | Group | Connector>(
+  private async findByMetadata<
+    T extends { getMetadata: (key: string) => Promise<unknown> },
+  >(
     items: T[],
-    predicate: (meta: any, item: T) => boolean,
+    predicate: (meta: unknown, item: T) => boolean,
   ): Promise<T | undefined> {
-    const metas = await Promise.all(
-      items.map(i => (i as any).getMetadata(META_KEY)),
-    );
+    const metas = await Promise.all(items.map(i => i.getMetadata(META_KEY)));
     for (let i = 0; i < items.length; i++) {
       if (predicate(metas[i], items[i])) {
         return items[i];
@@ -283,24 +299,23 @@ export class BoardBuilder {
     element: TemplateElement,
     label: string,
   ): void {
-    if (element.shape) (item as any).shape = element.shape;
-    if (element.rotation !== undefined)
-      (item as any).rotation = element.rotation;
-    if (element.width) (item as any).width = element.width;
-    if (element.height) (item as any).height = element.height;
-    (item as any).content = (element.text ?? '{{label}}').replace(
-      '{{label}}',
-      label,
-    );
-    const existing = (item as any).style ?? {};
-    const style: Record<string, unknown> = {
+    const shape = item as Shape;
+    if (element.shape) shape.shape = element.shape as Shape['shape'];
+    if (element.rotation !== undefined) shape.rotation = element.rotation;
+    if (element.width)
+      (shape as unknown as { width: number }).width = element.width;
+    if (element.height)
+      (shape as unknown as { height: number }).height = element.height;
+    shape.content = (element.text ?? '{{label}}').replace('{{label}}', label);
+    const existing = (shape.style ?? {}) as Partial<ShapeStyle>;
+    const style: Partial<ShapeStyle> & Record<string, unknown> = {
       ...existing,
       ...(element.style ?? {}),
     };
     if (element.fill && !('fillColor' in style)) {
-      (style as any).fillColor = element.fill;
+      style.fillColor = element.fill;
     }
-    (item as any).style = style as any;
+    shape.style = style as ShapeStyle;
   }
 
   /**
@@ -311,15 +326,13 @@ export class BoardBuilder {
     element: TemplateElement,
     label: string,
   ): void {
-    (item as any).content = (element.text ?? '{{label}}').replace(
-      '{{label}}',
-      label,
-    );
+    const text = item as Text;
+    text.content = (element.text ?? '{{label}}').replace('{{label}}', label);
     if (element.style) {
-      (item as any).style = {
-        ...((item as any).style ?? {}),
-        ...(element.style as any),
-      };
+      text.style = {
+        ...(text.style ?? ({} as Partial<TextStyle>)),
+        ...(element.style as Partial<TextStyle>),
+      } as TextStyle;
     }
   }
 
@@ -424,7 +437,8 @@ export class BoardBuilder {
         {
           content: edge.label,
           position: template?.caption?.position,
-          textAlignVertical: template?.caption?.textAlignVertical as any,
+          textAlignVertical: template?.caption
+            ?.textAlignVertical as TextAlignVertical,
         },
       ];
     }
@@ -432,20 +446,20 @@ export class BoardBuilder {
       connector.style = {
         ...connector.style,
         ...template.style,
-      } as ConnectorStyle as any;
+      } as ConnectorStyle;
     }
     connector.shape = template?.shape ?? connector.shape;
     if (hint?.startPosition) {
       connector.start = {
         ...(connector.start ?? {}),
         position: hint.startPosition,
-      } as any;
+      } as Connector['start'];
     }
     if (hint?.endPosition) {
       connector.end = {
         ...(connector.end ?? {}),
         position: hint.endPosition,
-      } as any;
+      } as Connector['end'];
     }
   }
 
@@ -468,11 +482,12 @@ export class BoardBuilder {
             {
               content: edge.label,
               position: template?.caption?.position,
-              textAlignVertical: template?.caption?.textAlignVertical as any,
+              textAlignVertical: template?.caption
+                ?.textAlignVertical as TextAlignVertical,
             },
           ]
         : undefined,
-      style: template?.style as any,
+      style: template?.style as ConnectorStyle | undefined,
     });
     await connector.setMetadata(META_KEY, {
       from: edge.from,

--- a/src/CardProcessor.ts
+++ b/src/CardProcessor.ts
@@ -96,7 +96,7 @@ export class CardProcessor {
     this.lastCreated.push(...created);
     if (frame) this.lastCreated.push(frame);
 
-    const target = frame ?? ([...created, ...updated] as any);
+    const target: Frame | Card[] = frame ?? [...created, ...updated];
     if (created.length || updated.length) {
       await this.builder.zoomTo(target);
     }
@@ -127,11 +127,12 @@ export class CardProcessor {
     if (!this.cardMap) {
       const cards = await this.getBoardCards();
       const metas = await Promise.all(
-        cards.map(c => (c as any).getMetadata(CardProcessor.META_KEY)),
+        cards.map(c => c.getMetadata(CardProcessor.META_KEY)),
       );
       this.cardMap = new Map();
       for (let i = 0; i < cards.length; i++) {
-        const id = metas[i]?.id as string | undefined;
+        const meta = metas[i] as Record<string, unknown> | undefined;
+        const id = typeof meta?.id === 'string' ? meta.id : undefined;
         if (id) {
           this.cardMap.set(id, cards[i]);
         }
@@ -206,7 +207,7 @@ export class CardProcessor {
       y,
     })) as Card;
     if (def.id) {
-      await (card as any).setMetadata(CardProcessor.META_KEY, { id: def.id });
+      await card.setMetadata(CardProcessor.META_KEY, { id: def.id });
     }
     this.lastCreated.push(card);
     return card;
@@ -221,12 +222,12 @@ export class CardProcessor {
     const tagIds = await this.ensureTagIds(def.tags, tagMap);
     card.title = def.title;
     card.description = def.description ?? '';
-    (card as any).tagIds = tagIds;
-    (card as any).fields = def.fields;
-    (card as any).style = def.style as CardStyle;
-    if (def.taskStatus) (card as any).taskStatus = def.taskStatus;
+    card.tagIds = tagIds;
+    card.fields = def.fields;
+    card.style = def.style as CardStyle;
+    if (def.taskStatus) card.taskStatus = def.taskStatus;
     if (def.id) {
-      await (card as any).setMetadata(CardProcessor.META_KEY, { id: def.id });
+      await card.setMetadata(CardProcessor.META_KEY, { id: def.id });
     }
     return card;
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -17,6 +17,8 @@ import {
   DEFAULT_LAYOUT_OPTIONS,
   DIRECTIONS,
   UserLayoutOptions,
+  ElkAlgorithm,
+  ElkDirection,
 } from './elk-options';
 
 // UI
@@ -206,7 +208,10 @@ export const App: React.FC = () => {
             <Select
               value={layoutOpts.algorithm}
               onChange={value =>
-                setLayoutOpts({ ...layoutOpts, algorithm: value as any })
+                setLayoutOpts({
+                  ...layoutOpts,
+                  algorithm: value as ElkAlgorithm,
+                })
               }
             >
               {ALGORITHMS.map(a => (
@@ -221,7 +226,10 @@ export const App: React.FC = () => {
             <Select
               value={layoutOpts.direction}
               onChange={value =>
-                setLayoutOpts({ ...layoutOpts, direction: value as any })
+                setLayoutOpts({
+                  ...layoutOpts,
+                  direction: value as ElkDirection,
+                })
               }
             >
               {DIRECTIONS.map(d => (

--- a/src/cards.ts
+++ b/src/cards.ts
@@ -39,28 +39,38 @@ export class CardLoader {
     fileUtils.validateFile(file);
     const text = await fileUtils.readFileAsText(file);
     const data = JSON.parse(text) as unknown;
-    if (!data || !Array.isArray((data as any).cards)) {
+    if (
+      !data ||
+      typeof data !== 'object' ||
+      !Array.isArray((data as { cards?: unknown }).cards)
+    ) {
       throw new Error('Invalid card data');
     }
-    return (data as CardFile).cards.map(c => this.normalizeCard(c));
+    return (data as CardFile).cards.map(card =>
+      this.normalizeCard(card as unknown as Record<string, unknown>),
+    );
   }
 
   /** Extract supported style fields and normalize values. */
-  private normalizeCard(card: any): CardData {
-    const styleRaw = card.style ?? {};
+  private normalizeCard(card: Record<string, unknown>): CardData {
+    const styleRaw = (card.style ?? {}) as Record<string, unknown>;
     const style: Partial<Pick<CardStyle, 'cardTheme' | 'fillBackground'>> = {};
-    if (styleRaw.cardTheme) style.cardTheme = styleRaw.cardTheme;
+    if (styleRaw.cardTheme)
+      style.cardTheme = styleRaw.cardTheme as CardStyle['cardTheme'];
     if (styleRaw.fillBackground !== undefined) {
       style.fillBackground =
         styleRaw.fillBackground === true || styleRaw.fillBackground === 'true';
     }
     return {
-      id: card.id,
-      title: card.title,
-      description: card.description,
-      tags: Array.isArray(card.tags) ? card.tags : undefined,
-      fields: Array.isArray(card.fields) ? card.fields : undefined,
-      taskStatus: card.taskStatus,
+      id: typeof card.id === 'string' ? card.id : undefined,
+      title: String(card.title),
+      description:
+        typeof card.description === 'string' ? card.description : undefined,
+      tags: Array.isArray(card.tags) ? (card.tags as string[]) : undefined,
+      fields: Array.isArray(card.fields)
+        ? (card.fields as CardField[])
+        : undefined,
+      taskStatus: card.taskStatus as CardTaskStatus | undefined,
       style: Object.keys(style).length ? style : undefined,
     };
   }

--- a/src/elk-layout.ts
+++ b/src/elk-layout.ts
@@ -1,4 +1,5 @@
 import ELK from 'elkjs/lib/elk.bundled.js';
+import type { ElkNode } from 'elkjs/lib/elk-api';
 import { GraphData } from './graph';
 import { templateManager } from './templates';
 import { UserLayoutOptions, validateLayoutOptions } from './elk-options';
@@ -65,7 +66,7 @@ export class LayoutEngine {
     opts: Partial<UserLayoutOptions> = {},
   ): Promise<LayoutResult> {
     const userOpts = validateLayoutOptions(opts);
-    const elkGraph: any = {
+    const elkGraph: ElkNode = {
       id: 'root',
       layoutOptions: {
         // Basic layered layout configuration
@@ -75,7 +76,7 @@ export class LayoutEngine {
         'elk.layered.mergeEdges': 'false',
         'elk.direction': userOpts.direction,
         'elk.layered.spacing.nodeNodeBetweenLayers': String(userOpts.spacing),
-        'elk.spacing.nodeNode': userOpts.spacing,
+        'elk.spacing.nodeNode': userOpts.spacing as unknown as string,
         'elk.layered.unnecessaryBendpoints': 'true',
         'elk.layered.cycleBreaking.strategy': 'GREEDY',
       },
@@ -85,10 +86,14 @@ export class LayoutEngine {
         const dims = tpl?.elements.find(e => e.width && e.height);
         // istanbul ignore next: fall back to template or default dimensions
         const width =
-          (n as any).metadata?.width ?? dims?.width ?? DEFAULT_WIDTH;
+          (n.metadata as { width?: number } | undefined)?.width ??
+          dims?.width ??
+          DEFAULT_WIDTH;
         // istanbul ignore next: fall back to template or default dimensions
         const height =
-          (n as any).metadata?.height ?? dims?.height ?? DEFAULT_HEIGHT;
+          (n.metadata as { height?: number } | undefined)?.height ??
+          dims?.height ??
+          DEFAULT_HEIGHT;
         return { id: n.id, width, height };
       }),
       edges: data.edges.map((e, idx) => ({
@@ -98,7 +103,7 @@ export class LayoutEngine {
       })),
     };
 
-    const layouted: any = await this.elk.layout(elkGraph);
+    const layouted = await this.elk.layout(elkGraph);
     const nodes: Record<string, PositionedNode> = {};
     const edges: PositionedEdge[] = [];
     // Convert ELK child nodes to a lookup table by id

--- a/src/file-utils.ts
+++ b/src/file-utils.ts
@@ -22,8 +22,11 @@ export class FileUtils {
    * a `FileReader` when `file.text()` is unavailable.
    */
   public async readFileAsText(file: File): Promise<string> {
-    if (typeof (file as any).text === 'function') {
-      return (file as any).text();
+    if (
+      'text' in file &&
+      typeof (file as { text: () => Promise<string> }).text === 'function'
+    ) {
+      return (file as { text: () => Promise<string> }).text();
     }
     return new Promise((resolve, reject) => {
       const reader = new FileReader();

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -59,8 +59,9 @@ export class GraphService {
     const data = JSON.parse(text) as unknown;
     if (
       !data ||
-      !Array.isArray((data as any).nodes) ||
-      !Array.isArray((data as any).edges)
+      typeof data !== 'object' ||
+      !Array.isArray((data as { nodes?: unknown; edges?: unknown }).nodes) ||
+      !Array.isArray((data as { nodes?: unknown; edges?: unknown }).edges)
     ) {
       throw new Error('Invalid graph data');
     }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -6,6 +6,8 @@ import type {
   Group,
   GroupableItem,
   ShapeType,
+  ShapeStyle,
+  TextStyle,
 } from '@mirohq/websdk-types';
 
 /**
@@ -88,7 +90,9 @@ export class TemplateManager {
     const created: GroupableItem[] = [];
     for (const el of template.elements) {
       if (el.shape) {
-        const style: Record<string, unknown> = { ...(el.style ?? {}) };
+        const style: Partial<ShapeStyle> & Record<string, unknown> = {
+          ...(el.style ?? {}),
+        };
         if (el.fill && !style.fillColor) {
           style.fillColor = el.fill;
         }
@@ -100,12 +104,12 @@ export class TemplateManager {
           height: el.height,
           rotation: el.rotation ?? 0,
           content: (el.text ?? '{{label}}').replace('{{label}}', label),
-          style: style as any,
+          style: style as Partial<ShapeStyle>,
         });
         frame?.add(shape);
         created.push(shape);
       } else if (el.text) {
-        const style: Record<string, unknown> = {
+        const style: Partial<TextStyle> & Record<string, unknown> = {
           textAlign: 'center',
           ...(el.style ?? {}),
         };
@@ -113,7 +117,7 @@ export class TemplateManager {
           content: el.text.replace('{{label}}', label),
           x,
           y,
-          style: style as any,
+          style: style as Partial<TextStyle>,
         });
         frame?.add(text);
         created.push(text);


### PR DESCRIPTION
## Summary
- remove TypeScript any usages across source
- adjust code to maintain types and improve metadata handling
- keep layout options typed using Elk interfaces

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6853e6fdc0ec832b88774fa50053c548