### PR TITLE
Fix text color styling

### DIFF
--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -13,7 +13,8 @@ import {
 import { BoardLike, getBoard } from './board';
 
 export interface StyleOptions {
-  fontColor?: string;
+  /** Text color for supported widgets */
+  color?: string;
   fillColor?: string;
   borderColor?: string;
   borderWidth?: number;
@@ -61,7 +62,7 @@ export async function applyStyleToSelection(
 
 /**
  * Lighten or darken the fill colour of all selected widgets ensuring the
- * font colour maintains sufficient contrast.
+ * text colour maintains sufficient contrast.
  *
  * @param delta - Adjustment amount between -1 (darken) and 1 (lighten).
  * @param board - Optional board API overriding `miro.board` for testing.
@@ -81,12 +82,12 @@ export async function tweakFillColor(
           ? style.fillColor
           : resolveColor(tokens.color.white, colors.white);
       const font =
-        typeof style.fontColor === 'string'
-          ? style.fontColor
+        typeof style.color === 'string'
+          ? style.color
           : resolveColor(tokens.color.primaryText, colors['gray-700']);
       const newFill = adjustColor(fill, delta);
       style.fillColor = newFill;
-      style.fontColor = ensureContrast(newFill, font);
+      style.color = ensureContrast(newFill, font);
       item.style = style;
       if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
         await (item as { sync: () => Promise<void> }).sync();

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -23,7 +23,7 @@ export const StyleTab: React.FC = () => {
   const selection = useSelection();
   const [opts, setOpts] = React.useState<StyleOptions>(() => ({
     fillColor: resolveColor(tokens.color.white, colors.white),
-    fontColor: resolveColor(tokens.color.primaryText, colors['gray-700']),
+    color: resolveColor(tokens.color.primaryText, colors['gray-700']),
     borderColor: resolveColor(tokens.color.primaryText, colors['gray-700']),
     borderWidth: 1,
     fontSize: 12,
@@ -84,12 +84,12 @@ export const StyleTab: React.FC = () => {
         />
       </InputLabel>
       <InputLabel>
-        Font color
+        Text color
         <Input
           type='color'
-          value={opts.fontColor}
-          onChange={update('fontColor')}
-          placeholder='Font color'
+          value={opts.color}
+          onChange={update('color')}
+          placeholder='Text color'
         />
       </InputLabel>
       <InputLabel>

--- a/tests/style-tools.test.ts
+++ b/tests/style-tools.test.ts
@@ -26,13 +26,13 @@ describe('style-tools', () => {
 
   test('tweakFillColor adjusts fill and font', async () => {
     const item = {
-      style: { fillColor: '#808080', fontColor: '#808080' },
+      style: { fillColor: '#808080', color: '#808080' },
       sync: jest.fn(),
     };
     const board = { getSelection: jest.fn().mockResolvedValue([item]) };
     await tweakFillColor(0.5, board);
     expect(item.style.fillColor).toBe('#c0c0c0');
-    expect(item.style.fontColor).toMatch(/^#(fff|000)/i);
+    expect(item.style.color).toMatch(/^#(fff|000)/i);
     expect(item.sync).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary
- correct styling option for text widgets
- update StyleTab to use `color` field
- adjust style-tools tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858002230f8832b92015669dbfd074f