### PR TITLE
Fix grid spacing control and sorting

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -89,7 +89,7 @@ Accessibility: show contrast ratio badge; warn < 4.5 : 1.
 | Control               | Details                          |
 | --------------------- | -------------------------------- |
 | **Columns Input**     | Numeric; min 1, max 20           |
-| **Gap**               | Dropdown (`tokens.space.xs–xl`)  |
+| **Gap**               | Numeric spacing in px            |
 | **Frame Title Input** | Optional; enables frame creation |
 | **Preview Overlay**   | CSS grid lines, `opacity: 0.3`   |
 | **Group Checkbox**    | “Group items into Frame”         |

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -25,13 +25,25 @@ import { BoardLike, getBoard } from './board';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {
-  return String(
+  const rootText =
     (item as { title?: string }).title ??
-      (item as { plainText?: string }).plainText ??
-      (item as { content?: string }).content ??
-      (item as { text?: string }).text ??
-      '',
-  );
+    (item as { plainText?: string }).plainText ??
+    (item as { content?: string }).content ??
+    (item as { text?: string }).text;
+  if (typeof rootText === 'string') return rootText;
+
+  // Some widgets expose text inside an object e.g. { text: { plainText: '' } }
+  const textObj = (item as { text?: unknown }).text;
+  if (textObj && typeof textObj === 'object') {
+    const nested =
+      (textObj as { plainText?: string; content?: string; text?: string })
+        .plainText ??
+      (textObj as { plainText?: string; content?: string; text?: string })
+        .content ??
+      (textObj as { plainText?: string; content?: string; text?: string }).text;
+    if (typeof nested === 'string') return nested;
+  }
+  return '';
 }
 
 /**

--- a/src/ui/pages/GridTab.tsx
+++ b/src/ui/pages/GridTab.tsx
@@ -6,7 +6,6 @@ import {
   InputLabel,
   Icon,
   Text,
-  tokens,
 } from 'mirotone-react';
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 
@@ -30,15 +29,6 @@ export const GridTab: React.FC = () => {
     setGrid({ ...grid, [key]: !grid[key] });
   };
 
-  const gaps = [
-    { label: 'xxs', value: tokens.space.xxsmall },
-    { label: 'xs', value: tokens.space.xsmall },
-    { label: 'sm', value: tokens.space.small },
-    { label: 'md', value: tokens.space.medium },
-    { label: 'lg', value: tokens.space.large },
-    { label: 'xl', value: tokens.space.xlarge },
-  ] as const;
-
   const apply = async (): Promise<void> => {
     await applyGridLayout(grid);
   };
@@ -56,16 +46,12 @@ export const GridTab: React.FC = () => {
       </InputLabel>
       <InputLabel>
         Gap
-        <select
+        <Input
+          type='number'
           value={String(grid.padding)}
-          onChange={e => setGrid({ ...grid, padding: Number(e.target.value) })}
-        >
-          {gaps.map(g => (
-            <option key={g.label} value={g.value as unknown as number}>
-              {g.label}
-            </option>
-          ))}
-        </select>
+          onChange={updateNumber('padding')}
+          placeholder='Gap'
+        />
       </InputLabel>
       <InputLabel>
         Frame Title

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -69,6 +69,37 @@ describe('grid-tools', () => {
     expect(items[0].x).toBe(0);
   });
 
+  test('applyGridLayout sorts by nested text fields', async () => {
+    const items = [
+      {
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        sync: jest.fn(),
+        text: { plainText: 'b' },
+      },
+      {
+        x: 0,
+        y: 0,
+        width: 10,
+        height: 10,
+        sync: jest.fn(),
+        text: { plainText: 'a' },
+      },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+      group: jest.fn(),
+    };
+    await applyGridLayout(
+      { cols: 1, padding: 0, sortByName: true, groupResult: false },
+      board,
+    );
+    expect(items[0].y).toBe(10); // second item should move down
+    expect(items[1].y).toBe(0); // first item sorted up
+  });
+
   test('applyGridLayout throws without board', async () => {
     await expect(applyGridLayout({ cols: 1, padding: 0 })).rejects.toThrow(
       'Miro board not available',


### PR DESCRIPTION
## Summary
- allow nested text for grid sorting
- replace grid gap dropdown with numeric input
- update docs to reflect the change
- test nested text sort logic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_685802cd0a78832b8994fd1cf5c501e2