### PR TITLE
Add sidebar tools with tabs

### DIFF
--- a/src/grid-tools.ts
+++ b/src/grid-tools.ts
@@ -1,0 +1,73 @@
+/**
+ * Calculate grid positions and apply a grid layout to the current selection.
+ */
+export interface GridOptions {
+  cols: number;
+  rows: number;
+  padding: number;
+}
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface BoardLike {
+  selection: {
+    get(): Promise<Array<Record<string, unknown>>>;
+  };
+}
+
+/**
+ * Compute the relative offsets for each grid cell.
+ */
+export function calculateGridPositions(
+  opts: GridOptions,
+  cellWidth: number,
+  cellHeight: number,
+): Position[] {
+  const positions: Position[] = [];
+  for (let r = 0; r < opts.rows; r += 1) {
+    for (let c = 0; c < opts.cols; c += 1) {
+      positions.push({
+        x: c * (cellWidth + opts.padding),
+        y: r * (cellHeight + opts.padding),
+      });
+    }
+  }
+  return positions;
+}
+
+/**
+ * Arrange selected widgets into a grid starting from the first widget's
+ * position.
+ */
+export async function applyGridLayout(
+  opts: GridOptions,
+  board?: BoardLike,
+): Promise<void> {
+  const b =
+    board ??
+    (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
+  if (!b) throw new Error('Miro board not available');
+  const selection = await b.selection.get();
+  const items = selection.slice(0, opts.cols * opts.rows);
+  if (!items.length) return;
+  const first = items[0] as {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  const positions = calculateGridPositions(opts, first.width, first.height);
+  await Promise.all(
+    items.map(async (item: Record<string, unknown>, i: number) => {
+      item.x = first.x + positions[i].x;
+      item.y = first.y + positions[i].y;
+      const sync = (item as { sync?: () => Promise<void> }).sync;
+      if (typeof sync === 'function') {
+        await sync();
+      }
+    }),
+  );
+}

--- a/src/resize-tools.ts
+++ b/src/resize-tools.ts
@@ -1,0 +1,72 @@
+/**
+ * Utility functions to copy a widget size from the current selection and
+ * apply it to other selected widgets.
+ *
+ * The board parameter defaults to the global `miro.board` when available so
+ * the functions may be used both inside the app and in tests with a mock
+ * board implementation.
+ */
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface BoardLike {
+  selection: {
+    get(): Promise<Array<Record<string, unknown>>>;
+  };
+}
+
+/**
+ * Retrieve the width and height of the first selected widget.
+ *
+ * @param board - Optional board API overriding `miro.board` for testing.
+ * @returns The size of the first widget or `null` when unavailable.
+ */
+export async function copySizeFromSelection(
+  board?: BoardLike,
+): Promise<Size | null> {
+  const b =
+    board ??
+    (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
+  if (!b) throw new Error('Miro board not available');
+  const selection = await b.selection.get();
+  const first = selection[0] as { width?: number; height?: number } | undefined;
+  if (
+    !first ||
+    typeof first.width !== 'number' ||
+    typeof first.height !== 'number'
+  ) {
+    return null;
+  }
+  return { width: first.width, height: first.height };
+}
+
+/**
+ * Resize all selected widgets to the provided size.
+ *
+ * @param size - Target width and height to apply.
+ * @param board - Optional board API overriding `miro.board` for testing.
+ */
+export async function applySizeToSelection(
+  size: Size,
+  board?: BoardLike,
+): Promise<void> {
+  const b =
+    board ??
+    (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
+  if (!b) throw new Error('Miro board not available');
+  const selection = await b.selection.get();
+  await Promise.all(
+    selection.map(async (item: Record<string, unknown>) => {
+      if (typeof item.width === 'number' && typeof item.height === 'number') {
+        item.width = size.width;
+        item.height = size.height;
+        const sync = (item as { sync?: () => Promise<void> }).sync;
+        if (typeof sync === 'function') {
+          await sync();
+        }
+      }
+    }),
+  );
+}

--- a/src/style-tools.ts
+++ b/src/style-tools.ts
@@ -1,0 +1,46 @@
+/**
+ * Helper utilities for applying style properties to all currently selected
+ * widgets on the board. Each property is optional and merged into the widget
+ * style object.
+ */
+export interface StyleOptions {
+  fontColor?: string;
+  fillColor?: string;
+  borderColor?: string;
+  borderWidth?: number;
+  fontSize?: number;
+}
+
+export interface BoardLike {
+  selection: {
+    get(): Promise<Array<Record<string, unknown>>>;
+  };
+}
+
+/**
+ * Apply the provided style options to every selected widget.
+ *
+ * @param opts - Style attributes to merge into each widget's style object.
+ * @param board - Optional board API used for testing.
+ */
+export async function applyStyleToSelection(
+  opts: StyleOptions,
+  board?: BoardLike,
+): Promise<void> {
+  const b =
+    board ??
+    (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
+  if (!b) throw new Error('Miro board not available');
+  const selection = await b.selection.get();
+  await Promise.all(
+    selection.map(async (item: Record<string, unknown>) => {
+      const style = (item.style ?? {}) as Record<string, unknown>;
+      Object.assign(style, opts);
+      item.style = style;
+      const sync = (item as { sync?: () => Promise<void> }).sync;
+      if (typeof sync === 'function') {
+        await sync();
+      }
+    }),
+  );
+}

--- a/src/tools.tsx
+++ b/src/tools.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Button, Input } from 'mirotone-react';
+import {
+  applySizeToSelection,
+  copySizeFromSelection,
+  Size,
+} from './resize-tools';
+import { applyStyleToSelection, StyleOptions } from './style-tools';
+import { applyGridLayout, GridOptions } from './grid-tools';
+
+/** UI for the Resize tab. */
+export const ResizeTab: React.FC = () => {
+  const [size, setSize] = React.useState<Size | null>(null);
+
+  const copy = async (): Promise<void> => {
+    const s = await copySizeFromSelection();
+    setSize(s);
+  };
+
+  const apply = async (): Promise<void> => {
+    if (size) await applySizeToSelection(size);
+  };
+
+  return (
+    <div>
+      <p data-testid='size-display'>
+        {size ? `${size.width}×${size.height}` : 'No size copied'}
+      </p>
+      <Button onClick={copy} size='small'>
+        Copy Size
+      </Button>
+      <Button onClick={apply} size='small'>
+        Apply Size
+      </Button>
+    </div>
+  );
+};
+
+/** UI for the Style tab. */
+export const StyleTab: React.FC = () => {
+  const [opts, setOpts] = React.useState<StyleOptions>({
+    fillColor: '#ffffff',
+    fontColor: '#1a1a1a',
+    borderColor: '#1a1a1a',
+    borderWidth: 1,
+    fontSize: 12,
+  });
+
+  const update =
+    (key: keyof StyleOptions) =>
+    (value: string): void => {
+      setOpts({
+        ...opts,
+        [key]:
+          key === 'borderWidth' || key === 'fontSize' ? Number(value) : value,
+      });
+    };
+
+  const apply = async (): Promise<void> => {
+    await applyStyleToSelection(opts);
+  };
+
+  return (
+    <div>
+      <Input
+        value={opts.fillColor}
+        onChange={update('fillColor')}
+        placeholder='Fill color'
+      />
+      <Input
+        value={opts.fontColor}
+        onChange={update('fontColor')}
+        placeholder='Font color'
+      />
+      <Input
+        value={opts.borderColor}
+        onChange={update('borderColor')}
+        placeholder='Border color'
+      />
+      <Input
+        type='number'
+        value={String(opts.borderWidth)}
+        onChange={update('borderWidth')}
+        placeholder='Border width'
+      />
+      <Input
+        type='number'
+        value={String(opts.fontSize)}
+        onChange={update('fontSize')}
+        placeholder='Font size'
+      />
+      <Button onClick={apply} size='small'>
+        Apply Style
+      </Button>
+    </div>
+  );
+};
+
+/** UI for the Grid tab. */
+export const GridTab: React.FC = () => {
+  const [grid, setGrid] = React.useState<GridOptions>({
+    cols: 2,
+    rows: 2,
+    padding: 20,
+  });
+
+  const update =
+    (key: keyof GridOptions) =>
+    (value: string): void => {
+      setGrid({ ...grid, [key]: Number(value) });
+    };
+
+  const apply = async (): Promise<void> => {
+    await applyGridLayout(grid);
+  };
+
+  return (
+    <div>
+      <Input
+        type='number'
+        value={String(grid.cols)}
+        onChange={update('cols')}
+        placeholder='Columns'
+      />
+      <Input
+        type='number'
+        value={String(grid.rows)}
+        onChange={update('rows')}
+        placeholder='Rows'
+      />
+      <Input
+        type='number'
+        value={String(grid.padding)}
+        onChange={update('padding')}
+        placeholder='Padding'
+      />
+      <Button onClick={apply} size='small'>
+        Arrange Grid
+      </Button>
+    </div>
+  );
+};

--- a/tests/app-ui-options.test.ts
+++ b/tests/app-ui-options.test.ts
@@ -44,7 +44,7 @@ describe('App layout options and undo button', () => {
 
   test('hides layout options in cards mode', () => {
     render(React.createElement(App));
-    fireEvent.click(screen.getByLabelText(/cards/i));
+    fireEvent.click(screen.getByRole('tab', { name: /cards/i }));
     expect(screen.queryByLabelText('Algorithm')).toBeNull();
     expect(screen.queryByLabelText('Direction')).toBeNull();
     expect(screen.queryByLabelText('Spacing')).toBeNull();

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -57,7 +57,7 @@ describe('App UI integration', () => {
       .spyOn(CardProcessor.prototype, 'processFile')
       .mockResolvedValue(undefined);
     render(React.createElement(App));
-    fireEvent.click(screen.getByLabelText(/cards/i));
+    fireEvent.click(screen.getByRole('tab', { name: /cards/i }));
     await act(async () => {
       selectFile();
     });
@@ -70,11 +70,11 @@ describe('App UI integration', () => {
 
   test('mode radio buttons change description text', () => {
     render(React.createElement(App));
-    fireEvent.click(screen.getByLabelText(/cards/i));
+    fireEvent.click(screen.getByRole('tab', { name: /cards/i }));
     expect(
       screen.getByText(/select the json file to import a list of cards/i),
     ).toBeInTheDocument();
-    fireEvent.click(screen.getByLabelText(/diagram/i));
+    fireEvent.click(screen.getByRole('tab', { name: /diagram/i }));
     expect(
       screen.getByText(/select the json file to import a diagram/i),
     ).toBeInTheDocument();

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -1,0 +1,27 @@
+import { applyGridLayout, calculateGridPositions } from '../src/grid-tools';
+
+describe('grid-tools', () => {
+  test('calculateGridPositions computes offsets', () => {
+    const positions = calculateGridPositions(
+      { cols: 2, rows: 2, padding: 5 },
+      10,
+      10,
+    );
+    expect(positions).toHaveLength(4);
+    expect(positions[1]).toEqual({ x: 15, y: 0 });
+    expect(positions[2]).toEqual({ x: 0, y: 15 });
+  });
+
+  test('applyGridLayout positions widgets', async () => {
+    const items = [
+      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn() },
+    ];
+    const board = { selection: { get: jest.fn().mockResolvedValue(items) } };
+    await applyGridLayout({ cols: 1, rows: 2, padding: 5 }, board);
+    expect(items[1].y).toBe(15);
+    expect(items[1].x).toBe(0);
+    expect(items[0].sync).toHaveBeenCalled();
+    expect(items[1].sync).toHaveBeenCalled();
+  });
+});

--- a/tests/resize-tools.test.ts
+++ b/tests/resize-tools.test.ts
@@ -1,0 +1,25 @@
+import {
+  applySizeToSelection,
+  copySizeFromSelection,
+} from '../src/resize-tools';
+
+describe('resize-tools', () => {
+  test('copySizeFromSelection returns size', async () => {
+    const board = {
+      selection: {
+        get: jest.fn().mockResolvedValue([{ width: 5, height: 6 }]),
+      },
+    };
+    const size = await copySizeFromSelection(board);
+    expect(size).toEqual({ width: 5, height: 6 });
+  });
+
+  test('applySizeToSelection updates widgets', async () => {
+    const item = { width: 1, height: 1, sync: jest.fn() };
+    const board = { selection: { get: jest.fn().mockResolvedValue([item]) } };
+    await applySizeToSelection({ width: 10, height: 20 }, board);
+    expect(item.width).toBe(10);
+    expect(item.height).toBe(20);
+    expect(item.sync).toHaveBeenCalled();
+  });
+});

--- a/tests/style-tools.test.ts
+++ b/tests/style-tools.test.ts
@@ -1,0 +1,12 @@
+import { applyStyleToSelection } from '../src/style-tools';
+
+describe('style-tools', () => {
+  test('applyStyleToSelection merges style', async () => {
+    const item = { style: {}, sync: jest.fn() };
+    const board = { selection: { get: jest.fn().mockResolvedValue([item]) } };
+    await applyStyleToSelection({ fillColor: '#f00', fontSize: 12 }, board);
+    expect(item.style.fillColor).toBe('#f00');
+    expect(item.style.fontSize).toBe(12);
+    expect(item.sync).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add new React tab layout with Diagram, Cards, Resize, Style and Grid tabs
- implement resize, style and grid utilities
- expose ResizeTab, StyleTab and GridTab components
- update UI tests for new tab layout
- add extensive unit tests for new utilities

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855625ca3c8832b8b07f6d769b7cd9e