### PR TITLE
Add spacing layout tab

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -4,11 +4,12 @@ import { createRoot } from 'react-dom/client';
 import { ResizeTab } from '../ui/pages/ResizeTab';
 import { StyleTab } from '../ui/pages/StyleTab';
 import { GridTab } from '../ui/pages/GridTab';
+import { SpacingTab } from '../ui/pages/SpacingTab';
 import { DiagramTab } from '../ui/pages/DiagramTab';
 import { CardsTab } from '../ui/pages/CardsTab';
 import { TabBar, allTabs } from '../ui/components/TabBar';
 
-export type Tab = 'diagram' | 'cards' | 'resize' | 'style' | 'grid';
+export type Tab = 'diagram' | 'cards' | 'resize' | 'style' | 'grid' | 'spacing';
 
 /**
  * React entry component that renders the file selection and mode
@@ -37,6 +38,7 @@ export const App: React.FC = () => {
       {tab === 'resize' && <ResizeTab />}
       {tab === 'style' && <StyleTab />}
       {tab === 'grid' && <GridTab />}
+      {tab === 'spacing' && <SpacingTab />}
     </div>
   );
 };

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -1,0 +1,49 @@
+import { BoardLike, getBoard } from './board';
+
+/** Options for spacing layout. */
+export interface SpacingOptions {
+  /** Axis to distribute along: 'x' for horizontal or 'y' for vertical. */
+  axis: 'x' | 'y';
+  /** Distance between successive items in board units. */
+  spacing: number;
+}
+
+/** Compute linear offsets for a given count and spacing. */
+export function calculateSpacingOffsets(
+  count: number,
+  spacing: number,
+): number[] {
+  const offsets: number[] = [];
+  for (let i = 0; i < count; i += 1) offsets.push(i * spacing);
+  return offsets;
+}
+
+/**
+ * Distribute the current selection so each item is spaced evenly on the
+ * chosen axis. Item order is derived from their current position.
+ */
+export async function applySpacingLayout(
+  opts: SpacingOptions,
+  board?: BoardLike,
+): Promise<void> {
+  const b = getBoard(board);
+  const selection = await b.getSelection();
+  if (!selection.length) return;
+
+  const axis = opts.axis;
+  const items = [...selection].sort(
+    (a, b) =>
+      ((a as Record<string, number>)[axis] ?? 0) -
+      ((b as Record<string, number>)[axis] ?? 0),
+  );
+  const start = (items[0] as Record<string, number>)[axis] ?? 0;
+  const offsets = calculateSpacingOffsets(items.length, opts.spacing);
+  await Promise.all(
+    items.map(async (item, i) => {
+      (item as Record<string, number>)[axis] = start + offsets[i];
+      if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
+        await (item as { sync: () => Promise<void> }).sync();
+      }
+    }),
+  );
+}

--- a/src/ui/components/TabBar.tsx
+++ b/src/ui/components/TabBar.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import type { Tab } from '../../app/app';
 
-const primaryTabs: Tab[] = ['diagram', 'cards', 'resize', 'style', 'grid'];
+const primaryTabs: Tab[] = [
+  'diagram',
+  'cards',
+  'resize',
+  'style',
+  'grid',
+  'spacing',
+];
 
 export const allTabs: Tab[] = [...primaryTabs];
 

