### PR TITLE
Refactor grid to infer rows

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -86,13 +86,13 @@ Accessibility: show contrast ratio badge; warn < 4.5 : 1.
 
 ## 5  Grid Tab
 
-| Control                   | Details                          |
-| ------------------------- | -------------------------------- |
-| **Rows / Columns Inputs** | Numeric; min 1, max 20           |
-| **Gap**                   | Dropdown (`tokens.space.xs–xl`)  |
-| **Frame Title Input**     | Optional; enables frame creation |
-| **Preview Overlay**       | CSS grid lines, `opacity: 0.3`   |
-| **Group Checkbox**        | “Group items into Frame”         |
+| Control               | Details                          |
+| --------------------- | -------------------------------- |
+| **Columns Input**     | Numeric; min 1, max 20           |
+| **Gap**               | Dropdown (`tokens.space.xs–xl`)  |
+| **Frame Title Input** | Optional; enables frame creation |
+| **Preview Overlay**   | CSS grid lines, `opacity: 0.3`   |
+| **Group Checkbox**    | “Group items into Frame”         |
 
 Flow: Change value → overlay updates real‑time. Press **Arrange** creates frame
 if enabled.

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -2,8 +2,9 @@
  * Calculate grid positions and apply a grid layout to the current selection.
  */
 export interface GridOptions {
+  /** Number of columns in the grid */
   cols: number;
-  rows: number;
+  /** Gap between cells in pixels */
   padding: number;
   /** Whether to group the widgets after layout. */
   groupResult?: boolean;
@@ -38,17 +39,18 @@ function getName(item: Record<string, unknown>): string {
  */
 export function calculateGridPositions(
   opts: GridOptions,
+  count: number,
   cellWidth: number,
   cellHeight: number,
 ): Position[] {
   const positions: Position[] = [];
-  for (let r = 0; r < opts.rows; r += 1) {
-    for (let c = 0; c < opts.cols; c += 1) {
-      positions.push({
-        x: c * (cellWidth + opts.padding),
-        y: r * (cellHeight + opts.padding),
-      });
-    }
+  for (let i = 0; i < count; i += 1) {
+    const c = i % opts.cols;
+    const r = Math.floor(i / opts.cols);
+    positions.push({
+      x: c * (cellWidth + opts.padding),
+      y: r * (cellHeight + opts.padding),
+    });
   }
   return positions;
 }
@@ -64,7 +66,7 @@ export async function applyGridLayout(
 ): Promise<void> {
   const b = getBoard(board);
   const selection = await b.getSelection();
-  let items = selection.slice(0, opts.cols * opts.rows);
+  let items = selection;
   if (opts.sortByName) {
     items = [...items].sort((a, b) => getName(a).localeCompare(getName(b)));
   }
@@ -75,7 +77,12 @@ export async function applyGridLayout(
     width: number;
     height: number;
   };
-  const positions = calculateGridPositions(opts, first.width, first.height);
+  const positions = calculateGridPositions(
+    opts,
+    items.length,
+    first.width,
+    first.height,
+  );
   await Promise.all(
     items.map(async (item: Record<string, unknown>, i: number) => {
       item.x = first.x + positions[i].x;

--- a/src/ui/pages/GridTab.tsx
+++ b/src/ui/pages/GridTab.tsx
@@ -14,7 +14,6 @@ import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 export const GridTab: React.FC = () => {
   const [grid, setGrid] = React.useState<GridOptions>({
     cols: 2,
-    rows: 2,
     padding: 20,
     groupResult: false,
     sortByName: false,
@@ -22,7 +21,7 @@ export const GridTab: React.FC = () => {
   const [frameTitle, setFrameTitle] = React.useState('');
 
   const updateNumber =
-    (key: 'cols' | 'rows' | 'padding') =>
+    (key: 'cols' | 'padding') =>
     (value: string): void => {
       setGrid({ ...grid, [key]: Number(value) });
     };
@@ -53,15 +52,6 @@ export const GridTab: React.FC = () => {
           value={String(grid.cols)}
           onChange={updateNumber('cols')}
           placeholder='Columns'
-        />
-      </InputLabel>
-      <InputLabel>
-        Rows
-        <Input
-          type='number'
-          value={String(grid.rows)}
-          onChange={updateNumber('rows')}
-          placeholder='Rows'
         />
       </InputLabel>
       <InputLabel>

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -7,7 +7,8 @@ import { BoardLike } from '../src/board/board';
 describe('grid-tools', () => {
   test('calculateGridPositions computes offsets', () => {
     const positions = calculateGridPositions(
-      { cols: 2, rows: 2, padding: 5 },
+      { cols: 2, padding: 5 },
+      4,
       10,
       10,
     );
@@ -26,7 +27,7 @@ describe('grid-tools', () => {
       group: jest.fn(),
     } as BoardLike;
     await applyGridLayout(
-      { cols: 1, rows: 2, padding: 5, sortByName: true, groupResult: true },
+      { cols: 1, padding: 5, sortByName: true, groupResult: true },
       board,
     );
     // Items are sorted so 'a' is positioned first
@@ -45,7 +46,7 @@ describe('grid-tools', () => {
     const board: BoardLike = {
       getSelection: jest.fn().mockResolvedValue(items),
     };
-    await applyGridLayout({ cols: 2, rows: 1, padding: 5 }, board);
+    await applyGridLayout({ cols: 2, padding: 5 }, board);
     expect(items[1].x).toBe(15);
     expect(items[1].y).toBe(0);
   });
@@ -55,10 +56,7 @@ describe('grid-tools', () => {
       getSelection: jest.fn().mockResolvedValue([]),
       group: jest.fn(),
     };
-    await applyGridLayout(
-      { cols: 1, rows: 1, padding: 0, groupResult: true },
-      board,
-    );
+    await applyGridLayout({ cols: 1, padding: 0, groupResult: true }, board);
     expect(board.group).not.toHaveBeenCalled();
   });
 
@@ -67,16 +65,13 @@ describe('grid-tools', () => {
     const board: BoardLike = {
       getSelection: jest.fn().mockResolvedValue(items),
     };
-    await applyGridLayout(
-      { cols: 1, rows: 1, padding: 0, groupResult: true },
-      board,
-    );
+    await applyGridLayout({ cols: 1, padding: 0, groupResult: true }, board);
     expect(items[0].x).toBe(0);
   });
 
   test('applyGridLayout throws without board', async () => {
-    await expect(
-      applyGridLayout({ cols: 1, rows: 1, padding: 0 }),
-    ).rejects.toThrow('Miro board not available');
+    await expect(applyGridLayout({ cols: 1, padding: 0 })).rejects.toThrow(
+      'Miro board not available',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- compute grid rows from the selected items
- simplify UI so only columns are specified
- update grid tests and documentation

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858015a20dc832b93ebd117ef388bef