### PR TITLE
Merge diagram and cards into a new Create tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,15 @@ a diagram on a Miro board. The application uses the **Eclipse Layout Kernel
 templates and each element can carry metadata that controls its appearance and
 placement.
 
-## Uploading JSON Graphs
+## Uploading JSON Content
 
 1. Click the app icon on your Miro board.
-2. Select a `.json` file containing `nodes` and `edges`.
-3. After the file uploads the ELK layout engine positions the elements and the
-   board is populated with the resulting shapes.
-
-## Importing Cards from JSON
-
-1. In the panel choose **Cards** mode.
-2. Select a `.json` file containing an object with a `cards` array.
-3. Each entry should provide an optional `id` to update existing cards along
-   with the card `title` and optional `description`, `tags`, `style` and
-   `fields` values. Matching tags are looked up on the board.
-4. See [`tests/fixtures/sample-cards.json`](tests/fixtures/sample-cards.json)
-   for an example format.
+2. In the **Create** tab choose whether to import a diagram or cards.
+3. Select a `.json` file. Diagrams require `nodes` and `edges` while the cards
+   option expects an object with a `cards` array.
+4. Once processed, widgets are placed on the board using the selected mode.
+5. See [`tests/fixtures/sample-cards.json`](tests/fixtures/sample-cards.json)
+   for a cards format example.
 
 ## ELK Layout
 

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -20,29 +20,17 @@ ambiguity.
 
 ---
 
-## 1  Diagram Tab
+## 1  Create Tab
 
-| Step | UI Element                               | Copy (EN‑AU)                                            | Interaction Flow                                                  | State Store    |
-| ---- | ---------------------------------------- | ------------------------------------------------------- | ----------------------------------------------------------------- | -------------- |
-| 1    | `<DropZone>` area (Stack `space="md"`)   | “Drag a .json / .csv / .mmd file or paste Mermaid code” | Drag file → highlight border; on drop validate                    | `importQueue`  |
-| 2    | `<Table>` preview (`DataGrid`)           | Column headers: **Node**, **Edge**, **Status**          | Rows auto‑populate; invalid rows coloured `tokens.color.red[600]` | `previewRows`  |
-| 3    | `<SegmentedControl>` (Layered/Tree/Grid) | –                                                       | Select layout type; updates helper description                    | `layoutChoice` |
-| 4    | `<Button variant="primary">`             | “Build diagram”                                         | Disabled until `previewRows.every(row.valid)`                     | –              |
-| 5    | `<Toast>` success                        | “Diagram created – Press ⌘Z to undo”                    | Shows 5 s then fades                                              | –              |
+| Step | UI Element               | Copy (EN‑AU)           | Interaction Flow                               | State Store   |
+| ---- | ------------------------ | ---------------------- | ---------------------------------------------- | ------------- |
+| 1    | `<Select>` mode dropdown | –                      | Choose **Diagram** or **Cards** mode           | `createMode`  |
+| 2    | `<DropZone>` area        | "Drag a .json file"    | Drag file → highlight border; on drop validate | `importQueue` |
+| 3    | Diagram mode options     | as per old Diagram tab | Layout settings + build button                 | –             |
+| 4    | Cards mode options       | as per old Cards tab   | Search, tag filter and create button           | –             |
 
