### PR TITLE
Add style preset formatting

### DIFF
--- a/src/board/format-tools.ts
+++ b/src/board/format-tools.ts
@@ -1,0 +1,27 @@
+import { resolveColor } from '../core/utils/color-utils';
+import { BoardLike, getBoard } from './board';
+import type { StylePreset } from '../ui/style-presets';
+
+/**
+ * Apply a style preset to all selected widgets.
+ */
+export async function applyStylePreset(
+  preset: StylePreset,
+  board?: BoardLike,
+): Promise<void> {
+  const b = getBoard(board);
+  const selection = await b.getSelection();
+  await Promise.all(
+    selection.map(async (item: Record<string, unknown>) => {
+      const style = (item.style ?? {}) as Record<string, unknown>;
+      style.color = resolveColor(preset.fontColor, '#000000');
+      style.borderColor = resolveColor(preset.borderColor, '#000000');
+      style.borderWidth = preset.borderWidth;
+      style.fillColor = resolveColor(preset.fillColor, '#ffffff');
+      item.style = style;
+      if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
+        await (item as { sync: () => Promise<void> }).sync();
+      }
+    }),
+  );
+}

--- a/src/ui/pages/StyleTab.tsx
+++ b/src/ui/pages/StyleTab.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Button, Icon, InputField, Text } from '../components/legacy';
 import { tweakFillColor, extractFillColor } from '../../board/style-tools';
+import { applyStylePreset } from '../../board/format-tools';
+import { STYLE_PRESETS } from '../style-presets';
 import { adjustColor } from '../../core/utils/color-utils';
 import { useSelection } from '../hooks/use-selection';
 import { tokens } from '../tokens';
@@ -81,6 +83,16 @@ export const StyleTab: React.FC = () => {
             <Text>Apply</Text>
           </React.Fragment>
         </Button>
+      </div>
+      <div className='buttons'>
+        {STYLE_PRESETS.map((p) => (
+          <Button
+            key={p.id}
+            onClick={() => applyStylePreset(p)}
+            variant='secondary'>
+            {p.label}
+          </Button>
+        ))}
       </div>
     </div>
   );

--- a/src/ui/style-presets.ts
+++ b/src/ui/style-presets.ts
@@ -1,0 +1,43 @@
+export interface StylePreset {
+  id: string;
+  label: string;
+  fontColor: string;
+  borderWidth: number;
+  borderColor: string;
+  fillColor: string;
+}
+
+export const STYLE_PRESETS: StylePreset[] = [
+  {
+    id: 'primary',
+    label: 'Primary',
+    fontColor: 'var(--white)',
+    borderWidth: 2,
+    borderColor: 'var(--colors-blue-200)',
+    fillColor: 'var(--colors-blue-150)',
+  },
+  {
+    id: 'success',
+    label: 'Success',
+    fontColor: 'var(--white)',
+    borderWidth: 2,
+    borderColor: 'var(--colors-green-200)',
+    fillColor: 'var(--colors-green-150)',
+  },
+  {
+    id: 'warning',
+    label: 'Warning',
+    fontColor: 'var(--black)',
+    borderWidth: 2,
+    borderColor: 'var(--colors-yellow-200)',
+    fillColor: 'var(--colors-yellow-150)',
+  },
+  {
+    id: 'danger',
+    label: 'Danger',
+    fontColor: 'var(--white)',
+    borderWidth: 2,
+    borderColor: 'var(--colors-red-200)',
+    fillColor: 'var(--colors-red-150)',
+  },
+];

--- a/tests/format-tools.test.ts
+++ b/tests/format-tools.test.ts
@@ -1,0 +1,32 @@
+import { applyStylePreset } from '../src/board/format-tools';
+import type { StylePreset } from '../src/ui/style-presets';
+
+describe('format-tools', () => {
+  const preset: StylePreset = {
+    id: 't',
+    label: 'Test',
+    fontColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: '#000000',
+    fillColor: '#ff00ff',
+  };
+
+  test('applyStylePreset updates style', async () => {
+    const item = { style: {}, sync: jest.fn() };
+    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    await applyStylePreset(preset, board);
+    expect(item.style).toEqual({
+      color: preset.fontColor,
+      borderColor: preset.borderColor,
+      borderWidth: preset.borderWidth,
+      fillColor: preset.fillColor,
+    });
+    expect(item.sync).toHaveBeenCalled();
+  });
+
+  test('applyStylePreset throws without board', async () => {
+    await expect(applyStylePreset(preset)).rejects.toThrow(
+      'Miro board not available',
+    );
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -10,6 +10,7 @@ import { DiagramTab } from '../src/ui/pages/DiagramTab';
 import { CardsTab } from '../src/ui/pages/CardsTab';
 import * as resizeTools from '../src/board/resize-tools';
 import * as styleTools from '../src/board/style-tools';
+import * as formatTools from '../src/board/format-tools';
 import * as gridTools from '../src/board/grid-tools';
 import * as spacingTools from '../src/board/spacing-tools';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
@@ -21,6 +22,7 @@ vi.mock('../src/board/style-tools', async () => {
     await vi.importActual('../src/board/style-tools');
   return { ...actual, tweakFillColor: jest.fn() };
 });
+vi.mock('../src/board/format-tools');
 vi.mock('../src/board/grid-tools');
 vi.mock('../src/board/spacing-tools');
 vi.mock('../src/core/graph/graph-processor');
@@ -130,6 +132,19 @@ describe('tab components', () => {
     });
     const preview = screen.getByTestId('adjust-preview');
     expect(preview.style.backgroundColor).toBe('rgb(18, 52, 86)');
+  });
+
+  test('StyleTab applies preset style', async () => {
+    const spy = jest
+      .spyOn(formatTools, 'applyStylePreset')
+      .mockResolvedValue(undefined as unknown as void);
+    await act(async () => {
+      render(React.createElement(StyleTab));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /primary/i }));
+    });
+    expect(spy).toHaveBeenCalled();
   });
 
   test('GridTab applies layout', async () => {


### PR DESCRIPTION
## Summary
- add `STYLE_PRESETS` config
- add `applyStylePreset` board utility
- allow Style tab to apply preset styles
- test the new preset behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_68594df9e0d8832bb978eab41cf9bbed