### PR TITLE
Update docs with references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ npm run lint --silent
 npm run prettier --silent
 ```
 
-Exported functions and complex logic should include documentation comments to
-aid readability.
+Refer to [docs/CODE_STYLE.md](docs/CODE_STYLE.md) for formatting and naming
+guidelines. Exported functions and complex logic should include documentation
+comments to aid readability. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow and a link to the developer tutorial. Build and deployment steps are
+documented in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Per [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) §6, maintain **90 % line and
 branch coverage** and keep **cyclomatic complexity ≤ 8**. New or updated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing to Miro JSON Graph Diagram App
+
+We welcome pull requests and issues. Please read
+[Miro's contributing guide](https://github.com/miroapp/app-examples/blob/main/CONTRIBUTING.md)
+for the general workflow.
+
+## Developer Tutorial
+
+See the
+[Miro developer documentation](https://developers.miro.com/docs/overview) for a
+step-by-step tutorial on building diagramming apps. When contributing code,
+please follow the formatting rules in [docs/CODE_STYLE.md](docs/CODE_STYLE.md).

--- a/README.md
+++ b/README.md
@@ -148,10 +148,6 @@ the rest of the UI. These guidelines help keep layouts consistent:
   [Node.js](https://nodejs.org/en/download) v18 or v20.
 - All examples use `npm` as a package manager and `npx` as a package runner.
 
-## 📖 Associated Developer Tutorial <a name="tutorial"></a>
-
-See the Miro documentation for details on building diagramming apps.
-
 ## 🏃🏽‍♂️ Run the app locally <a name="run"></a>
 
 1. Run `npm install` to install dependencies.
@@ -220,12 +216,6 @@ These commands perform TypeScript type checking, execute the Jest suite, run
 ESLint and format files with Prettier. Run them before committing so code
 conforms to the repository guidelines.
 
-## Building a Production Bundle
-
-Run `npm run build` to create the optimized static files in the `dist/` folder.
-Host these files on a web server and update the `sdkUri` in your app manifest to
-point to the deployed bundle.
-
 ## 🗂️ Folder structure <a name="folder"></a>
 
 ```
@@ -250,17 +240,18 @@ point to the deployed bundle.
 - [Architecture](docs/ARCHITECTURE.md) explains how the source modules are
   organised.
 - [Tab Overview](docs/TABS.md) describes the sidebar tabs and their purpose.
-- [Deployment Guide](docs/DEPLOYMENT.md) shows how to build and host the bundle.
+- [Deployment & Build Guide](docs/DEPLOYMENT.md) explains how to build and host
+  the bundle.
 - [Components Catalogue](docs/COMPONENTS.md) documents reusable React
   components.
 - [Design Foundation](docs/FOUNDATION.md) explains tokens and theming rules.
+- [Code Style](docs/CODE_STYLE.md) outlines formatting and naming rules.
 - [UI Patterns](docs/PATTERNS.md) shows common layouts and best practices.
 
 ## 🫱🏻‍🫲🏽 Contributing <a name="contributing"></a>
 
-If you want to contribute to this example, or any other Miro Open Source
-project, please review
-[Miro's contributing guide](https://github.com/miroapp/app-examples/blob/main/CONTRIBUTING.md).
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and
+the development workflow.
 
 ## 🪪 License <a name="license"></a>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -209,6 +209,8 @@ Deployment, rollback and monitoring hooks are documented in **DEPLOYMENT.md**.
 
 ## 15 Appendix: Coding Conventions
 
+See [CODE_STYLE.md](CODE_STYLE.md) for detailed style rules.
+
 - File names: PascalCase.tsx for React, kebab-case.ts for util.
 - Import order: std → vendor → local, alphabetical within group.
 - No raw grid-column in style blocks (enforced by custom ESLint rule).

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -1,0 +1,31 @@
+# Code Style Guide
+
+This project enforces consistent formatting with
+[Prettier](https://prettier.io/) and lint rules via
+[ESLint](https://eslint.org/).
+
+## Formatting
+
+- Two space indentation and LF line endings are defined in
+  [.editorconfig](../.editorconfig).
+- Prettier configuration lives in [.prettierrc](../.prettierrc) and formats all
+  source files. Run `npm run prettier --silent` before committing.
+- The `printWidth` is 80 characters; lines should wrap accordingly.
+- Semicolons are required and single quotes are preferred for strings.
+
+## Naming
+
+- Files containing React components use `PascalCase.tsx`.
+- Utility modules use `kebab-case.ts`.
+- Variables and functions are `camelCase`; types and components use
+  `PascalCase`.
+
+## Conventions
+
+- Keep functions focused on a single task and maintain cyclomatic complexity
+  under eight.
+- Document exported functions with TSDoc comments.
+- Import order follows standard → vendor → local, alphabetically within each
+  group.
+
+For additional architectural guidelines see [ARCHITECTURE.md](ARCHITECTURE.md).


### PR DESCRIPTION
## Summary
- link to CONTRIBUTING from development notes
- mention code style guide in contributing instructions
- remove tutorial from README and reference deployment guide
- clarify build notes in development docs

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6859c8f20ad0832b928fc35edd01acbe