### PR TITLE
Fix resize for standard shapes

### DIFF
--- a/src/board/resize-tools.ts
+++ b/src/board/resize-tools.ts
@@ -36,7 +36,11 @@ export async function copySizeFromSelection(
 }
 
 /**
- * Resize all selected widgets to the provided size.
+ * Resize all currently selected shapes.
+ *
+ * Only widgets exposing numeric `width` and `height` properties are
+ * modified. Each widget is synchronised via its `.sync()` method when
+ * available.
  *
  * @param size - Target width and height to apply.
  * @param board - Optional board API overriding `miro.board` for testing.


### PR DESCRIPTION
## Summary
- revert group recursion logic so standard shape resize works
- document applySizeToSelection and rely on width/height properties
- update unit tests for resize utilities

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6857fb75fe6c832b8ea12f84f23fdf49