-**Tooltip for invalid row** – “Edge refers to missing node ‘%id%’.” Shortcut:
-**⌘/** toggles Advanced Options panel.
-
----
-
-## 2  Cards Tab
-
-| UI Element                                  | Copy                                 | Interaction Flow                                         | State Store   |
-| ------------------------------------------- | ------------------------------------ | -------------------------------------------------------- | ------------- |
-| `<SearchInput placeholder="Search cards…">` | –                                    | Type → debounced 300 ms filter                           | `cardSearch`  |
-| `<TagChips>` filter row (virtual scroll)    | Tag names                            | Click chip toggles filter; multi‑select allowed          | `cardFilters` |
-| `<VirtualisedList>` of CardTiles            | Each tile shows 64×64 preview + name | Drag tile → board; on drop call `BoardBuilder.placeCard` | –             |
-| **Undo chip** (floating)                    | “Undo import (⌘Z)”                   | Appears for 3s after drop                                | –             |
+**Tooltip for invalid row** – "Edge refers to missing node '‘%id%’.'" Shortcut:
+**⌘/** toggles Advanced Options panel when in Diagram mode.
 
 ---
 

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -12,7 +12,6 @@ import {
 import { tokens } from '../tokens';
 import { CardProcessor } from '../../board/CardProcessor';
 import { cardLoader, CardData } from '../../core/utils/cards';
-import type { TabTuple } from './tab-definitions';
 import { showError } from '../hooks/notifications';
 import { getDropzoneStyle, undoLastImport } from '../hooks/ui-utils';
 
@@ -239,10 +238,3 @@ export const CardsTab: React.FC = () => {
     </div>
   );
 };
-export const cardsTabDef: TabTuple = [
-  2,
-  'cards',
-  'Cards',
-  'Select the JSON file to import a list of cards',
-  CardsTab,
-];

--- a/src/ui/pages/CreateTab.tsx
+++ b/src/ui/pages/CreateTab.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Select, SelectOption, InputLabel } from '../components/legacy';
+import { DiagramTab } from './DiagramTab';
+import { CardsTab } from './CardsTab';
+import type { TabTuple } from './tab-definitions';
+
+/**
+ * Allows users to choose between diagram or cards import.
+ */
+export const CreateTab: React.FC = () => {
+  const [mode, setMode] = React.useState<'diagram' | 'cards'>('diagram');
+  return (
+    <div>
+      <InputLabel>
+        Create mode
+        <Select value={mode} onChange={v => setMode(v as 'diagram' | 'cards')}>
+          <SelectOption value='diagram'>Diagram</SelectOption>
+          <SelectOption value='cards'>Cards</SelectOption>
+        </Select>
+      </InputLabel>
+      {mode === 'diagram' ? <DiagramTab /> : <CardsTab />}
+    </div>
+  );
+};
+
+export const createTabDef: TabTuple = [
+  1,
+  'create',
+  'Create',
+  'Import diagrams or cards from JSON',
+  CreateTab,
+];

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -14,7 +14,6 @@ import {
 import { tokens } from '../tokens';
 import { SegmentedControl } from '../components/SegmentedControl';
 import { GraphProcessor } from '../../core/graph/GraphProcessor';
-import type { TabTuple } from './tab-definitions';
 import { showError } from '../hooks/notifications';
 import {
   ALGORITHMS,
@@ -251,10 +250,3 @@ export const DiagramTab: React.FC = () => {
     </div>
   );
 };
-export const diagramTabDef: TabTuple = [
-  1,
-  'diagram',
-  'Diagram',
-  'Select the JSON file to import a diagram',
-  DiagramTab,
-];

--- a/src/ui/pages/GridTab.tsx
+++ b/src/ui/pages/GridTab.tsx
@@ -84,7 +84,7 @@ export const GridTab: React.FC = () => {
   );
 };
 export const gridTabDef: TabTuple = [
-  5,
+  4,
   'grid',
   'Grid',
   'Arrange selected items into a grid',

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -151,7 +151,7 @@ export const ResizeTab: React.FC = () => {
   );
 };
 export const resizeTabDef: TabTuple = [
-  3,
+  2,
   'resize',
   'Resize',
   'Adjust size manually or copy from selection',

--- a/src/ui/pages/SpacingTab.tsx
+++ b/src/ui/pages/SpacingTab.tsx
@@ -53,7 +53,7 @@ export const SpacingTab: React.FC = () => {
   );
 };
 export const spacingTabDef: TabTuple = [
-  6,
+  5,
   'spacing',
   'Spacing',
   'Distribute items evenly',

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -53,7 +53,7 @@ export const StyleTab: React.FC = () => {
 };
 
 export const styleTabDef: TabTuple = [
-  4,
+  3,
   'style',
   'Colour Adjust',
   'Lighten or darken the fill colour of selected shapes',

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -1,12 +1,6 @@
 import type React from 'react';
 
-export type TabId =
-  | 'diagram'
-  | 'cards'
-  | 'resize'
-  | 'style'
-  | 'grid'
-  | 'spacing';
+export type TabId = 'create' | 'resize' | 'style' | 'grid' | 'spacing';
 
 export type TabTuple = readonly [
   order: number,

--- a/src/ui/pages/tabs.ts
+++ b/src/ui/pages/tabs.ts
@@ -1,14 +1,12 @@
 import type { TabTuple, TabId } from './tab-definitions';
-import { diagramTabDef } from './DiagramTab';
-import { cardsTabDef } from './CardsTab';
+import { createTabDef } from './CreateTab';
 import { resizeTabDef } from './ResizeTab';
 import { styleTabDef } from './StyleTab';
 import { gridTabDef } from './GridTab';
 import { spacingTabDef } from './SpacingTab';
 
 export const TAB_DATA: TabTuple[] = [
-  diagramTabDef,
-  cardsTabDef,
+  createTabDef,
   resizeTabDef,
   styleTabDef,
   gridTabDef,

--- a/tests/app-ui-options.test.ts
+++ b/tests/app-ui-options.test.ts
@@ -46,7 +46,9 @@ describe('App layout options and undo button', () => {
 
   test('hides layout options in cards mode', () => {
     render(React.createElement(App));
-    fireEvent.click(screen.getByRole('tab', { name: /cards/i }));
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'cards' },
+    });
     expect(screen.queryByLabelText('Algorithm')).toBeNull();
     expect(screen.queryByLabelText('Direction')).toBeNull();
     expect(screen.queryByLabelText('Spacing')).toBeNull();

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -58,7 +58,9 @@ describe('App UI integration', () => {
       .spyOn(CardProcessor.prototype, 'processFile')
       .mockResolvedValue(undefined);
     render(React.createElement(App));
-    fireEvent.click(screen.getByRole('tab', { name: /cards/i }));
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'cards' },
+    });
     await act(async () => {
       selectFile();
     });
@@ -69,16 +71,11 @@ describe('App UI integration', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  test('mode radio buttons change description text', () => {
+  test('mode dropdown switches value', () => {
     render(React.createElement(App));
-    fireEvent.click(screen.getByRole('tab', { name: /cards/i }));
-    expect(
-      screen.getByText(/select the json file to import a list of cards/i),
-    ).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('tab', { name: /diagram/i }));
-    expect(
-      screen.getByText(/select the json file to import a diagram/i),
-    ).toBeInTheDocument();
+    const combo = screen.getByRole('combobox');
+    fireEvent.change(combo, { target: { value: 'cards' } });
+    expect(combo).toHaveValue('cards');
   });
 
   test('dropzone has accessibility attributes', () => {

--- a/tests/create-tab.test.tsx
+++ b/tests/create-tab.test.tsx
@@ -1,0 +1,56 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CreateTab } from '../src/ui/pages/CreateTab';
+import { GraphProcessor } from '../src/core/graph/GraphProcessor';
+import { CardProcessor } from '../src/board/CardProcessor';
+
+jest.mock('../src/core/graph/GraphProcessor');
+jest.mock('../src/board/CardProcessor');
+
+describe('CreateTab', () => {
+  beforeEach(() => {
+    (globalThis as any).miro = { board: { ui: { on: jest.fn() } } };
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).miro;
+    jest.clearAllMocks();
+  });
+
+  test('processes diagram file', async () => {
+    const spy = jest
+      .spyOn(GraphProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<CreateTab />);
+    const input = screen.getByTestId('file-input');
+    const file = new File(['{}'], 'graph.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create diagram/i }));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('processes cards file', async () => {
+    const spy = jest
+      .spyOn(CardProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<CreateTab />);
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'cards' },
+    });
+    const input = screen.getByTestId('file-input');
+    const file = new File(['{}'], 'cards.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create cards/i }));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/tabbar.test.tsx
+++ b/tests/tabbar.test.tsx
@@ -17,10 +17,10 @@ afterEach(() => {
   delete (globalThis as { miro?: unknown }).miro;
 });
 
-test('Ctrl+Alt+4 selects Style tab', async () => {
+test('Ctrl+Alt+3 selects Style tab', async () => {
   render(<App />);
   await act(async () => {
-    fireEvent.keyDown(window, { key: '4', ctrlKey: true, altKey: true });
+    fireEvent.keyDown(window, { key: '3', ctrlKey: true, altKey: true });
   });
   expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- combine Diagram and Cards tabs into a single Create tab
- update tab ordering and definitions
- document the Create tab in README and design docs
- adapt tests to new Create tab

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858a915b8d4832bab4f7849686e3cde