### PR TITLE
Replace hex literals with color tokens

### DIFF
--- a/src/color-utils.ts
+++ b/src/color-utils.ts
@@ -5,6 +5,24 @@
  * contrast calculations so fill and font colours remain readable.
  */
 
+import { tokens } from 'mirotone-react';
+import { colors } from '@mirohq/design-tokens';
+
+/** Convert a token reference to its hex value. */
+export function resolveColor(token: string, fallback: string): string {
+  if (token.startsWith('var(')) {
+    if (typeof document !== 'undefined') {
+      const name = token.slice(4, -1);
+      const val = getComputedStyle(document.documentElement).getPropertyValue(
+        name,
+      );
+      return (val.trim() || fallback).toLowerCase();
+    }
+    return fallback.toLowerCase();
+  }
+  return token.toLowerCase();
+}
+
 /** RGB colour representation. */
 export interface Rgb {
   r: number;
@@ -76,7 +94,15 @@ export function contrastRatio(a: string, b: string): number {
  */
 export function ensureContrast(bg: string, fg: string): string {
   if (contrastRatio(bg, fg) >= 4.5) return fg;
-  const black = contrastRatio(bg, '#000000');
-  const white = contrastRatio(bg, '#ffffff');
-  return black >= white ? '#000000' : '#ffffff';
+  const black = contrastRatio(
+    bg,
+    resolveColor(tokens.color.black, colors.black),
+  );
+  const white = contrastRatio(
+    bg,
+    resolveColor(tokens.color.white, colors.white),
+  );
+  return black >= white
+    ? resolveColor(tokens.color.black, colors.black)
+    : resolveColor(tokens.color.white, colors.white);
 }

--- a/src/tabs/StyleTab.tsx
+++ b/src/tabs/StyleTab.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   InputLabel,
   Paragraph,
+  tokens,
 } from 'mirotone-react';
 import {
   applyStyleToSelection,
@@ -19,9 +20,9 @@ import { useSelection } from '../useSelection';
 export const StyleTab: React.FC = () => {
   const selection = useSelection();
   const [opts, setOpts] = React.useState<StyleOptions>({
-    fillColor: '#ffffff',
-    fontColor: '#1a1a1a',
-    borderColor: '#1a1a1a',
+    fillColor: tokens.color.white,
+    fontColor: tokens.color.primaryText,
+    borderColor: tokens.color.primaryText,
     borderWidth: 1,
     fontSize: 12,
   });


### PR DESCRIPTION
## Summary
- replace hardcoded colour values with tokens
- map tokens to design-token values when needed
- resolve token strings for style tools

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685697fd8db8832bb3aa44a96b139a4b