### PR TITLE
Fix DiagramApp icon click

### DIFF
--- a/src/DiagramApp.ts
+++ b/src/DiagramApp.ts
@@ -19,7 +19,7 @@ export class DiagramApp {
     if (typeof miro === 'undefined' || !miro?.board?.ui) {
       throw new Error('Miro SDK not available');
     }
-    await miro.board.ui.on('icon:click', async () => {
+    miro.board.ui.on('icon:click', async () => {
       await miro.board.ui.openPanel({ url: 'app.html' });
     });
   }


### PR DESCRIPTION
## Summary
- don't await `miro.board.ui.on()` in DiagramApp

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68564ab3134c832b957cf1f823412b6b