--- a/src/ui/pages/SpacingTab.tsx
+++ b/src/ui/pages/SpacingTab.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Button, Input, InputLabel, Icon, Text } from 'mirotone-react';
+import { SegmentedControl } from '../components/SegmentedControl';
+import { applySpacingLayout, SpacingOptions } from '../../board/spacing-tools';
+
+/** UI for evenly spacing selected items. */
+export const SpacingTab: React.FC = () => {
+  const [opts, setOpts] = React.useState<SpacingOptions>({
+    axis: 'x',
+    spacing: 20,
+  });
+
+  const updateAxis = (axis: string): void => {
+    if (axis === 'x' || axis === 'y') setOpts({ ...opts, axis });
+  };
+  const updateSpacing = (value: string): void => {
+    setOpts({ ...opts, spacing: Number(value) });
+  };
+
+  const apply = async (): Promise<void> => {
+    await applySpacingLayout(opts);
+  };
+
+  return (
+    <div>
+      <SegmentedControl
+        value={opts.axis}
+        onChange={updateAxis}
+        options={[
+          { label: 'Horizontal', value: 'x' },
+          { label: 'Vertical', value: 'y' },
+        ]}
+      />
+      <InputLabel>
+        Spacing
+        <Input
+          type='number'
+          value={String(opts.spacing)}
+          onChange={updateSpacing}
+          placeholder='Distance'
+        />
+      </InputLabel>
+      <div className='buttons'>
+        <Button onClick={apply} variant='primary'>
+          <React.Fragment key='.0'>
+            <Icon name='arrow-right' />
+            <Text>Distribute</Text>
+          </React.Fragment>
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -33,7 +33,7 @@ export const StyleTab: React.FC = () => {
   const [styleClipboard, setStyleClipboard] =
     React.useState<StyleOptions | null>(null);
   const preview = React.useMemo(
-    () => adjustColor(currentFill ?? opts.fillColor, adjust / 100),
+    () => adjustColor(currentFill ?? opts.fillColor ?? '#ffffff', adjust / 100),
     [adjust, currentFill, opts.fillColor],
   );
 
@@ -159,7 +159,7 @@ export const StyleTab: React.FC = () => {
           min='-100'
           max='100'
           value={String(adjust)}
-          onChange={e => setAdjust(Number(e.target.value))}
+          onChange={v => setAdjust(Number(v))}
           placeholder='Adjust (-100–100)'
         />
       </InputLabel>

--- a/tests/spacing-tools.test.ts
+++ b/tests/spacing-tools.test.ts
@@ -1,0 +1,38 @@
+import {
+  applySpacingLayout,
+  calculateSpacingOffsets,
+} from '../src/board/spacing-tools';
+import { BoardLike } from '../src/board/board';
+
+describe('spacing-tools', () => {
+  test('calculateSpacingOffsets computes positions', () => {
+    expect(calculateSpacingOffsets(3, 5)).toEqual([0, 5, 10]);
+  });
+
+  test('applySpacingLayout moves widgets horizontally', async () => {
+    const items = [
+      { x: 0, y: 0, sync: jest.fn() },
+      { x: 5, y: 0, sync: jest.fn() },
+      { x: 2, y: 0, sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+    };
+    await applySpacingLayout({ axis: 'x', spacing: 10 }, board);
+    const sorted = [...items].sort((a, b) => a.x - b.x);
+    expect(sorted.map(i => i.x)).toEqual([0, 10, 20]);
+    expect(items[0].sync).toHaveBeenCalled();
+  });
+
+  test('applySpacingLayout returns early on empty selection', async () => {
+    const board: BoardLike = { getSelection: jest.fn().mockResolvedValue([]) };
+    await applySpacingLayout({ axis: 'y', spacing: 5 }, board);
+    expect(board.getSelection).toHaveBeenCalled();
+  });
+
+  test('applySpacingLayout throws without board', async () => {
+    await expect(applySpacingLayout({ axis: 'x', spacing: 1 })).rejects.toThrow(
+      'Miro board not available',
+    );
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -5,11 +5,13 @@ import '@testing-library/jest-dom';
 import { ResizeTab } from '../src/ui/pages/ResizeTab';
 import { StyleTab } from '../src/ui/pages/StyleTab';
 import { GridTab } from '../src/ui/pages/GridTab';
+import { SpacingTab } from '../src/ui/pages/SpacingTab';
 import { DiagramTab } from '../src/ui/pages/DiagramTab';
 import { CardsTab } from '../src/ui/pages/CardsTab';
 import * as resizeTools from '../src/board/resize-tools';
 import * as styleTools from '../src/board/style-tools';
 import * as gridTools from '../src/board/grid-tools';
+import * as spacingTools from '../src/board/spacing-tools';
 import { GraphProcessor } from '../src/core/graph/GraphProcessor';
 import { CardProcessor } from '../src/board/CardProcessor';
 import { cardLoader } from '../src/core/utils/cards';
@@ -18,6 +20,7 @@ import type { CardData } from '../src/core/utils/cards';
 jest.mock('../src/board/resize-tools');
 jest.mock('../src/board/style-tools');
 jest.mock('../src/board/grid-tools');
+jest.mock('../src/board/spacing-tools');
 jest.mock('../src/core/graph/GraphProcessor');
 jest.mock('../src/board/CardProcessor');
 
@@ -106,6 +109,17 @@ describe('tab components', () => {
     render(React.createElement(GridTab));
     await act(async () => {
       fireEvent.click(screen.getByText(/arrange grid/i));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('SpacingTab applies layout', async () => {
+    const spy = jest
+      .spyOn(spacingTools, 'applySpacingLayout')
+      .mockResolvedValue(undefined as unknown as void);
+    render(React.createElement(SpacingTab));
+    await act(async () => {
+      fireEvent.click(screen.getByText(/distribute/i));
     });
     expect(spy).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- include new SpacingTab for evenly distributing selected widgets
- support spacing layout in core board utilities
- connect new tab to application tab bar
- keep style tools type safety
- test spacing layout logic and UI

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68580662d5a0832b91171a552214c115