### PR TITLE
Fix spacing layout to use edge spacing

### DIFF
--- a/tests/spacing-tools.test.ts
+++ b/tests/spacing-tools.test.ts
@@ -9,19 +9,31 @@ describe('spacing-tools', () => {
     expect(calculateSpacingOffsets(3, 5)).toEqual([0, 5, 10]);
   });
 
-  test('applySpacingLayout moves widgets horizontally', async () => {
+  test('applySpacingLayout spaces widgets horizontally by edges', async () => {
     const items = [
-      { x: 0, y: 0, sync: jest.fn() },
-      { x: 5, y: 0, sync: jest.fn() },
-      { x: 2, y: 0, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, sync: jest.fn() },
+      { x: 0, y: 0, width: 20, sync: jest.fn() },
+      { x: 0, y: 0, width: 10, sync: jest.fn() },
     ];
     const board: BoardLike = {
       getSelection: jest.fn().mockResolvedValue(items),
     };
-    await applySpacingLayout({ axis: 'x', spacing: 10 }, board);
-    const sorted = [...items].sort((a, b) => a.x - b.x);
-    expect(sorted.map(i => i.x)).toEqual([0, 10, 20]);
+    await applySpacingLayout({ axis: 'x', spacing: 5 }, board);
+    expect(items.map(i => i.x)).toEqual([0, 20, 40]);
     expect(items[0].sync).toHaveBeenCalled();
+  });
+
+  test('applySpacingLayout spaces widgets vertically by edges', async () => {
+    const items = [
+      { x: 0, y: 0, height: 10, sync: jest.fn() },
+      { x: 0, y: 0, height: 20, sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+    };
+    await applySpacingLayout({ axis: 'y', spacing: 3 }, board);
+    expect(items.map(i => i.y)).toEqual([0, 18]);
+    expect(items[1].sync).toHaveBeenCalled();
   });
 
   test('applySpacingLayout returns early on empty selection', async () => {


### PR DESCRIPTION
## Summary
- space widgets between edges instead of equal x values
- test spacing on both axes

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_68588ef931c4832b989356614d17a9ed