### PR TITLE
Handle async warnings

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -33,12 +33,12 @@ const dropzoneStyles = {
 } as const;
 
 /** Undo last import and reset state helper. */
-export function undoLastImport(
+export async function undoLastImport(
   proc: GraphProcessor | CardProcessor | undefined,
   clear: () => void,
-): void {
+): Promise<void> {
   if (!proc) return;
-  proc.undoLast();
+  await proc.undoLast();
   clear();
 }
 
@@ -118,7 +118,7 @@ export const App: React.FC = () => {
       } catch (e) {
         const msg = String(e);
         setError(msg);
-        showError(msg);
+        await showError(msg);
       }
     }
     setFiles([]);
@@ -255,9 +255,9 @@ export const App: React.FC = () => {
           {error && <p className="error">{error}</p>}
           {lastProc && (
             <Button
-              onClick={() =>
-                undoLastImport(lastProc, () => setLastProc(undefined))
-              }
+              onClick={() => {
+                void undoLastImport(lastProc, () => setLastProc(undefined));
+              }}
               size="small"
               style={{ marginTop: '8px' }}
             >

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { DiagramApp } from './DiagramApp';
 
-DiagramApp.getInstance().init();
+DiagramApp.getInstance()
+  .init()
+  .catch(err => {
+    // eslint-disable-next-line no-console
+    console.error(err);
+  });
 
 export {};

--- a/src/notifications.ts
+++ b/src/notifications.ts
@@ -9,12 +9,12 @@
  *
  * @param message - The text to display.
  */
-export function showError(message: string): void {
+export async function showError(message: string): Promise<void> {
   const trimmed = message.length > 80 ? `${message.slice(0, 77)}...` : message;
   // Log the original message to the browser console for troubleshooting.
   // The raw message is logged to preserve detail, while the trimmed version is
   // passed to the Miro notification API.
   // eslint-disable-next-line no-console
   console.error(message);
-  miro.board.notifications.showError(trimmed);
+  await miro.board.notifications.showError(trimmed);
 }

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -10,7 +10,11 @@ declare const global: any;
 
 describe('App UI integration', () => {
   beforeEach(() => {
-    global.miro = { board: { notifications: { showError: jest.fn() } } };
+    global.miro = {
+      board: {
+        notifications: { showError: jest.fn().mockResolvedValue(undefined) },
+      },
+    };
   });
 
   afterEach(() => {
@@ -125,10 +129,10 @@ describe('App UI integration', () => {
     );
   });
 
-  test('undoLastImport helper calls undo and clears state', () => {
-    const proc = { undoLast: jest.fn() } as any;
+  test('undoLastImport helper calls undo and clears state', async () => {
+    const proc = { undoLast: jest.fn().mockResolvedValue(undefined) } as any;
     let cleared = false;
-    undoLastImport(proc, () => {
+    await undoLastImport(proc, () => {
       cleared = true;
     });
     expect(proc.undoLast).toHaveBeenCalled();

--- a/tests/index-import.test.ts
+++ b/tests/index-import.test.ts
@@ -2,7 +2,9 @@
 jest.mock('../src/DiagramApp', () => {
   return {
     DiagramApp: {
-      getInstance: jest.fn(() => ({ init: jest.fn() })),
+      getInstance: jest.fn(() => ({
+        init: jest.fn().mockResolvedValue(undefined),
+      })),
     },
   };
 });

--- a/tests/notifications.test.ts
+++ b/tests/notifications.test.ts
@@ -4,7 +4,11 @@ declare const global: any;
 
 describe('showError', () => {
   beforeEach(() => {
-    global.miro = { board: { notifications: { showError: jest.fn() } } };
+    global.miro = {
+      board: {
+        notifications: { showError: jest.fn().mockResolvedValue(undefined) },
+      },
+    };
     jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
@@ -13,17 +17,17 @@ describe('showError', () => {
     delete global.miro;
   });
 
-  test('passes through short messages', () => {
-    showError('fail');
+  test('passes through short messages', async () => {
+    await showError('fail');
     expect(console.error).toHaveBeenCalledWith('fail');
     expect(global.miro.board.notifications.showError).toHaveBeenCalledWith(
       'fail',
     );
   });
 
-  test('truncates long messages', () => {
+  test('truncates long messages', async () => {
     const long = 'a'.repeat(90);
-    showError(long);
+    await showError(long);
     expect(console.error).toHaveBeenCalledWith(long);
     const arg = (global.miro.board.notifications.showError as jest.Mock).mock
       .calls[0][0];


### PR DESCRIPTION
## Summary
- fix `showError` to return a promise and await in `App`
- update `undoLastImport` to be async
- handle `DiagramApp.init()` errors
- adjust tests for async changes

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6853e8fcbe18832ba4d6c85450256597