### PR TITLE
Prefix custom CSS classes

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,3 +1,4 @@
+/* Figma reference: https://figma.com/file/XYZ123 */
 @import 'mirotone/dist/styles.css';
 
 *,
@@ -27,14 +28,14 @@ body {
         align-items: stretch;
 }
 
-.centered .buttons {
+.custom-centered .custom-buttons {
     position: sticky;
     bottom: 0;
     padding-block: var(--space-medium);
-    background: #fff;
+    background: var(--colors-white);
 }
 
-.dropped-files {
+.custom-dropped-files {
     list-style: none;
     padding: var(--space-xxsmall) var(--space-xsmall);
     border: 3px dashed var(--indigoAlpha40);
@@ -44,7 +45,7 @@ body {
 }
 
 
-.visually-hidden {
+.custom-visually-hidden {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/src/ui/tabs/CardsTab.tsx
+++ b/src/ui/tabs/CardsTab.tsx
@@ -96,14 +96,14 @@ export const CardsTab: React.FC = () => {
           </>
         )}
       </div>
-      <Paragraph id='dropzone-instructions' className='visually-hidden'>
+      <Paragraph id='dropzone-instructions' className='custom-visually-hidden'>
         Press Enter to open the file picker or drop a JSON file on the area
         above.
       </Paragraph>
 
       {files.length > 0 && (
         <>
-          <ul className='dropped-files'>
+          <ul className='custom-dropped-files'>
             {files.map((file, i) => (
               <li key={i}>{file.name}</li>
             ))}

--- a/src/ui/tabs/DiagramTab.tsx
+++ b/src/ui/tabs/DiagramTab.tsx
@@ -110,14 +110,14 @@ export const DiagramTab: React.FC = () => {
           </>
         )}
       </div>
-      <Paragraph id='dropzone-instructions' className='visually-hidden'>
+      <Paragraph id='dropzone-instructions' className='custom-visually-hidden'>
         Press Enter to open the file picker or drop a JSON file on the area
         above.
       </Paragraph>
 
       {files.length > 0 && (
         <>
-          <ul className='dropped-files'>
+          <ul className='custom-dropped-files'>
             {files.map((file, i) => (
               <li key={i}>{file.name}</li>
             ))}

--- a/src/ui/tabs/ResizeTab.tsx
+++ b/src/ui/tabs/ResizeTab.tsx
@@ -56,7 +56,7 @@ export const ResizeTab: React.FC = () => {
   }, [selection]);
 
   return (
-    <div className='centered'>
+    <div className='custom-centered'>
       <Heading level={2}>Resize Shapes</Heading>
       <Paragraph data-testid='size-display'>
         {copied ? `Copied ${size.width}×${size.height}` : 'Manual size'}
@@ -85,7 +85,7 @@ export const ResizeTab: React.FC = () => {
         {boardUnitsToInches(size.width).toFixed(2)} ×{' '}
         {boardUnitsToInches(size.height).toFixed(2)} in)
       </Paragraph>
-      <div className='buttons'>
+      <div className='custom-buttons'>
         <Button onClick={copy} variant='secondary'>
           <React.Fragment key='.0'>
             <Icon name='duplicate' />


### PR DESCRIPTION
## Summary
- rename helper classes to use `custom-` prefix
- apply design tokens in global CSS
- update tab components to use new class names

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68569e36cb80832b9137dd8c988d1b4a