### PR TITLE
Fix checkbox visibility

### DIFF
--- a/src/ui/components/legacy/Checkbox.tsx
+++ b/src/ui/components/legacy/Checkbox.tsx
@@ -29,7 +29,8 @@ export function Checkbox({
         onChange={handleChange}
         {...props}
       />
-      {label}
+      {/* span enables Mirotone checkbox styling */}
+      <span>{label}</span>
     </label>
   );
 }

--- a/tests/checkbox.test.tsx
+++ b/tests/checkbox.test.tsx
@@ -1,0 +1,15 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Checkbox } from '../src/ui/components/legacy/Checkbox';
+
+test('Checkbox renders Mirotone span and toggles value', () => {
+  const handler = jest.fn();
+  render(<Checkbox label='Option' value={false} onChange={handler} />);
+  const input = screen.getByRole('checkbox');
+  // sibling span provides visible checkbox styling
+  expect(input.nextSibling).toBeInstanceOf(HTMLElement);
+  fireEvent.click(input);
+  expect(handler).toHaveBeenCalledWith(true);
+});


### PR DESCRIPTION
## Summary
- fix Checkbox to include span element for Mirotone styling
- add unit test covering checkbox behavior

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685922fe28d4832b82fbf599d1e0bbb0