### PR TITLE
Add spacing growth mode

### DIFF
--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -6,6 +6,12 @@ export interface SpacingOptions {
   axis: 'x' | 'y';
   /** Distance between successive items in board units. */
   spacing: number;
+  /**
+   * Layout mode:
+   * - `move` keeps widget sizes and changes positions.
+   * - `grow` expands all widgets equally so outer edges remain fixed.
+   */
+  mode?: 'move' | 'grow';
 }
 
 /** Compute linear offsets for a given count and spacing. */
@@ -16,6 +22,28 @@ export function calculateSpacingOffsets(
   const offsets: number[] = [];
   for (let i = 0; i < count; i += 1) offsets.push(i * spacing);
   return offsets;
+}
+
+/** Plan widget positions and size when distributing by growth. */
+export function calculateGrowthPlan(
+  items: Array<Record<string, number>>,
+  axis: 'x' | 'y',
+  spacing: number,
+): { size: number; positions: number[] } {
+  const sizeKey = axis === 'x' ? 'width' : 'height';
+  const first = items[0];
+  const last = items[items.length - 1];
+  const startEdge = (first[axis] ?? 0) - getDimension(first, sizeKey) / 2;
+  const endEdge = (last[axis] ?? 0) + getDimension(last, sizeKey) / 2;
+  const total = endEdge - startEdge;
+  const size = (total - spacing * (items.length - 1)) / items.length;
+  const positions: number[] = [];
+  let pos = startEdge + size / 2;
+  for (let i = 0; i < items.length; i += 1) {
+    positions.push(pos);
+    pos += size + spacing;
+  }
+  return { size, positions };
 }
 
 /**
@@ -40,7 +68,19 @@ export async function applySpacingLayout(
     (a, b) =>
       ((a as Record<string, number>)[axis] ?? 0) -
       ((b as Record<string, number>)[axis] ?? 0),
-  );
+  ) as Array<Record<string, number> & { sync?: () => Promise<void> }>;
+  const mode = opts.mode ?? 'move';
+  if (mode === 'grow') {
+    const plan = calculateGrowthPlan(items, axis, opts.spacing);
+    await Promise.all(
+      items.map(async (item, i) => {
+        item[sizeKey] = plan.size;
+        item[axis] = plan.positions[i];
+        await item.sync?.();
+      }),
+    );
+    return;
+  }
 
   let position = (items[0] as Record<string, number>)[axis] ?? 0;
   await moveWidget(

--- a/src/ui/pages/SpacingTab.tsx
+++ b/src/ui/pages/SpacingTab.tsx
@@ -9,6 +9,7 @@ export const SpacingTab: React.FC = () => {
   const [opts, setOpts] = React.useState<SpacingOptions>({
     axis: 'x',
     spacing: 20,
+    mode: 'move',
   });
 
   const updateAxis = (axis: string): void => {
@@ -16,6 +17,9 @@ export const SpacingTab: React.FC = () => {
   };
   const updateSpacing = (value: string): void => {
     setOpts({ ...opts, spacing: Number(value) });
+  };
+  const updateMode = (mode: string): void => {
+    if (mode === 'move' || mode === 'grow') setOpts({ ...opts, mode });
   };
 
   const apply = async (): Promise<void> => {
@@ -30,6 +34,14 @@ export const SpacingTab: React.FC = () => {
         options={[
           { label: 'Horizontal', value: 'x' },
           { label: 'Vertical', value: 'y' },
+        ]}
+      />
+      <SegmentedControl
+        value={opts.mode ?? 'move'}
+        onChange={updateMode}
+        options={[
+          { label: 'Move', value: 'move' },
+          { label: 'Expand', value: 'grow' },
         ]}
       />
       <InputLabel>

--- a/tests/create-tab.test.tsx
+++ b/tests/create-tab.test.tsx
@@ -11,10 +11,12 @@ jest.mock('../src/board/CardProcessor');
 
 describe('CreateTab', () => {
   beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).miro = { board: { ui: { on: jest.fn() } } };
   });
 
   afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).miro;
     jest.clearAllMocks();
   });

--- a/tests/spacing-tools.test.ts
+++ b/tests/spacing-tools.test.ts
@@ -23,6 +23,33 @@ describe('spacing-tools', () => {
     expect(items[0].sync).toHaveBeenCalled();
   });
 
+  test('applySpacingLayout grows widgets horizontally', async () => {
+    const items = [
+      { x: 0, y: 0, width: 10, sync: jest.fn() },
+      { x: 30, y: 0, width: 20, sync: jest.fn() },
+      { x: 60, y: 0, width: 10, sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+    };
+    await applySpacingLayout({ axis: 'x', spacing: 5, mode: 'grow' }, board);
+    expect(items.map(i => i.width)).toEqual([20, 20, 20]);
+    expect(items.map(i => i.x)).toEqual([5, 30, 55]);
+  });
+
+  test('applySpacingLayout grows widgets vertically', async () => {
+    const items = [
+      { x: 0, y: 0, height: 10, sync: jest.fn() },
+      { x: 0, y: 30, height: 20, sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+    };
+    await applySpacingLayout({ axis: 'y', spacing: 5, mode: 'grow' }, board);
+    expect(items.map(i => i.height)).toEqual([20, 20]);
+    expect(items.map(i => i.y)).toEqual([5, 30]);
+  });
+
   test('applySpacingLayout spaces widgets vertically by edges', async () => {
     const items = [
       { x: 0, y: 0, height: 10, sync: jest.fn() },

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -123,10 +123,13 @@ describe('tab components', () => {
       .spyOn(spacingTools, 'applySpacingLayout')
       .mockResolvedValue(undefined as unknown as void);
     render(React.createElement(SpacingTab));
+    fireEvent.click(screen.getByText('Expand'));
     await act(async () => {
       fireEvent.click(screen.getByText(/distribute/i));
     });
-    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ axis: 'x', spacing: 20, mode: 'grow' }),
+    );
   });
 
   test('DiagramTab processes file', async () => {


### PR DESCRIPTION
## Summary
- add growth mode to spacing options
- calculate widget growth positions and apply them
- allow spacing tab to toggle between moving and growing
- test the new grow behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858ce322bd0832b829d30ff05c45ba8