### PR TITLE
Improve style tab UI and layout

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -65,22 +65,14 @@ viewport”). Shortcut: **⌥C** copies size, **⌥V** applies.
 
 ## 4  Style Tab
 
-Layout: two‑column Grid (`cs1 ce7` colour, `cs7 ce13` border/text).
+Layout: single column Stack.
 
-### 4.1  Colour Panel
+- **Brightness Slider** (−100 %–100 %) – down/up arrow changes by 1 %.
+- Numeric input mirrors slider value.
+- **Apply** button calls `tweakFillColor` with the selected adjustment.
 
-- **Current Fill Swatch** (live)
-- **Brightness Slider** (0 %–150 %) – down/up arrow changes by 1 %.
-- **Copy Style** button → stores `styleClipboard`.
-- **Apply Style** button (disabled if clipboard empty).
-
-### 4.2  Border & Text Panel
-
-- Dropdown Border Style: None, Solid 1‑4 px, Dashed.
-- Border Colour picker (token palette).
-- Text Size dropdown: 10 – 48 pt.
-
-Accessibility: show contrast ratio badge; warn < 4.5 : 1.
+This tab no longer exposes border or text options; use native Miro style tools
+instead.
 
 ---
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -9,7 +9,7 @@
 
 html,
 body {
-  height: unset;
+  height: 100%;
   background: none;
 }
 
