### PR TITLE
Improve coverage above 90%

### DIFF
--- a/tests/file-utils-error.test.ts
+++ b/tests/file-utils-error.test.ts
@@ -1,0 +1,22 @@
+import { fileUtils } from '../src/core/utils/file-utils';
+
+describe('FileUtils error handling', () => {
+  afterEach(() => {
+    // restore mocked FileReader after each test
+    delete (global as { FileReader?: unknown }).FileReader;
+  });
+
+  test('readFileAsText rejects on FileReader error', async () => {
+    class FR {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        if (this.onerror) this.onerror();
+      }
+    }
+    (global as { FileReader?: unknown }).FileReader = FR;
+    await expect(
+      fileUtils.readFileAsText({ name: 'file.txt' } as unknown as File),
+    ).rejects.toBe('Failed to load file');
+  });
+});

--- a/tests/heading.test.tsx
+++ b/tests/heading.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Heading } from '../src/ui/components/legacy/Heading';
+
+describe('Heading', () => {
+  test('renders h1 by default', () => {
+    render(<Heading>Title</Heading>);
+    const el = screen.getByRole('heading', { level: 1 });
+    expect(el).toHaveTextContent('Title');
+  });
+
+  test('renders correct heading level', () => {
+    render(<Heading level={3}>Sub</Heading>);
+    const el = screen.getByRole('heading', { level: 3 });
+    expect(el.tagName).toBe('H3');
+  });
+});

--- a/tests/segmented-control.test.tsx
+++ b/tests/segmented-control.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SegmentedControl } from '../src/ui/components/SegmentedControl';
+
+describe('SegmentedControl', () => {
+  test('click triggers onChange with value', () => {
+    const handler = jest.fn();
+    const options = [
+      { label: 'One', value: '1' },
+      { label: 'Two', value: '2' },
+    ];
+    render(
+      <SegmentedControl
+        value='1'
+        onChange={handler}
+        options={options}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Two' });
+    fireEvent.click(btn);
+    expect(handler).toHaveBeenCalledWith('2');
+  });
+});


### PR DESCRIPTION
## Summary
- add SegmentedControl tests
- add Heading tests
- test FileUtils error handling

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685947625a94832bb01ab9d396358162