### PR TITLE
Add design documents and expand styling guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ The CSS for this project imports
 [`src/assets/style.css`](src/assets/style.css) to match the Miro UI. When adding
 new UI elements reuse the Mirotone utility classes such as `button`,
 `button-primary` and the grid helpers so your components align with existing
-styles.
+styles. Avoid custom CSS when a utility class exists. All interactive elements
+should be built using `mirotone-react` components so the underlying markup
+follows the same structure and spacing tokens as the native Mirotone widgets.
 
 ## Form Design Guidelines
 
@@ -140,6 +142,8 @@ match the rest of the UI. These guidelines help keep layouts consistent:
   responsive.
 - Use the tokens from `mirotone-react` (`tokens.space.*`) for margins and
   padding instead of hard‑coded numbers.
+- When customisation is needed prefer extending Mirotone variables over creating
+  bespoke CSS classes.
 - Stick to the provided `Button` component and choose the `primary` variant for
   the main action. Place secondary actions on the right using the `buttons`
   wrapper as seen in the tabs.
@@ -249,6 +253,15 @@ point to the deployed bundle.
 ├── app.html       // The app itself. It's loaded on the board inside the 'appContainer'
 └── index.html     // The app entry point. This is what you specify in the 'App URL' box in the Miro app settings
 ```
+
+## 📚 Additional Design Docs
+
+- [Architecture](docs/ARCHITECTURE.md) explains how the source modules are
+  organised.
+- [Tab Overview](docs/TABS.md) describes the sidebar tabs and their purpose.
+- [Deployment Guide](docs/DEPLOYMENT.md) shows how to build and host the bundle.
+- [Styling and Formatting](docs/STYLING.md) covers Mirotone usage and coding
+  conventions.
 
 ## 🫱🏻‍🫲🏽 Contributing <a name="contributing"></a>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Project Architecture
+
+This document outlines the high level structure of the application and how the
+main functions are divided across modules.
+
+## Overview
+
+The project is built in TypeScript using React. UI logic lives under `src/` and
+test cases under `tests/`. Each module is designed with a single responsibility
+so behaviour is easy to test and maintain.
+
+### Core Modules
+
+- **GraphProcessor** (`src/GraphProcessor.ts`)
+
+  - Parses the JSON graph input and normalises nodes and edges.
+  - Provides helper functions to extract metadata and create template mappings.
+
+- **BoardBuilder** (`src/BoardBuilder.ts`)
+
+  - Responsible for creating widgets on the board using data prepared by
+    `GraphProcessor`.
+  - Handles caching of widgets and offers utilities for updating or removing
+    items.
+
+- **CardProcessor** (`src/CardProcessor.ts`)
+
+  - Loads card definitions from JSON files and converts them into board widgets.
+  - Exposes undo support so recent imports can be reverted.
+
+- **DiagramApp** (`src/DiagramApp.ts`)
+
+  - Entry point for the sidebar UI and orchestration of the different tabs.
+  - Maintains application state such as the current selection and registered
+    tools.
+
+- **Utility Modules**
+  - `elk-layout.ts` and `layout-utils.ts` contain layout logic using the ELK
+    engine.
+  - `ui-utils.ts`, `style-tools.ts`, and other helpers encapsulate UI behaviour.
+
+Each function within these files aims for a cyclomatic complexity below 8 and
+focuses on a single task to keep the design modular.
+
+## Testing
+
+The `tests/` directory mirrors the source layout with extensive Jest suites.
+Module and branch coverage is above 90% to ensure reliability. New functions
+should include corresponding tests to maintain this coverage level.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,28 @@
+# Deployment Guide
+
+Follow these steps to build and deploy the application in a production
+environment.
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Create the production bundle**
+
+   ```bash
+   npm run build
+   ```
+
+   This generates the optimized assets inside `dist/`.
+
+3. **Host the bundle** Serve the `dist/` directory with any static web server
+   (for example Nginx or GitHub Pages). Update the `sdkUri` in your app manifest
+   to point to the hosted `app.html`.
+
+4. **Update the manifest** Ensure your `app-manifest.yml` uses `SDK_V2` and the
+   correct URL for the deployed bundle.
+
+5. **Install on a Miro board** After deploying, install or reinstall the app
+   from your Miro developer team so it loads the new bundle.

--- a/docs/STYLING.md
+++ b/docs/STYLING.md
@@ -1,0 +1,42 @@
+# Styling and Formatting
+
+This guide describes how to apply styles using Mirotone and how to keep the code
+base consistent.
+
+## Mirotone CSS
+
+The application imports `mirotone/dist/styles.css` which provides the base
+styles used across Miro products. To maintain a consistent look:
+
+- Use the predefined utility classes such as `button`, `button-primary`, `cs*`
+  and `ce*` for grid positioning.
+- Avoid writing custom CSS when a Mirotone class exists for the same purpose.
+- Keep layout spacing based on the sizing scale provided by `mirotone-react` via
+  `tokens.space.*`.
+- Components from `mirotone-react` already apply the correct Mirotone classes so
+  prefer them over raw HTML elements.
+
+## Using mirotone-react
+
+`mirotone-react` supplies React wrappers for common controls like `Button`,
+`Input`, `Checkbox` and more. Import these components instead of hand‑rolling
+DOM elements. They expose props that map directly to Mirotone classes, ensuring
+the markup follows the design system.
+
+```tsx
+import { Button, Checkbox, Input } from 'mirotone-react';
+```
+
+## Formatting
+
+All code is formatted with Prettier. Before committing run the following
+commands:
+
+```bash
+npm run typecheck --silent
+npm test --silent
+npm run lint --silent
+npm run prettier --silent
+```
+
+This keeps the style consistent and catches common issues early.

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -1,0 +1,18 @@
+# Tab Overview
+
+The sidebar interface groups functionality into five tabs. Each tab is
+implemented as a React component under `src/tabs/` and exposes a simple UI that
+calls into the processing modules.
+
+| Tab Component | Purpose                                                        |
+| ------------- | -------------------------------------------------------------- |
+| `DiagramTab`  | Import a graph description and build the diagram on the board. |
+| `CardsTab`    | Load a list of cards from JSON and create card widgets.        |
+| `ResizeTab`   | Resize selected widgets or apply a stored size across items.   |
+| `StyleTab`    | Apply fill and border styles to the current selection.         |
+| `GridTab`     | Arrange widgets into a grid and optionally group them.         |
+
+The tabs are rendered by `DiagramApp` which controls which tab is active. Each
+component focuses on a single concern and delegates work to helper classes such
+as `BoardBuilder` or `CardProcessor`. Because the logic is encapsulated the tabs
+remain small and easy to test.


### PR DESCRIPTION
## Summary
- detail project architecture, tab overview, deployment, and styling best practices
- expand README styling section and link to the new docs

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6856772d5f80832baf0031de519d13a6