### PR TITLE
Add reset copy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ selection radios are grouped with a descriptive label.
 The sidebar exposes extra tabs to manipulate existing widgets:
 
 - **Resize** allows copying a widget size and applying it to others. You can
-  also type width and height manually. The tool displays conversions between
-  board units, millimetres and inches based on the ratio `96 units = 1 inch`.
+  also type width and height manually. When a size is copied the same button
+  becomes a **Reset Copy** action so you can quickly revert. The tool displays
+  conversions between board units, millimetres and inches based on the ratio
+  `96 units = 1 inch`.
 - **Style** sets common style properties like fill colour or border width on all
   selected items. The tab shows the current fill colour swatch and updates when
   the selection changes. A slider lightens or darkens the colour while keeping

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -42,6 +42,10 @@ export const ResizeTab: React.FC = () => {
     }
   };
 
+  const resetCopy = (): void => {
+    setCopiedSize(null);
+  };
+
   const apply = async (): Promise<void> => {
     const target = copiedSize ?? size;
     if (target.width > 10000 || target.height > 10000) {
@@ -131,10 +135,10 @@ export const ResizeTab: React.FC = () => {
         {boardUnitsToInches(size.height).toFixed(2)} in)
       </Paragraph>
       <div className='buttons'>
-        <Button onClick={copy} variant='secondary'>
+        <Button onClick={copiedSize ? resetCopy : copy} variant='secondary'>
           <React.Fragment key='.0'>
-            <Icon name='duplicate' />
-            <Text>Copy Size</Text>
+            <Icon name={copiedSize ? 'undo' : 'duplicate'} />
+            <Text>{copiedSize ? 'Reset Copy' : 'Copy Size'}</Text>
           </React.Fragment>
         </Button>
         <Button onClick={apply} variant='primary'>

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -55,6 +55,21 @@ describe('tab components', () => {
     expect(spy).toHaveBeenCalledWith({ width: 50, height: 40 });
   });
 
+  test('ResizeTab toggles copy and reset', async () => {
+    jest
+      .spyOn(resizeTools, 'copySizeFromSelection')
+      .mockResolvedValue({ width: 20, height: 30 });
+    render(React.createElement(ResizeTab));
+    await act(async () => {
+      fireEvent.click(screen.getByText(/copy size/i));
+    });
+    expect(screen.getByText(/reset copy/i)).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText(/reset copy/i));
+    });
+    expect(screen.getByText(/copy size/i)).toBeInTheDocument();
+  });
+
   test('StyleTab applies style', async () => {
     const spy = jest
       .spyOn(styleTools, 'applyStyleToSelection')


### PR DESCRIPTION
## Summary
- add ability to reset copied resize value
- toggle copy button label/icon when a size has been copied
- document the new reset functionality
- test UI logic for resetting copied size

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6857ffcefabc832bae74531ca371a470