### PR TITLE
Add aspect ratio options to resize tools

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -43,6 +43,7 @@ Panel split vertically **(Stack space="lg")**
 | **Current Selection** | `<Text>` size readout (W × H px)              | “Selection: 180 × 120 px”                  | Updates on `selection:update`                 | `selectionSize` |
 | **Copied Size**       | `<Text>` (grey if none)                       | “Copied: (none)” OR “Copied: 280 × 160 px” | Shows last copied dimensions                  | `copiedSize`    |
 | **Presets**           | Buttons S/M/L, `<InputField>` Width + Height  | “Apply”                                    | Click preset or enter numbers → preview ghost | –               |
+| **Aspect Ratio**      | `<Select>` Golden, 16:9, 16:10, 4:3           | “Free” default                             | Changing width or ratio updates height        | `ratio`         |
 | **Copy Size**         | `<Button variant="secondary">Copy size`       | Copies `selectionSize` → `copiedSize`      | –                                             |
 | **Apply Copied**      | `<Button variant="primary">Apply copied size` | Disabled if `!copiedSize`                  | Iterates selection; sets dimensions           |
 

--- a/src/core/utils/aspect-ratio.ts
+++ b/src/core/utils/aspect-ratio.ts
@@ -1,0 +1,53 @@
+/**
+ * Utilities for handling common aspect ratios when resizing widgets.
+ *
+ * Ratios are expressed as width divided by height. The `applyAspectRatio`
+ * helper computes a rounded height value from a given width.
+ */
+
+/** Representation of an aspect ratio preset. */
+export interface AspectRatioPreset {
+  /** Unique identifier used by the UI. */
+  id: AspectRatioId;
+  /** Human readable label shown in dropdowns. */
+  label: string;
+  /** Numeric ratio of width / height. */
+  ratio: number;
+}
+
+/** Supported preset identifiers. */
+export type AspectRatioId = 'golden' | '16:9' | '16:10' | '4:3';
+
+/** Golden ratio constant used by presets. */
+export const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+
+/** List of selectable aspect ratios. */
+export const ASPECT_RATIOS: AspectRatioPreset[] = [
+  { id: 'golden', label: 'Golden', ratio: GOLDEN_RATIO },
+  { id: '16:9', label: '16:9', ratio: 16 / 9 },
+  { id: '16:10', label: '16:10', ratio: 16 / 10 },
+  { id: '4:3', label: '4:3', ratio: 4 / 3 },
+];
+
+/**
+ * Retrieve the numeric ratio for a preset identifier.
+ *
+ * @param id - Identifier from `ASPECT_RATIOS`.
+ * @returns Width divided by height as a number.
+ */
+export function aspectRatioValue(id: AspectRatioId): number {
+  const preset = ASPECT_RATIOS.find((p) => p.id === id);
+  if (!preset) throw new Error(`Unknown aspect ratio: ${id}`);
+  return preset.ratio;
+}
+
+/**
+ * Calculate height from width using a ratio.
+ *
+ * @param width - Target width in board units.
+ * @param ratio - Aspect ratio value (width / height).
+ * @returns Rounded height respecting the ratio.
+ */
+export function ratioHeight(width: number, ratio: number): number {
+  return Math.round(width / ratio);
+}

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -3,6 +3,8 @@ import {
   Button,
   FormGroup,
   InputField,
+  Select,
+  SelectOption,
   Paragraph,
   Icon,
   Text,
@@ -18,6 +20,12 @@ import {
   boardUnitsToMm,
   boardUnitsToInches,
 } from '../../core/utils/unit-utils';
+import {
+  ASPECT_RATIOS,
+  aspectRatioValue,
+  ratioHeight,
+  AspectRatioId,
+} from '../../core/utils/aspect-ratio';
 
 /** UI for the Resize tab. */
 export const ResizeTab: React.FC = () => {
@@ -25,6 +33,7 @@ export const ResizeTab: React.FC = () => {
   const [size, setSize] = React.useState<Size>({ width: 100, height: 100 });
   const [copiedSize, setCopiedSize] = React.useState<Size | null>(null);
   const [warning, setWarning] = React.useState('');
+  const [ratio, setRatio] = React.useState<AspectRatioId | 'none'>('none');
 
   const update =
     (key: keyof Size) =>
@@ -68,6 +77,14 @@ export const ResizeTab: React.FC = () => {
   }, [selection]);
 
   React.useEffect(() => {
+    if (ratio === 'none') return;
+    setSize((prev) => {
+      const h = ratioHeight(prev.width, aspectRatioValue(ratio));
+      return prev.height === h ? prev : { ...prev, height: h };
+    });
+  }, [ratio, size.width]);
+
+  React.useEffect(() => {
     const handler = (e: KeyboardEvent): void => {
       if (e.altKey && e.key.toLowerCase() === 'c') {
         e.preventDefault();
@@ -109,6 +126,22 @@ export const ResizeTab: React.FC = () => {
           />
         </InputField>
       </FormGroup>
+      <InputField label='Aspect Ratio'>
+        <Select
+          data-testid='ratio-select'
+          className='select-small'
+          value={ratio}
+          onChange={(v) => setRatio(v as AspectRatioId | 'none')}>
+          <SelectOption value='none'>Free</SelectOption>
+          {ASPECT_RATIOS.map((r) => (
+            <SelectOption
+              key={r.id}
+              value={r.id}>
+              {r.label}
+            </SelectOption>
+          ))}
+        </Select>
+      </InputField>
       <div>
         {['S', 'M', 'L'].map((p) => (
           <Button

--- a/tests/aspect-ratio.test.ts
+++ b/tests/aspect-ratio.test.ts
@@ -1,0 +1,15 @@
+import { aspectRatioValue, ratioHeight } from '../src/core/utils/aspect-ratio';
+
+describe('aspect-ratio utilities', () => {
+  test('aspectRatioValue returns numeric ratios', () => {
+    expect(aspectRatioValue('16:9')).toBeCloseTo(16 / 9);
+    expect(aspectRatioValue('16:10')).toBeCloseTo(16 / 10);
+    expect(aspectRatioValue('4:3')).toBeCloseTo(4 / 3);
+    expect(aspectRatioValue('golden')).toBeCloseTo((1 + Math.sqrt(5)) / 2);
+  });
+
+  test('ratioHeight computes height', () => {
+    const height = ratioHeight(160, aspectRatioValue('16:9'));
+    expect(height).toBe(90);
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -81,6 +81,19 @@ describe('tab components', () => {
     expect(screen.getByText(/copy size/i)).toBeInTheDocument();
   });
 
+  test('ResizeTab aspect ratio adjusts height', async () => {
+    render(React.createElement(ResizeTab));
+    const widthInput = screen.getByPlaceholderText(/width/i);
+    fireEvent.change(widthInput, { target: { value: '160' } });
+    fireEvent.change(screen.getByTestId('ratio-select'), {
+      target: { value: '16:9' },
+    });
+    const heightInput = screen.getByPlaceholderText(
+      /height/i,
+    ) as HTMLInputElement;
+    expect(heightInput.value).toBe('90');
+  });
+
   test('StyleTab tweaks fill colour', async () => {
     const spy = jest
       .spyOn(styleTools, 'tweakFillColor')


### PR DESCRIPTION
## Summary
- add utilities for common aspect ratios
- update Resize tab to select golden ratio, 16:9, 16:10 or 4:3
- document new controls in Resize tab docs
- test aspect ratio utils and UI behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6859c0289858832b933d5766e2700bc2