### PR TITLE
Update UI layout behaviour

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -205,63 +205,72 @@ export const App: React.FC = () => {
             />
           )}
 
-          <InputLabel
-            style={{ display: 'block', marginTop: tokens.space.small }}
-          >
-            Algorithm
-            <Select
-              value={layoutOpts.algorithm}
-              onChange={value =>
-                setLayoutOpts({
-                  ...layoutOpts,
-                  algorithm: value as ElkAlgorithm,
-                })
-              }
-            >
-              {ALGORITHMS.map(a => (
-                <SelectOption key={a} value={a}>
-                  {a}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputLabel>
-          <InputLabel
-            style={{ display: 'block', marginTop: tokens.space.xsmall }}
-          >
-            Direction
-            <Select
-              value={layoutOpts.direction}
-              onChange={value =>
-                setLayoutOpts({
-                  ...layoutOpts,
-                  direction: value as ElkDirection,
-                })
-              }
-            >
-              {DIRECTIONS.map(d => (
-                <SelectOption key={d} value={d}>
-                  {d}
-                </SelectOption>
-              ))}
-            </Select>
-          </InputLabel>
-          <InputLabel
-            style={{ display: 'block', marginTop: tokens.space.xsmall }}
-          >
-            Spacing
-            <Input
-              type='number'
-              value={String(layoutOpts.spacing)}
-              onChange={value =>
-                setLayoutOpts({
-                  ...layoutOpts,
-                  spacing: Number(value),
-                })
-              }
-            />
-          </InputLabel>
+          {mode === 'diagram' && (
+            <>
+              <InputLabel
+                style={{ display: 'block', marginTop: tokens.space.small }}
+              >
+                Algorithm
+                <Select
+                  value={layoutOpts.algorithm}
+                  onChange={value =>
+                    setLayoutOpts({
+                      ...layoutOpts,
+                      algorithm: value as ElkAlgorithm,
+                    })
+                  }
+                >
+                  {ALGORITHMS.map(a => (
+                    <SelectOption key={a} value={a}>
+                      {a}
+                    </SelectOption>
+                  ))}
+                </Select>
+              </InputLabel>
+              <InputLabel
+                style={{ display: 'block', marginTop: tokens.space.xsmall }}
+              >
+                Direction
+                <Select
+                  value={layoutOpts.direction}
+                  onChange={value =>
+                    setLayoutOpts({
+                      ...layoutOpts,
+                      direction: value as ElkDirection,
+                    })
+                  }
+                >
+                  {DIRECTIONS.map(d => (
+                    <SelectOption key={d} value={d}>
+                      {d}
+                    </SelectOption>
+                  ))}
+                </Select>
+              </InputLabel>
+              <InputLabel
+                style={{ display: 'block', marginTop: tokens.space.xsmall }}
+              >
+                Spacing
+                <Input
+                  type='number'
+                  value={String(layoutOpts.spacing)}
+                  onChange={value =>
+                    setLayoutOpts({
+                      ...layoutOpts,
+                      spacing: Number(value),
+                    })
+                  }
+                />
+              </InputLabel>
+            </>
+          )}
 
-          <Button onClick={handleCreate} size='small' variant='primary'>
+          <Button
+            onClick={handleCreate}
+            size='small'
+            variant='primary'
+            style={{ marginTop: tokens.space.xsmall }}
+          >
             {mode === 'diagram' ? 'Create Diagram' : 'Create Cards'}
           </Button>
           {progress > 0 && progress < 100 && (

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -35,8 +35,9 @@ body {
     list-style: none;
     padding: var(--space-xxsmall) var(--space-xsmall);
     border: 3px dashed var(--indigoAlpha40);
-    max-height: 40px;
+    max-height: 80px;
     overflow-y: auto;
+    font-size: var(--font-size-large);
 }
 
 .container {

--- a/tests/app-ui-options.test.ts
+++ b/tests/app-ui-options.test.ts
@@ -41,4 +41,12 @@ describe('App layout options and undo button', () => {
       }),
     );
   });
+
+  test('hides layout options in cards mode', () => {
+    render(React.createElement(App));
+    fireEvent.click(screen.getByLabelText(/cards/i));
+    expect(screen.queryByLabelText('Algorithm')).toBeNull();
+    expect(screen.queryByLabelText('Direction')).toBeNull();
+    expect(screen.queryByLabelText('Spacing')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- hide layout options when Cards mode is selected
- increase dropped files font size
- add spacing before create button
- test that layout options are hidden when creating cards

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685557b0d0b4832bb587c92f4dc80e05