@@ -71,7 +71,12 @@ body {
 }
 
 .tabs-header-list {
+  display: flex;
   flex-wrap: wrap;
+}
+
+.tabs-header-list .tab {
+  flex: 0 0 auto;
 }
 
 button {

--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -1,7 +1,5 @@
 /**
- * Helper utilities for applying style properties to all currently selected
- * widgets on the board. Each property is optional and merged into the widget
- * style object.
+ * Colour manipulation utilities for the currently selected widgets.
  */
 import { tokens } from '../ui/tokens';
 import { colors } from '@mirohq/design-tokens';
@@ -11,54 +9,6 @@ import {
   resolveColor,
 } from '../core/utils/color-utils';
 import { BoardLike, getBoard } from './board';
-
-export interface StyleOptions {
-  /** Text color for supported widgets */
-  color?: string;
-  fillColor?: string;
-  borderColor?: string;
-  borderWidth?: number;
-  fontSize?: number;
-}
-
-/** Get the fill colour of the first selected widget. */
-export async function getFillColorFromSelection(
-  board?: BoardLike,
-): Promise<string | null> {
-  const b = getBoard(board);
-  const selection = await b.getSelection();
-  const first = selection[0] as { style?: { fillColor?: string } } | undefined;
-  return first?.style?.fillColor ?? null;
-}
-
-/**
- * Apply the provided style options to every selected widget.
- *
- * @param opts - Style attributes to merge into each widget's style object.
- * @param board - Optional board API used for testing.
- */
-export async function applyStyleToSelection(
-  opts: StyleOptions,
-  board?: BoardLike,
-): Promise<void> {
-  const b = getBoard(board);
-  const selection = await b.getSelection();
-  await Promise.all(
-    selection.map(async (item: Record<string, unknown>) => {
-      const style = (item.style ?? {}) as Record<string, unknown>;
-      Object.entries(opts).forEach(([k, v]) => {
-        let fallback = String(v);
-        if (v === tokens.color.white) fallback = colors.white;
-        if (v === tokens.color.primaryText) fallback = colors['gray-700'];
-        style[k] = typeof v === 'string' ? resolveColor(v, fallback) : v;
-      });
-      item.style = style;
-      if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-        await (item as { sync: () => Promise<void> }).sync();
-      }
-    }),
-  );
-}
 
 /**
  * Lighten or darken the fill colour of all selected widgets ensuring the

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,135 +1,16 @@
 import React from 'react';
-import {
-  Button,
-  Icon,
-  Input,
-  Text,
-  InputLabel,
-  Paragraph,
-} from '../components/legacy';
-import { tokens } from '../tokens';
-import { colors } from '@mirohq/design-tokens';
-import { adjustColor, resolveColor } from '../../core/utils/color-utils';
-import {
-  applyStyleToSelection,
-  StyleOptions,
-  getFillColorFromSelection,
-  tweakFillColor,
-} from '../../board/style-tools';
-import { useSelection } from '../hooks/useSelection';
-
+import { Button, Icon, Input, Text, InputLabel } from '../components/legacy';
+import { tweakFillColor } from '../../board/style-tools';
 import type { TabTuple } from './tab-definitions';
-/** UI for the Style tab. */
+
+/** Adjusts the fill colour of selected widgets. */
 export const StyleTab: React.FC = () => {
-  const selection = useSelection();
-  const [opts, setOpts] = React.useState<StyleOptions>(() => ({
-    fillColor: resolveColor(tokens.color.white, colors.white ?? '#ffffff'),
-    color: resolveColor(
-      tokens.color.primaryText,
-      colors['gray-700'] ?? '#595959',
-    ),
-    borderColor: resolveColor(
-      tokens.color.primaryText,
-      colors['gray-700'] ?? '#595959',
-    ),
-    borderWidth: 1,
-    fontSize: 12,
-  }));
   const [adjust, setAdjust] = React.useState(0);
-  const [currentFill, setCurrentFill] = React.useState<string | null>(null);
-  const [styleClipboard, setStyleClipboard] =
-    React.useState<StyleOptions | null>(null);
-  const preview = React.useMemo(
-    () => adjustColor(currentFill ?? opts.fillColor ?? '#ffffff', adjust / 100),
-    [adjust, currentFill, opts.fillColor],
-  );
-
-  const update =
-    (key: keyof StyleOptions) =>
-    (value: string): void => {
-      setOpts({
-        ...opts,
-        [key]:
-          key === 'borderWidth' || key === 'fontSize' ? Number(value) : value,
-      });
-    };
-
   const apply = async (): Promise<void> => {
-    const target = styleClipboard ?? opts;
-    await applyStyleToSelection(target);
-    setAdjust(0);
-    await copyColor();
-  };
-
-  const copyColor = async (): Promise<void> => {
-    const color = await getFillColorFromSelection();
-    if (color) {
-      const hex = resolveColor(color, color);
-      setCurrentFill(hex);
-      setOpts({ ...opts, fillColor: hex });
-    }
-  };
-
-  const copyStyle = (): void => {
-    setStyleClipboard({ ...opts });
-  };
-
-  const applyAdjust = async (): Promise<void> => {
     await tweakFillColor(adjust / 100);
-    await copyColor();
   };
-
-  React.useEffect(() => {
-    void copyColor();
-  }, [selection]);
-
   return (
     <div>
-      <InputLabel>
-        Fill color
-        <Input
-          type='color'
-          value={opts.fillColor}
-          onChange={update('fillColor')}
-          placeholder='Fill color'
-        />
-      </InputLabel>
-      <InputLabel>
-        Text color
-        <Input
-          type='color'
-          value={opts.color}
-          onChange={update('color')}
-          placeholder='Text color'
-        />
-      </InputLabel>
-      <InputLabel>
-        Border color
-        <Input
-          type='color'
-          value={opts.borderColor}
-          onChange={update('borderColor')}
-          placeholder='Border color'
-        />
-      </InputLabel>
-      <InputLabel>
-        Border width
-        <Input
-          type='number'
-          value={String(opts.borderWidth)}
-          onChange={update('borderWidth')}
-          placeholder='Border width'
-        />
-      </InputLabel>
-      <InputLabel>
-        Font size
-        <Input
-          type='number'
-          value={String(opts.fontSize)}
-          onChange={update('fontSize')}
-          placeholder='Font size'
-        />
-      </InputLabel>
       <InputLabel>
         Adjust fill
         <input
@@ -140,17 +21,6 @@ export const StyleTab: React.FC = () => {
           list='adjust-marks'
           value={adjust}
           onChange={e => setAdjust(Number(e.target.value))}
-          onKeyDown={e => {
-            if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
-              e.preventDefault();
-              setAdjust(a =>
-                Math.min(
-                  100,
-                  Math.max(-100, a + (e.key === 'ArrowUp' ? 1 : -1)),
-                ),
-              );
-            }
-          }}
         />
         <datalist id='adjust-marks'>
           {[-100, -50, 0, 50, 100].map(n => (
@@ -170,56 +40,22 @@ export const StyleTab: React.FC = () => {
           placeholder='Adjust (-100–100)'
         />
       </InputLabel>
-      <Button onClick={applyAdjust} variant='secondary'>
-        <React.Fragment key='.0'>
-          <Icon name='parameters' />
-          <Text>Adjust</Text>
-        </React.Fragment>
-      </Button>
-      <React.Fragment>
-        <Paragraph data-testid='current-fill'>
-          Current fill: {currentFill ?? opts.fillColor}
-        </Paragraph>
-        <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-          <Paragraph data-testid='preview-text'>Preview: {preview}</Paragraph>
-          <div
-            data-testid='fill-preview'
-            style={{
-              width: '24px',
-              height: '24px',
-              border: '1px solid #000',
-              backgroundColor: preview,
-            }}
-          />
-        </div>
-      </React.Fragment>
       <div className='buttons'>
-        <Button onClick={copyStyle} variant='secondary'>
-          <React.Fragment key='.0'>
-            <Icon name='duplicate' />
-            <Text>Copy Style</Text>
-          </React.Fragment>
-        </Button>
         <Button onClick={apply} variant='primary'>
-          <React.Fragment key='.0'>
-            <Icon name='arrow-right' />
-            <Text>Apply Style</Text>
-          </React.Fragment>
-        </Button>
-        <Button onClick={copyColor} variant='secondary'>
-          <React.Fragment key='.0'>
-            <Icon name='duplicate' />
-            <Text>Copy Fill</Text>
+          <React.Fragment>
+            <Icon name='parameters' />
+            <Text>Apply</Text>
           </React.Fragment>
         </Button>
       </div>
     </div>
   );
 };
+
 export const styleTabDef: TabTuple = [
   4,
   'style',
-  'Style',
-  'Modify color and typography of selected shapes',
+  'Colour Adjust',
+  'Lighten or darken the fill colour of selected shapes',
   StyleTab,
 ];

--- a/tests/style-tools.test.ts
+++ b/tests/style-tools.test.ts
@@ -1,29 +1,6 @@
-import {
-  applyStyleToSelection,
-  getFillColorFromSelection,
-  tweakFillColor,
-} from '../src/board/style-tools';
+import { tweakFillColor } from '../src/board/style-tools';
 
 describe('style-tools', () => {
-  test('applyStyleToSelection merges style', async () => {
-    const item = { style: {}, sync: jest.fn() };
-    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
-    await applyStyleToSelection({ fillColor: '#f00', fontSize: 12 }, board);
-    expect(item.style.fillColor).toBe('#f00');
-    expect(item.style.fontSize).toBe(12);
-    expect(item.sync).toHaveBeenCalled();
-  });
-
-  test('getFillColorFromSelection returns colour', async () => {
-    const board = {
-      getSelection: jest
-        .fn()
-        .mockResolvedValue([{ style: { fillColor: '#abc' } }]),
-    };
-    const color = await getFillColorFromSelection(board);
-    expect(color).toBe('#abc');
-  });
-
   test('tweakFillColor adjusts fill and font', async () => {
     const item = {
       style: { fillColor: '#808080', color: '#808080' },
@@ -34,18 +11,6 @@ describe('style-tools', () => {
     expect(item.style.fillColor).toBe('#c0c0c0');
     expect(item.style.color).toMatch(/^#(fff|000)/i);
     expect(item.sync).toHaveBeenCalled();
-  });
-
-  test('getFillColorFromSelection throws without board', async () => {
-    await expect(getFillColorFromSelection()).rejects.toThrow(
-      'Miro board not available',
-    );
-  });
-
-  test('applyStyleToSelection throws without board', async () => {
-    await expect(applyStyleToSelection({ fillColor: '#fff' })).rejects.toThrow(
-      'Miro board not available',
-    );
   });
 
   test('tweakFillColor throws without board', async () => {

--- a/tests/tabbar.test.tsx
+++ b/tests/tabbar.test.tsx
@@ -22,7 +22,5 @@ test('Ctrl+Alt+4 selects Style tab', async () => {
   await act(async () => {
     fireEvent.keyDown(window, { key: '4', ctrlKey: true, altKey: true });
   });
-  expect(
-    screen.getByRole('button', { name: /apply style/i }),
-  ).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument();
 });

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -73,33 +73,28 @@ describe('tab components', () => {
     expect(screen.getByText(/copy size/i)).toBeInTheDocument();
   });
 
-  test('StyleTab applies style', async () => {
+  test('StyleTab tweaks fill colour', async () => {
     const spy = jest
-      .spyOn(styleTools, 'applyStyleToSelection')
+      .spyOn(styleTools, 'tweakFillColor')
       .mockResolvedValue(undefined as unknown as void);
     render(React.createElement(StyleTab));
-    fireEvent.change(screen.getByPlaceholderText(/fill color/i), {
-      target: { value: '#f00' },
+    fireEvent.change(screen.getByTestId('adjust-input'), {
+      target: { value: '20' },
     });
     await act(async () => {
-      fireEvent.click(screen.getByText(/apply style/i));
+      fireEvent.click(screen.getByRole('button', { name: /apply/i }));
     });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(0.2);
   });
 
-  test('StyleTab updates preview on adjustment', async () => {
+  test('StyleTab syncs slider and input', async () => {
     render(React.createElement(StyleTab));
     const slider = screen.getByTestId('adjust-slider');
     await act(async () => {
-      fireEvent.change(slider, { target: { value: '20' } });
+      fireEvent.change(slider, { target: { value: '30' } });
     });
     const input = screen.getByTestId('adjust-input') as HTMLInputElement;
-    expect(input.value).toBe('20');
-    const preview = screen.getByTestId('fill-preview');
-    expect(preview).toHaveStyle({ backgroundColor: '#ffffff' });
-    expect(screen.getByTestId('preview-text')).toHaveTextContent(
-      'Preview: #ffffff',
-    );
+    expect(input.value).toBe('30');
   });
 
   test('GridTab applies layout', async () => {


### PR DESCRIPTION
## Summary
- fix height to enable scrollable content
- allow tab bar to wrap without stretching each tab
- remove style copy functions and preview
- focus style tab on adjusting fill colour only
- update tests and docs for streamlined Style tab

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858a25d784c832b895d9dcb61a300bf