### PR TITLE
Refactor spacing tools

### DIFF
--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -22,7 +22,9 @@ export function calculateSpacingOffsets(
  * Distribute the current selection so each item is spaced evenly on the
  * chosen axis. Spacing is measured between the outer edges of each
  * widget so items with different dimensions maintain the same gap.
- * Item order is derived from their current position.
+ * Item order is derived from their current position. Every widget is
+ * synchronised immediately after its coordinates are updated so the
+ * board reflects the new layout.
  */
 export async function applySpacingLayout(
   opts: SpacingOptions,
@@ -59,11 +61,25 @@ export async function applySpacingLayout(
   }
 }
 
+/**
+ * Safely retrieve a numeric dimension from a widget.
+ *
+ * @param item - Widget instance.
+ * @param key - Dimension property name ('width' or 'height').
+ * @returns The numeric value or `0` when unavailable.
+ */
 function getDimension(item: Record<string, number>, key: string): number {
   const val = item[key];
   return typeof val === 'number' ? val : 0;
 }
 
+/**
+ * Move a widget along one axis and sync it with the board.
+ *
+ * @param item - The widget to update.
+ * @param axis - Axis to modify ('x' or 'y').
+ * @param position - New coordinate value.
+ */
 async function moveWidget(
   item: Record<string, number> & { sync?: () => Promise<void> },
   axis: 'x' | 'y',

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -41,12 +41,8 @@ export async function applySpacingLayout(
   );
 
   let pos = (items[0] as Record<string, number>)[axis] ?? 0;
-  const tasks: Array<Promise<void>> = [];
   (items[0] as Record<string, number>)[axis] = pos;
-  const firstSync = (items[0] as { sync?: () => Promise<void> }).sync;
-  if (typeof firstSync === 'function') {
-    tasks.push(firstSync());
-  }
+  await (items[0] as { sync?: () => Promise<void> }).sync?.();
 
   for (let i = 1; i < items.length; i += 1) {
     const prev = items[i - 1] as Record<string, number>;
@@ -57,10 +53,6 @@ export async function applySpacingLayout(
       typeof curr[sizeKey] === 'number' ? (curr[sizeKey] as number) : 0;
     pos = pos + prevSize / 2 + opts.spacing + currSize / 2;
     curr[axis] = pos;
-    const syncFn = (curr as { sync?: () => Promise<void> }).sync;
-    if (typeof syncFn === 'function') {
-      tasks.push(syncFn());
-    }
+    await (curr as { sync?: () => Promise<void> }).sync?.();
   }
-  await Promise.all(tasks);
 }


### PR DESCRIPTION
## Summary
- run selection syncs sequentially in `spacing-tools`
- inline sync calls for direct invocation

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685896bc242c832baa13786f004a3441