### PR TITLE
Extract diagram and card tabs

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,29 +1,11 @@
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
-import { useDropzone } from 'react-dropzone';
-import {
-  Button,
-  Checkbox,
-  Input,
-  InputLabel,
-  Select,
-  SelectOption,
-  tokens,
-} from 'mirotone-react';
-import { GraphProcessor } from './GraphProcessor';
-import { CardProcessor } from './CardProcessor';
-import { showError } from './notifications';
+
 import { ResizeTab } from './tabs/ResizeTab';
 import { StyleTab } from './tabs/StyleTab';
 import { GridTab } from './tabs/GridTab';
-import {
-  ALGORITHMS,
-  DEFAULT_LAYOUT_OPTIONS,
-  DIRECTIONS,
-  ElkAlgorithm,
-  ElkDirection,
-  UserLayoutOptions,
-} from './elk-options';
+import { DiagramTab } from './tabs/DiagramTab';
+import { CardsTab } from './tabs/CardsTab';
 
 export type Tab = 'diagram' | 'cards' | 'resize' | 'style' | 'grid';
 
@@ -46,50 +28,6 @@ const TabBar: React.FC<{ tab: Tab; onChange: (t: Tab) => void }> = ({
   </nav>
 );
 
-// UI
-const dropzoneStyles = {
-  display: 'flex',
-  height: '100%',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  textAlign: 'center',
-  border: `3px dashed ${tokens.color.indigoAlpha[40]}`,
-  color: tokens.color.indigo[700],
-  fontWeight: tokens.typography.fontWeight.bold,
-  fontSize: tokens.typography.fontSize.large,
-} as const;
-
-/** Undo last import and reset state helper. */
-export async function undoLastImport(
-  proc: GraphProcessor | CardProcessor | undefined,
-  clear: () => void,
-): Promise<void> {
-  if (!proc) return;
-  await proc.undoLast();
-  clear();
-}
-
-/**
- * Compute the inline style for the dropzone element.
- * The border colour changes based on drag-and-drop state.
- */
-export function getDropzoneStyle(
-  accept: boolean,
-  reject: boolean,
-): React.CSSProperties {
-  let borderColor: string = tokens.color.indigoAlpha[40];
-  if (accept) {
-    borderColor = tokens.color.green[700];
-  }
-  if (reject) {
-    borderColor = tokens.color.red[700];
-  }
-  return {
-    ...dropzoneStyles,
-    borderColor,
-  };
-}
-
 /**
  * React entry component that renders the file selection and mode
  * toggling user interface. Extraction as an exported constant allows
@@ -97,201 +35,11 @@ export function getDropzoneStyle(
  */
 export const App: React.FC = () => {
   const [tab, setTab] = React.useState<Tab>('diagram');
-  const [files, setFiles] = React.useState<File[]>([]);
-  const [withFrame, setWithFrame] = React.useState(false);
-  const [frameTitle, setFrameTitle] = React.useState('');
-  const [progress, setProgress] = React.useState<number>(0);
-  const [error, setError] = React.useState<string | null>(null);
-  const [layoutOpts, setLayoutOpts] = React.useState<UserLayoutOptions>(
-    DEFAULT_LAYOUT_OPTIONS,
-  );
-  const [lastProc, setLastProc] = React.useState<
-    GraphProcessor | CardProcessor | undefined
-  >(undefined);
-  const dropzone = useDropzone({
-    accept: {
-      'application/json': ['.json'],
-    },
-    maxFiles: 1,
-    onDrop: (droppedFiles: File[]) => {
-      const file = droppedFiles[0];
-      setFiles([file]);
-    },
-  });
-
-  const graphProcessor = React.useMemo(() => new GraphProcessor(), []);
-  const cardProcessor = React.useMemo(() => new CardProcessor(), []);
-
-  const handleCreate = async () => {
-    setProgress(0);
-    setError(null);
-    for (const file of files) {
-      try {
-        if (tab === 'diagram') {
-          setLastProc(graphProcessor);
-          await graphProcessor.processFile(file, {
-            createFrame: withFrame,
-            frameTitle: frameTitle || undefined,
-            layout: layoutOpts,
-          });
-        } else if (tab === 'cards') {
-          setLastProc(cardProcessor);
-          await cardProcessor.processFile(file, {
-            createFrame: withFrame,
-            frameTitle: frameTitle || undefined,
-          });
-        }
-        setProgress(100);
-      } catch (e) {
-        const msg = String(e);
-        setError(msg);
-        await showError(msg);
-      }
-    }
-    setFiles([]);
-  };
-
-  const style = React.useMemo(
-    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
-    [dropzone.isDragActive, dropzone.isDragReject],
-  );
-
   return (
     <div className='dnd-container'>
       <TabBar tab={tab} onChange={setTab} />
-      {tab === 'diagram' || tab === 'cards' ? (
-        <p>
-          Select the JSON file to import{' '}
-          {tab === 'diagram' ? 'a diagram' : 'a list of cards'}
-        </p>
-      ) : null}
-      {(tab === 'diagram' || tab === 'cards') && (
-        <>
-          <div
-            {...dropzone.getRootProps({ style })}
-            aria-label='File drop area'
-            aria-describedby='dropzone-instructions'
-          >
-            <input
-              data-testid='file-input'
-              {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
-            />
-            {dropzone.isDragAccept ? (
-              <p className='dnd-text'>Drop your JSON file here</p>
-            ) : (
-              <>
-                <div>
-                  <Button variant='primary' type='button'>
-                    Select JSON file
-                  </Button>
-                  <p className='dnd-text'>Or drop your JSON file here</p>
-                </div>
-              </>
-            )}
-          </div>
-          <p id='dropzone-instructions' className='visually-hidden'>
-            Press Enter to open the file picker or drop a JSON file on the area
-            above.
-          </p>
-        </>
-      )}
-
-      {(tab === 'diagram' || tab === 'cards') && files.length > 0 && (
-        <>
-          <ul className='dropped-files'>
-            {files.map((file, i) => (
-              <li key={i}>{file.name}</li>
-            ))}
-          </ul>
-          <div style={{ marginTop: tokens.space.small }}>
-            <Checkbox
-              label='Wrap items in frame'
-              value={withFrame}
-              onChange={setWithFrame}
-            />
-          </div>
-          {withFrame && (
-            <Input
-              placeholder='Frame title'
-              value={frameTitle}
-              onChange={setFrameTitle}
-              style={{ marginTop: tokens.space.xsmall }}
-            />
-          )}
-
-          {tab === 'diagram' && (
-            <>
-              <InputLabel>
-                Algorithm
-                <Select
-                  value={layoutOpts.algorithm}
-                  onChange={value =>
-                    setLayoutOpts({
-                      ...layoutOpts,
-                      algorithm: value as ElkAlgorithm,
-                    })
-                  }
-                >
-                  {ALGORITHMS.map(a => (
-                    <SelectOption key={a} value={a}>
-                      {a}
-                    </SelectOption>
-                  ))}
-                </Select>
-              </InputLabel>
-              <InputLabel>
-                Direction
-                <Select
-                  value={layoutOpts.direction}
-                  onChange={value =>
-                    setLayoutOpts({
-                      ...layoutOpts,
-                      direction: value as ElkDirection,
-                    })
-                  }
-                >
-                  {DIRECTIONS.map(d => (
-                    <SelectOption key={d} value={d}>
-                      {d}
-                    </SelectOption>
-                  ))}
-                </Select>
-              </InputLabel>
-              <InputLabel>
-                Spacing
-                <Input
-                  type='number'
-                  value={String(layoutOpts.spacing)}
-                  onChange={value =>
-                    setLayoutOpts({
-                      ...layoutOpts,
-                      spacing: Number(value),
-                    })
-                  }
-                />
-              </InputLabel>
-            </>
-          )}
-
-          <Button onClick={handleCreate} size='small' variant='primary'>
-            {tab === 'diagram' ? 'Create Diagram' : 'Create Cards'}
-          </Button>
-          {progress > 0 && progress < 100 && (
-            <progress value={progress} max={100} />
-          )}
-          {error && <p className='error'>{error}</p>}
-          {lastProc && (
-            <Button
-              onClick={() => {
-                void undoLastImport(lastProc, () => setLastProc(undefined));
-              }}
-              size='small'
-            >
-              Undo Last Import
-            </Button>
-          )}
-        </>
-      )}
+      {tab === 'diagram' && <DiagramTab />}
+      {tab === 'cards' && <CardsTab />}
       {tab === 'resize' && <ResizeTab />}
       {tab === 'style' && <StyleTab />}
       {tab === 'grid' && <GridTab />}

--- a/src/tabs/CardsTab.tsx
+++ b/src/tabs/CardsTab.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Button, Checkbox, Input, tokens } from 'mirotone-react';
+import { CardProcessor } from '../CardProcessor';
+import { showError } from '../notifications';
+import { getDropzoneStyle, undoLastImport } from '../ui-utils';
+
+/** UI for the Cards tab. */
+export const CardsTab: React.FC = () => {
+  const [files, setFiles] = React.useState<File[]>([]);
+  const [withFrame, setWithFrame] = React.useState(false);
+  const [frameTitle, setFrameTitle] = React.useState('');
+  const [progress, setProgress] = React.useState<number>(0);
+  const [error, setError] = React.useState<string | null>(null);
+  const [lastProc, setLastProc] = React.useState<CardProcessor | undefined>(
+    undefined,
+  );
+
+  const dropzone = useDropzone({
+    accept: {
+      'application/json': ['.json'],
+    },
+    maxFiles: 1,
+    onDrop: (droppedFiles: File[]) => {
+      const file = droppedFiles[0];
+      setFiles([file]);
+    },
+  });
+
+  const cardProcessor = React.useMemo(() => new CardProcessor(), []);
+
+  const handleCreate = async (): Promise<void> => {
+    setProgress(0);
+    setError(null);
+    for (const file of files) {
+      try {
+        setLastProc(cardProcessor);
+        await cardProcessor.processFile(file, {
+          createFrame: withFrame,
+          frameTitle: frameTitle || undefined,
+        });
+        setProgress(100);
+      } catch (e) {
+        const msg = String(e);
+        setError(msg);
+        await showError(msg);
+      }
+    }
+    setFiles([]);
+  };
+
+  const style = React.useMemo(
+    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
+    [dropzone.isDragAccept, dropzone.isDragReject],
+  );
+
+  return (
+    <div>
+      <p>Select the JSON file to import a list of cards</p>
+      <div
+        {...dropzone.getRootProps({ style })}
+        aria-label='File drop area'
+        aria-describedby='dropzone-instructions'
+      >
+        <input
+          data-testid='file-input'
+          {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
+        />
+        {dropzone.isDragAccept ? (
+          <p className='dnd-text'>Drop your JSON file here</p>
+        ) : (
+          <>
+            <div>
+              <Button variant='primary' type='button'>
+                Select JSON file
+              </Button>
+              <p className='dnd-text'>Or drop your JSON file here</p>
+            </div>
+          </>
+        )}
+      </div>
+      <p id='dropzone-instructions' className='visually-hidden'>
+        Press Enter to open the file picker or drop a JSON file on the area
+        above.
+      </p>
+
+      {files.length > 0 && (
+        <>
+          <ul className='dropped-files'>
+            {files.map((file, i) => (
+              <li key={i}>{file.name}</li>
+            ))}
+          </ul>
+          <div style={{ marginTop: tokens.space.small }}>
+            <Checkbox
+              label='Wrap items in frame'
+              value={withFrame}
+              onChange={setWithFrame}
+            />
+          </div>
+          {withFrame && (
+            <Input
+              placeholder='Frame title'
+              value={frameTitle}
+              onChange={setFrameTitle}
+              style={{ marginTop: tokens.space.xsmall }}
+            />
+          )}
+          <Button onClick={handleCreate} size='small' variant='primary'>
+            Create Cards
+          </Button>
+          {progress > 0 && progress < 100 && (
+            <progress value={progress} max={100} />
+          )}
+          {error && <p className='error'>{error}</p>}
+          {lastProc && (
+            <Button
+              onClick={() => {
+                void undoLastImport(lastProc, () => setLastProc(undefined));
+              }}
+              size='small'
+            >
+              Undo Last Import
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/tabs/DiagramTab.tsx
+++ b/src/tabs/DiagramTab.tsx
@@ -1,0 +1,199 @@
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import {
+  Button,
+  Checkbox,
+  Input,
+  InputLabel,
+  Select,
+  SelectOption,
+  tokens,
+} from 'mirotone-react';
+import { GraphProcessor } from '../GraphProcessor';
+import { showError } from '../notifications';
+import {
+  ALGORITHMS,
+  DEFAULT_LAYOUT_OPTIONS,
+  DIRECTIONS,
+  ElkAlgorithm,
+  ElkDirection,
+  UserLayoutOptions,
+} from '../elk-options';
+import { getDropzoneStyle, undoLastImport } from '../ui-utils';
+
+/** UI for the Diagram tab. */
+export const DiagramTab: React.FC = () => {
+  const [files, setFiles] = React.useState<File[]>([]);
+  const [withFrame, setWithFrame] = React.useState(false);
+  const [frameTitle, setFrameTitle] = React.useState('');
+  const [layoutOpts, setLayoutOpts] = React.useState<UserLayoutOptions>(
+    DEFAULT_LAYOUT_OPTIONS,
+  );
+  const [progress, setProgress] = React.useState<number>(0);
+  const [error, setError] = React.useState<string | null>(null);
+  const [lastProc, setLastProc] = React.useState<GraphProcessor | undefined>(
+    undefined,
+  );
+
+  const dropzone = useDropzone({
+    accept: {
+      'application/json': ['.json'],
+    },
+    maxFiles: 1,
+    onDrop: (droppedFiles: File[]) => {
+      const file = droppedFiles[0];
+      setFiles([file]);
+    },
+  });
+
+  const graphProcessor = React.useMemo(() => new GraphProcessor(), []);
+
+  const handleCreate = async (): Promise<void> => {
+    setProgress(0);
+    setError(null);
+    for (const file of files) {
+      try {
+        setLastProc(graphProcessor);
+        await graphProcessor.processFile(file, {
+          createFrame: withFrame,
+          frameTitle: frameTitle || undefined,
+          layout: layoutOpts,
+        });
+        setProgress(100);
+      } catch (e) {
+        const msg = String(e);
+        setError(msg);
+        await showError(msg);
+      }
+    }
+    setFiles([]);
+  };
+
+  const style = React.useMemo(
+    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
+    [dropzone.isDragAccept, dropzone.isDragReject],
+  );
+
+  return (
+    <div>
+      <p>Select the JSON file to import a diagram</p>
+      <div
+        {...dropzone.getRootProps({ style })}
+        aria-label='File drop area'
+        aria-describedby='dropzone-instructions'
+      >
+        <input
+          data-testid='file-input'
+          {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
+        />
+        {dropzone.isDragAccept ? (
+          <p className='dnd-text'>Drop your JSON file here</p>
+        ) : (
+          <>
+            <div>
+              <Button variant='primary' type='button'>
+                Select JSON file
+              </Button>
+              <p className='dnd-text'>Or drop your JSON file here</p>
+            </div>
+          </>
+        )}
+      </div>
+      <p id='dropzone-instructions' className='visually-hidden'>
+        Press Enter to open the file picker or drop a JSON file on the area
+        above.
+      </p>
+
+      {files.length > 0 && (
+        <>
+          <ul className='dropped-files'>
+            {files.map((file, i) => (
+              <li key={i}>{file.name}</li>
+            ))}
+          </ul>
+          <div style={{ marginTop: tokens.space.small }}>
+            <Checkbox
+              label='Wrap items in frame'
+              value={withFrame}
+              onChange={setWithFrame}
+            />
+          </div>
+          {withFrame && (
+            <Input
+              placeholder='Frame title'
+              value={frameTitle}
+              onChange={setFrameTitle}
+              style={{ marginTop: tokens.space.xsmall }}
+            />
+          )}
+          <InputLabel>
+            Algorithm
+            <Select
+              value={layoutOpts.algorithm}
+              onChange={value =>
+                setLayoutOpts({
+                  ...layoutOpts,
+                  algorithm: value as ElkAlgorithm,
+                })
+              }
+            >
+              {ALGORITHMS.map(a => (
+                <SelectOption key={a} value={a}>
+                  {a}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputLabel>
+          <InputLabel>
+            Direction
+            <Select
+              value={layoutOpts.direction}
+              onChange={value =>
+                setLayoutOpts({
+                  ...layoutOpts,
+                  direction: value as ElkDirection,
+                })
+              }
+            >
+              {DIRECTIONS.map(d => (
+                <SelectOption key={d} value={d}>
+                  {d}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputLabel>
+          <InputLabel>
+            Spacing
+            <Input
+              type='number'
+              value={String(layoutOpts.spacing)}
+              onChange={value =>
+                setLayoutOpts({
+                  ...layoutOpts,
+                  spacing: Number(value),
+                })
+              }
+            />
+          </InputLabel>
+          <Button onClick={handleCreate} size='small' variant='primary'>
+            Create Diagram
+          </Button>
+          {progress > 0 && progress < 100 && (
+            <progress value={progress} max={100} />
+          )}
+          {error && <p className='error'>{error}</p>}
+          {lastProc && (
+            <Button
+              onClick={() => {
+                void undoLastImport(lastProc, () => setLastProc(undefined));
+              }}
+              size='small'
+            >
+              Undo Last Import
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/ui-utils.ts
+++ b/src/ui-utils.ts
@@ -1,0 +1,47 @@
+import { tokens } from 'mirotone-react';
+import { GraphProcessor } from './GraphProcessor';
+import { CardProcessor } from './CardProcessor';
+import type React from 'react';
+
+const dropzoneStyles = {
+  display: 'flex',
+  height: '100%',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  textAlign: 'center',
+  border: `3px dashed ${tokens.color.indigoAlpha[40]}`,
+  color: tokens.color.indigo[700],
+  fontWeight: tokens.typography.fontWeight.bold,
+  fontSize: tokens.typography.fontSize.large,
+} as const;
+
+/** Undo last import and reset state helper. */
+export async function undoLastImport(
+  proc: GraphProcessor | CardProcessor | undefined,
+  clear: () => void,
+): Promise<void> {
+  if (!proc) return;
+  await proc.undoLast();
+  clear();
+}
+
+/**
+ * Compute the inline style for the dropzone element.
+ * The border colour changes based on drag-and-drop state.
+ */
+export function getDropzoneStyle(
+  accept: boolean,
+  reject: boolean,
+): React.CSSProperties {
+  let borderColor: string = tokens.color.indigoAlpha[40];
+  if (accept) {
+    borderColor = tokens.color.green[700];
+  }
+  if (reject) {
+    borderColor = tokens.color.red[700];
+  }
+  return {
+    ...dropzoneStyles,
+    borderColor,
+  };
+}

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -2,7 +2,8 @@
 import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { App, getDropzoneStyle, undoLastImport } from '../src/app';
+import { App } from '../src/app';
+import { getDropzoneStyle, undoLastImport } from '../src/ui-utils';
 import { tokens } from 'mirotone-react';
 import { GraphProcessor } from '../src/GraphProcessor';
 import { CardProcessor } from '../src/CardProcessor';

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -5,13 +5,19 @@ import '@testing-library/jest-dom';
 import { ResizeTab } from '../src/tabs/ResizeTab';
 import { StyleTab } from '../src/tabs/StyleTab';
 import { GridTab } from '../src/tabs/GridTab';
+import { DiagramTab } from '../src/tabs/DiagramTab';
+import { CardsTab } from '../src/tabs/CardsTab';
 import * as resizeTools from '../src/resize-tools';
 import * as styleTools from '../src/style-tools';
 import * as gridTools from '../src/grid-tools';
+import { GraphProcessor } from '../src/GraphProcessor';
+import { CardProcessor } from '../src/CardProcessor';
 
 jest.mock('../src/resize-tools');
 jest.mock('../src/style-tools');
 jest.mock('../src/grid-tools');
+jest.mock('../src/GraphProcessor');
+jest.mock('../src/CardProcessor');
 
 describe('tab components', () => {
   beforeEach(() => {
@@ -68,6 +74,38 @@ describe('tab components', () => {
     render(React.createElement(GridTab));
     await act(async () => {
       fireEvent.click(screen.getByText(/arrange grid/i));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('DiagramTab processes file', async () => {
+    const spy = jest
+      .spyOn(GraphProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as unknown as void);
+    render(React.createElement(DiagramTab));
+    const input = screen.getByTestId('file-input');
+    const file = new File(['{}'], 'graph.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create diagram/i }));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('CardsTab processes file', async () => {
+    const spy = jest
+      .spyOn(CardProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as unknown as void);
+    render(React.createElement(CardsTab));
+    const input = screen.getByTestId('file-input');
+    const file = new File(['{}'], 'cards.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create cards/i }));
     });
     expect(spy).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- refactor `App` to use new DiagramTab and CardsTab components
- add shared UI utilities
- implement new `DiagramTab` and `CardsTab` tab components
- update tests for new structure and add coverage for new tabs

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68564af6f6e4832badc34528557f0356