### PR TITLE
Add vertical sorting orientation for grid layout

### DIFF
--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -10,6 +10,8 @@ export interface GridOptions {
   groupResult?: boolean;
   /** Sort widgets alphabetically by their name before layout. */
   sortByName?: boolean;
+  /** Direction for placing sorted items, defaults to horizontal */
+  sortOrientation?: 'horizontal' | 'vertical';
 }
 
 export interface Position {
@@ -56,9 +58,11 @@ export function calculateGridPositions(
   cellHeight: number,
 ): Position[] {
   const positions: Position[] = [];
+  const vertical = opts.sortOrientation === 'vertical';
+  const rows = Math.ceil(count / opts.cols);
   for (let i = 0; i < count; i += 1) {
-    const c = i % opts.cols;
-    const r = Math.floor(i / opts.cols);
+    const c = vertical ? Math.floor(i / rows) : i % opts.cols;
+    const r = vertical ? i % rows : Math.floor(i / opts.cols);
     positions.push({
       x: c * (cellWidth + opts.padding),
       y: r * (cellHeight + opts.padding),

--- a/src/ui/pages/GridTab.tsx
+++ b/src/ui/pages/GridTab.tsx
@@ -6,6 +6,8 @@ import {
   InputLabel,
   Icon,
   Text,
+  Select,
+  SelectOption,
 } from '../components/legacy';
 import { applyGridLayout, GridOptions } from '../../board/grid-tools';
 import type { TabTuple } from './tab-definitions';
@@ -17,6 +19,7 @@ export const GridTab: React.FC = () => {
     padding: 20,
     groupResult: false,
     sortByName: false,
+    sortOrientation: 'horizontal',
   });
   const [frameTitle, setFrameTitle] = React.useState('');
 
@@ -28,6 +31,10 @@ export const GridTab: React.FC = () => {
 
   const toggle = (key: 'groupResult' | 'sortByName') => (): void => {
     setGrid({ ...grid, [key]: !grid[key] });
+  };
+
+  const setOrientation = (value: string): void => {
+    setGrid({ ...grid, sortOrientation: value as 'horizontal' | 'vertical' });
   };
 
   const apply = async (): Promise<void> => {
@@ -67,6 +74,15 @@ export const GridTab: React.FC = () => {
         value={Boolean(grid.sortByName)}
         onChange={toggle('sortByName')}
       />
+      {grid.sortByName && (
+        <InputLabel>
+          Order
+          <Select value={grid.sortOrientation} onChange={setOrientation}>
+            <SelectOption value='horizontal'>Horizontally</SelectOption>
+            <SelectOption value='vertical'>Vertically</SelectOption>
+          </Select>
+        </InputLabel>
+      )}
       <Checkbox
         label='Group items into Frame'
         value={Boolean(grid.groupResult)}

--- a/tests/grid-tools.test.ts
+++ b/tests/grid-tools.test.ts
@@ -100,6 +100,32 @@ describe('grid-tools', () => {
     expect(items[1].y).toBe(0); // first item sorted up
   });
 
+  test('applyGridLayout sorts vertically when requested', async () => {
+    const items = [
+      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'b' },
+      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'a' },
+      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'd' },
+      { x: 0, y: 0, width: 10, height: 10, sync: jest.fn(), title: 'c' },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+      group: jest.fn(),
+    };
+    await applyGridLayout(
+      {
+        cols: 2,
+        padding: 5,
+        sortByName: true,
+        sortOrientation: 'vertical',
+      },
+      board,
+    );
+    const byTitle = Object.fromEntries(items.map(i => [i.title, i]));
+    expect(byTitle.a.x).toBe(0);
+    expect(byTitle.b.y).toBe(15);
+    expect(byTitle.c.x).toBe(15);
+  });
+
   test('applyGridLayout throws without board', async () => {
     await expect(applyGridLayout({ cols: 1, padding: 0 })).rejects.toThrow(
       'Miro board not available',


### PR DESCRIPTION
## Summary
- extend GridOptions with `sortOrientation`
- add vertical calculation to `calculateGridPositions`
- expose orientation selector in Grid tab UI
- test vertical sort ordering

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685923139ce8832bbc7128d1a8374aad