### PR TITLE
Add nested layout algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ A small example is provided in
 }
 ```
 
+## Nested Layouts
+
+Hierarchical data where children are contained within parent shapes can be
+visualised using the **Nested** layout option in the Diagram tab. Nodes are
+sorted alphabetically by default or via a custom metadata key. A three‑level
+sample dataset is available at
+[tests/fixtures/sample-hier.json](tests/fixtures/sample-hier.json).
+
 ## Accessibility
 
 The import panel is keyboard accessible. The drop area includes an ARIA label

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ To add your own templates create new entries in these JSON files and reference
 them by name in your graph metadata. The app reloads templates on startup so
 changes are picked up automatically.
 
+Additional details and a sample dataset are provided in
+[`docs/TEMPLATES.md`](docs/TEMPLATES.md).
+
 ## Metadata Usage
 
 Nodes may include a `metadata` object with any additional information. Typical

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ Hierarchical data where children are contained within parent shapes can be
 visualised using the **Nested** layout option in the Diagram tab. Nodes are
 sorted alphabetically by default or via a custom metadata key. A three‑level
 sample dataset is available at
-[tests/fixtures/sample-hier.json](tests/fixtures/sample-hier.json).
+[tests/fixtures/sample-hier.json](tests/fixtures/sample-hier.json). Simply
+select **Nested** and import this file to see parent widgets sized to fit their
+children. If a standard flat graph is supplied instead, the importer will raise
+an error indicating an invalid hierarchy.
 
 ## Accessibility
 

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -1,0 +1,57 @@
+# Template Authoring Guide
+
+---
+
+## 0 Purpose
+
+Explain how shape and connector templates are defined and consumed by the
+diagramming add-on. This allows designers to tweak sizes and styles without
+touching the code.
+
+---
+
+## 1 Shape Templates
+
+Shape templates live in
+[`templates/shapeTemplates.json`](../templates/shapeTemplates.json). Each entry
+describes one or more elements that make up a widget. The minimal form is:
+
+```json
+"Role": {
+  "elements": [
+    { "shape": "round_rectangle", "width": 160, "height": 60, "text": "{{label}}" }
+  ]
+}
+```
+
+The `text` field supports the `{{label}}` placeholder which is replaced with the
+node's label. Additional `style` properties use the same keys as the Web SDK
+widgets and support design tokens such as `"tokens.color.yellow[150]"`.
+
+Connector styling is defined in
+[`templates/connectorTemplates.json`](../templates/connectorTemplates.json) and
+follows the same pattern.
+
+---
+
+## 2 Configuration
+
+Templates are loaded by the `TemplateManager` at runtime. To reference a
+template simply set `type` on a node or supply a `template` name in the node's
+metadata. Connector templates are chosen via the edge's `metadata.template`
+value.
+
+---
+
+## 3 Sample Data
+
+A small hierarchical dataset can be found in
+[`tests/fixtures/sample-hier.json`](../tests/fixtures/sample-hier.json). This is
+useful when experimenting with the nested layout algorithm. Import the JSON in
+the **Create** tab and choose the diagram mode.
+
+---
+
+The UI for template selection is part of the Structured Diagramming add-on
+running on a Miro board. All widgets are created through the Miro Web SDK and
+can be customised by editing the template files.

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -49,7 +49,8 @@ A three-level hierarchical dataset can be found in
 [`tests/fixtures/sample-hier.json`](../tests/fixtures/sample-hier.json). It
 contains four top-level groups, each with four subgroups and four items per
 subgroup. This is useful when experimenting with the nested layout algorithm.
-Import the JSON in the **Create** tab and choose the diagram mode.
+Import the JSON in the **Create** tab and choose the **Nested** diagram layout
+to see child nodes arranged inside their parents.
 
 ---
 

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -45,10 +45,11 @@ value.
 
 ## 3 Sample Data
 
-A small hierarchical dataset can be found in
-[`tests/fixtures/sample-hier.json`](../tests/fixtures/sample-hier.json). This is
-useful when experimenting with the nested layout algorithm. Import the JSON in
-the **Create** tab and choose the diagram mode.
+A three-level hierarchical dataset can be found in
+[`tests/fixtures/sample-hier.json`](../tests/fixtures/sample-hier.json). It
+contains four top-level groups, each with four subgroups and four items per
+subgroup. This is useful when experimenting with the nested layout algorithm.
+Import the JSON in the **Create** tab and choose the diagram mode.
 
 ---
 

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -6,6 +6,7 @@ import type {
   ConnectorStyle,
   Frame,
   Group,
+  GroupableItem,
   Shape,
   ShapeStyle,
   Text,
@@ -184,7 +185,7 @@ export class BoardBuilder {
   }
 
   /** Group multiple widgets together on the board. */
-  public async groupItems(items: Array<BaseItem | Group>): Promise<Group> {
+  public async groupItems(items: GroupableItem[]): Promise<Group> {
     this.ensureBoard();
     return (await miro.board.group({ items })) as Group;
   }

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -183,6 +183,12 @@ export class BoardBuilder {
     );
   }
 
+  /** Group multiple widgets together on the board. */
+  public async groupItems(items: Array<BaseItem | Group>): Promise<Group> {
+    this.ensureBoard();
+    return (await miro.board.group({ items })) as Group;
+  }
+
   private ensureBoard(): void {
     if (typeof miro === 'undefined' || !miro?.board) {
       throw new Error('Miro board not initialized');

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -121,7 +121,9 @@ export class BoardBuilder {
     if (!templateDef) {
       throw new Error(`Template '${nodeData.type}' not found`);
     }
-    return this.createNewNode(nodeData, pos);
+    const widget = await this.createNewNode(nodeData, pos);
+    await this.resizeItem(widget, pos.width, pos.height);
+    return widget;
   }
 
   /**
@@ -338,6 +340,25 @@ export class BoardBuilder {
       label: node.label,
     });
     return widget as BaseItem;
+  }
+
+  /**
+   * Resize an item if width and height properties are available.
+   * The widget is synchronised when a sync method exists.
+   */
+  public async resizeItem(
+    item: BaseItem | Group,
+    width: number,
+    height: number,
+  ): Promise<void> {
+    const target = item as {
+      width?: number;
+      height?: number;
+      sync?: () => Promise<void>;
+    };
+    if (typeof target.width === 'number') target.width = width;
+    if (typeof target.height === 'number') target.height = height;
+    if (typeof target.sync === 'function') await target.sync();
   }
 
   /**

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -1,0 +1,131 @@
+import { BoardBuilder } from '../../board/board-builder';
+import { fileUtils } from '../utils/file-utils';
+import {
+  HierNode,
+  layoutHierarchy,
+  NestedLayoutResult,
+} from '../layout/nested-layout';
+import type { BaseItem, Group, Frame } from '@mirohq/websdk-types';
+
+export interface HierarchyProcessOptions {
+  createFrame?: boolean;
+  frameTitle?: string;
+  sortKey?: string;
+}
+
+export class HierarchyProcessor {
+  private lastCreated: Array<BaseItem | Group | Frame> = [];
+
+  constructor(private builder: BoardBuilder = new BoardBuilder()) {}
+
+  public async processFile(
+    file: File,
+    opts: HierarchyProcessOptions = {},
+  ): Promise<void> {
+    fileUtils.validateFile(file);
+    const text = await fileUtils.readFileAsText(file);
+    const data = JSON.parse(text) as HierNode[];
+    await this.processHierarchy(data, opts);
+  }
+
+  public async processHierarchy(
+    roots: HierNode[],
+    opts: HierarchyProcessOptions = {},
+  ): Promise<void> {
+    if (!Array.isArray(roots)) throw new Error('Invalid hierarchy');
+    this.lastCreated = [];
+    const result = layoutHierarchy(roots, { sortKey: opts.sortKey });
+    const bounds = this.computeBounds(result);
+    const margin = 40;
+    const width = bounds.maxX - bounds.minX + margin * 2;
+    const height = bounds.maxY - bounds.minY + margin * 2;
+    const spot = await this.builder.findSpace(width, height);
+    const offsetX = spot.x - width / 2 + margin - bounds.minX;
+    const offsetY = spot.y - height / 2 + margin - bounds.minY;
+    const frame = await this.createFrame(
+      opts.createFrame !== false,
+      width,
+      height,
+      spot,
+      opts.frameTitle,
+    );
+    await this.createWidgets(roots, result.nodes, offsetX, offsetY);
+    await this.builder.syncAll(this.lastCreated.filter((i) => i !== frame));
+    const target = frame
+      ? frame
+      : (this.lastCreated as Array<BaseItem | Group>);
+    await this.builder.zoomTo(target);
+  }
+
+  private computeBounds(result: NestedLayoutResult) {
+    let minX = Infinity,
+      minY = Infinity,
+      maxX = -Infinity,
+      maxY = -Infinity;
+    Object.values(result.nodes).forEach(({ x, y, width, height }) => {
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + width);
+      maxY = Math.max(maxY, y + height);
+    });
+    return { minX, minY, maxX, maxY };
+  }
+
+  private async createFrame(
+    useFrame: boolean,
+    width: number,
+    height: number,
+    spot: { x: number; y: number },
+    title?: string,
+  ): Promise<Frame | undefined> {
+    if (!useFrame) {
+      this.builder.setFrame(undefined);
+      return undefined;
+    }
+    const frame = await this.builder.createFrame(
+      width,
+      height,
+      spot.x,
+      spot.y,
+      title,
+    );
+    this.lastCreated.push(frame);
+    return frame;
+  }
+
+  private async createWidgets(
+    nodes: HierNode[],
+    posMap: Record<
+      string,
+      { x: number; y: number; width: number; height: number }
+    >,
+    offsetX: number,
+    offsetY: number,
+  ): Promise<void> {
+    for (const node of nodes) {
+      const pos = posMap[node.id];
+      const centerX = pos.x + offsetX + pos.width / 2;
+      const centerY = pos.y + offsetY + pos.height / 2;
+      const widget = await this.builder.createNode(node, {
+        x: centerX,
+        y: centerY,
+        width: pos.width,
+        height: pos.height,
+      });
+      await this.builder.resizeItem(widget, pos.width, pos.height);
+      this.lastCreated.push(widget);
+      if (node.children?.length) {
+        await this.createWidgets(node.children, posMap, offsetX, offsetY);
+      }
+    }
+  }
+
+  public async undoLast(): Promise<void> {
+    if (this.lastCreated.length) {
+      await this.builder.removeItems(this.lastCreated);
+      this.lastCreated = [];
+    }
+  }
+}
+
+export const hierarchyProcessor = new HierarchyProcessor();

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -5,7 +5,12 @@ import {
   layoutHierarchy,
   NestedLayoutResult,
 } from '../layout/nested-layout';
-import type { BaseItem, Group, Frame } from '@mirohq/websdk-types';
+import type {
+  BaseItem,
+  Group,
+  Frame,
+  GroupableItem,
+} from '@mirohq/websdk-types';
 
 export interface HierarchyProcessOptions {
   createFrame?: boolean;
@@ -118,7 +123,7 @@ export class HierarchyProcessor {
       return widget;
     }
 
-    const childWidgets: Array<BaseItem | Group> = [];
+    const childWidgets: GroupableItem[] = [];
     for (const child of node.children) {
       const childWidget = await this.createNodeTree(
         child,
@@ -126,14 +131,17 @@ export class HierarchyProcessor {
         offsetX,
         offsetY,
       );
-      childWidgets.push(childWidget);
+      childWidgets.push(childWidget as unknown as GroupableItem);
     }
 
     // Remove children from undo list; they will be represented by the group.
     this.lastCreated = this.lastCreated.filter(
-      (i) => !childWidgets.includes(i),
+      (i) => !childWidgets.includes(i as unknown as GroupableItem),
     );
-    const group = await this.builder.groupItems([widget, ...childWidgets]);
+    const group = await this.builder.groupItems([
+      widget as unknown as GroupableItem,
+      ...childWidgets,
+    ]);
     this.lastCreated.push(group);
     return group;
   }

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -18,11 +18,22 @@ export interface HierarchyProcessOptions {
   sortKey?: string;
 }
 
+/**
+ * Processor responsible for creating nested diagrams where child widgets are
+ * contained inside their parent shapes. Widgets are created using
+ * {@link BoardBuilder} and arranged via {@link layoutHierarchy}.
+ */
 export class HierarchyProcessor {
+  /** List of widgets created in the last run for easy undo. */
   private lastCreated: Array<BaseItem | Group | Frame> = [];
 
   constructor(private builder: BoardBuilder = new BoardBuilder()) {}
 
+  /**
+   * Load a hierarchical JSON file and create the corresponding diagram.
+   * @param file File containing the hierarchy array.
+   * @param opts Optional behaviour flags such as frame creation.
+   */
   public async processFile(
     file: File,
     opts: HierarchyProcessOptions = {},
@@ -33,6 +44,11 @@ export class HierarchyProcessor {
     await this.processHierarchy(data, opts);
   }
 
+  /**
+   * Process a hierarchy data structure and create the widgets on the board.
+   * @param roots Root nodes of the hierarchy.
+   * @param opts Additional options such as custom sort key.
+   */
   public async processHierarchy(
     roots: HierNode[],
     opts: HierarchyProcessOptions = {},
@@ -62,6 +78,9 @@ export class HierarchyProcessor {
     await this.builder.zoomTo(target);
   }
 
+  /**
+   * Determine the overall bounding box of a layout result.
+   */
   private computeBounds(result: NestedLayoutResult) {
     let minX = Infinity,
       minY = Infinity,
@@ -76,6 +95,9 @@ export class HierarchyProcessor {
     return { minX, minY, maxX, maxY };
   }
 
+  /**
+   * Optionally create a frame around the entire hierarchy.
+   */
   private async createFrame(
     useFrame: boolean,
     width: number,
@@ -98,6 +120,9 @@ export class HierarchyProcessor {
     return frame;
   }
 
+  /**
+   * Recursively create widgets for a node and its children.
+   */
   private async createNodeTree(
     node: HierNode,
     posMap: Record<
@@ -146,6 +171,9 @@ export class HierarchyProcessor {
     return group;
   }
 
+  /**
+   * Iterate root nodes and delegate to {@link createNodeTree}.
+   */
   private async createWidgets(
     nodes: HierNode[],
     posMap: Record<
@@ -160,6 +188,9 @@ export class HierarchyProcessor {
     }
   }
 
+  /**
+   * Remove widgets created in the last run from the board.
+   */
   public async undoLast(): Promise<void> {
     if (this.lastCreated.length) {
       await this.builder.removeItems(this.lastCreated);
@@ -168,4 +199,7 @@ export class HierarchyProcessor {
   }
 }
 
+/**
+ * Shared singleton instance used by the UI layer.
+ */
 export const hierarchyProcessor = new HierarchyProcessor();

--- a/src/core/graph/index.ts
+++ b/src/core/graph/index.ts
@@ -1,2 +1,3 @@
 export * from './graph-service';
 export * from './graph-processor';
+export * from './hierarchy-processor';

--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -9,6 +9,7 @@ export interface HierNode {
 }
 
 export interface NestedLayoutOptions {
+  /** Optional metadata key used for sorting children. */
   sortKey?: string;
 }
 
@@ -27,80 +28,109 @@ export interface NestedLayoutResult {
 const GOLDEN_RATIO = 1.618;
 const DEFAULT_SIZE = 160;
 
-function templateSize(type: string): { width: number; height: number } {
-  const tpl = templateManager.getTemplate(type);
-  const element = tpl?.elements.find((e) => e.width && e.height);
-  const width = element?.width ?? DEFAULT_SIZE;
-  const height = element?.height ?? width / GOLDEN_RATIO;
-  return { width, height };
-}
-
-function sortValue(node: HierNode, key?: string): string {
-  if (key && node.metadata && key in node.metadata) {
-    return String(node.metadata[key]);
+/**
+ * Helper class that positions hierarchical nodes using an intrinsic grid
+ * computed from the golden ratio. Children are sorted alphabetically unless a
+ * specific metadata key is provided.
+ */
+export class NestedLayouter {
+  /**
+   * Determine a node's width and height from its template or use fallbacks.
+   */
+  private templateSize(type: string): { width: number; height: number } {
+    const tpl = templateManager.getTemplate(type);
+    const element = tpl?.elements.find((e) => e.width && e.height);
+    const width = element?.width ?? DEFAULT_SIZE;
+    const height = element?.height ?? width / GOLDEN_RATIO;
+    return { width, height };
   }
-  return node.label ?? node.id;
+
+  /** Retrieve the sort value for a node. */
+  private sortValue(node: HierNode, key?: string): string {
+    if (key && node.metadata && key in node.metadata) {
+      return String(node.metadata[key]);
+    }
+    return node.label ?? node.id;
+  }
+
+  /**
+   * Recursively position a node and its children.
+   */
+  private layoutChildren(
+    node: HierNode,
+    centerX: number,
+    centerY: number,
+    width: number,
+    height: number,
+    map: Record<string, PositionedNode>,
+    opts: NestedLayoutOptions,
+  ): void {
+    map[node.id] = { id: node.id, x: centerX, y: centerY, width, height };
+    const children = node.children;
+    if (!children?.length) return;
+    const sorted = [...children].sort((a, b) =>
+      this.sortValue(a, opts.sortKey).localeCompare(
+        this.sortValue(b, opts.sortKey),
+      ),
+    );
+    const marginX = width * 0.1;
+    const marginY = height * 0.2;
+    const innerW = width - marginX * 2;
+    const innerH = height - marginY * 2;
+    const cols = Math.ceil(Math.sqrt(sorted.length * GOLDEN_RATIO));
+    const rows = Math.ceil(sorted.length / cols);
+    const cellW = innerW / cols;
+    const cellH = innerH / rows;
+    sorted.forEach((child, i) => {
+      const col = i % cols;
+      const row = Math.floor(i / cols);
+      const cx = centerX - width / 2 + marginX + col * cellW + cellW / 2;
+      const cy = centerY - height / 2 + marginY + row * cellH + cellH / 2;
+      const dims = this.templateSize(child.type);
+      const cw = Math.min(dims.width, cellW);
+      const ch = Math.min(dims.height, cellH);
+      this.layoutChildren(child, cx, cy, cw, ch, map, opts);
+    });
+  }
+
+  /**
+   * Compute a nested layout where child nodes are contained within their
+   * parent.
+   */
+  public layoutHierarchy(
+    roots: HierNode[],
+    opts: NestedLayoutOptions = {},
+  ): NestedLayoutResult {
+    const nodes: Record<string, PositionedNode> = {};
+    let offsetY = 0;
+    const gap = 40;
+    roots.forEach((root) => {
+      const size = this.templateSize(root.type);
+      const y = offsetY + size.height / 2;
+      this.layoutChildren(
+        root,
+        size.width / 2,
+        y,
+        size.width,
+        size.height,
+        nodes,
+        opts,
+      );
+      offsetY += size.height + gap;
+    });
+    return { nodes };
+  }
 }
 
-function layoutChildren(
-  node: HierNode,
-  centerX: number,
-  centerY: number,
-  width: number,
-  height: number,
-  map: Record<string, PositionedNode>,
-  opts: NestedLayoutOptions,
-): void {
-  map[node.id] = { id: node.id, x: centerX, y: centerY, width, height };
-  const children = node.children;
-  if (!children?.length) return;
-  const sorted = [...children].sort((a, b) =>
-    sortValue(a, opts.sortKey).localeCompare(sortValue(b, opts.sortKey)),
-  );
-  const marginX = width * 0.1;
-  const marginY = height * 0.2;
-  const innerW = width - marginX * 2;
-  const innerH = height - marginY * 2;
-  const cols = Math.ceil(Math.sqrt(sorted.length * GOLDEN_RATIO));
-  const rows = Math.ceil(sorted.length / cols);
-  const cellW = innerW / cols;
-  const cellH = innerH / rows;
-  sorted.forEach((child, i) => {
-    const col = i % cols;
-    const row = Math.floor(i / cols);
-    const cx = centerX - width / 2 + marginX + col * cellW + cellW / 2;
-    const cy = centerY - height / 2 + marginY + row * cellH + cellH / 2;
-    const dims = templateSize(child.type);
-    const cw = Math.min(dims.width, cellW);
-    const ch = Math.min(dims.height, cellH);
-    layoutChildren(child, cx, cy, cw, ch, map, opts);
-  });
-}
+/** Shared instance for convenience. */
+export const nestedLayouter = new NestedLayouter();
 
 /**
- * Compute a nested layout where child nodes are contained within their parent.
- * Nodes are sorted alphabetically by label unless a custom key is provided.
+ * Convenience wrapper for {@link NestedLayouter.layoutHierarchy}.
  */
 export function layoutHierarchy(
   roots: HierNode[],
   opts: NestedLayoutOptions = {},
 ): NestedLayoutResult {
-  const nodes: Record<string, PositionedNode> = {};
-  let offsetY = 0;
-  const gap = 40;
-  roots.forEach((root) => {
-    const size = templateSize(root.type);
-    const y = offsetY + size.height / 2;
-    layoutChildren(
-      root,
-      size.width / 2,
-      y,
-      size.width,
-      size.height,
-      nodes,
-      opts,
-    );
-    offsetY += size.height + gap;
-  });
-  return { nodes };
+  return nestedLayouter.layoutHierarchy(roots, opts);
 }

--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -1,0 +1,106 @@
+import { templateManager } from '../../board/templates';
+
+export interface HierNode {
+  id: string;
+  label: string;
+  type: string;
+  children?: HierNode[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface NestedLayoutOptions {
+  sortKey?: string;
+}
+
+export interface PositionedNode {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface NestedLayoutResult {
+  nodes: Record<string, PositionedNode>;
+}
+
+const GOLDEN_RATIO = 1.618;
+const DEFAULT_SIZE = 160;
+
+function templateSize(type: string): { width: number; height: number } {
+  const tpl = templateManager.getTemplate(type);
+  const element = tpl?.elements.find((e) => e.width && e.height);
+  const width = element?.width ?? DEFAULT_SIZE;
+  const height = element?.height ?? width / GOLDEN_RATIO;
+  return { width, height };
+}
+
+function sortValue(node: HierNode, key?: string): string {
+  if (key && node.metadata && key in node.metadata) {
+    return String(node.metadata[key]);
+  }
+  return node.label ?? node.id;
+}
+
+function layoutChildren(
+  node: HierNode,
+  centerX: number,
+  centerY: number,
+  width: number,
+  height: number,
+  map: Record<string, PositionedNode>,
+  opts: NestedLayoutOptions,
+): void {
+  map[node.id] = { id: node.id, x: centerX, y: centerY, width, height };
+  const children = node.children;
+  if (!children?.length) return;
+  const sorted = [...children].sort((a, b) =>
+    sortValue(a, opts.sortKey).localeCompare(sortValue(b, opts.sortKey)),
+  );
+  const marginX = width * 0.1;
+  const marginY = height * 0.2;
+  const innerW = width - marginX * 2;
+  const innerH = height - marginY * 2;
+  const cols = Math.ceil(Math.sqrt(sorted.length * GOLDEN_RATIO));
+  const rows = Math.ceil(sorted.length / cols);
+  const cellW = innerW / cols;
+  const cellH = innerH / rows;
+  sorted.forEach((child, i) => {
+    const col = i % cols;
+    const row = Math.floor(i / cols);
+    const cx = centerX - width / 2 + marginX + col * cellW + cellW / 2;
+    const cy = centerY - height / 2 + marginY + row * cellH + cellH / 2;
+    const dims = templateSize(child.type);
+    const cw = Math.min(dims.width, cellW);
+    const ch = Math.min(dims.height, cellH);
+    layoutChildren(child, cx, cy, cw, ch, map, opts);
+  });
+}
+
+/**
+ * Compute a nested layout where child nodes are contained within their parent.
+ * Nodes are sorted alphabetically by label unless a custom key is provided.
+ */
+export function layoutHierarchy(
+  roots: HierNode[],
+  opts: NestedLayoutOptions = {},
+): NestedLayoutResult {
+  const nodes: Record<string, PositionedNode> = {};
+  let offsetY = 0;
+  const gap = 40;
+  roots.forEach((root) => {
+    const size = templateSize(root.type);
+    const y = offsetY + size.height / 2;
+    layoutChildren(
+      root,
+      size.width / 2,
+      y,
+      size.width,
+      size.height,
+      nodes,
+      opts,
+    );
+    offsetY += size.height + gap;
+  });
+  return { nodes };
+}

--- a/src/ui/hooks/ui-utils.ts
+++ b/src/ui/hooks/ui-utils.ts
@@ -1,5 +1,6 @@
 import { tokens } from '../tokens';
 import { GraphProcessor } from '../../core/graph/graph-processor';
+import { HierarchyProcessor } from '../../core/graph/hierarchy-processor';
 import { CardProcessor } from '../../board/card-processor';
 import type React from 'react';
 
@@ -17,7 +18,7 @@ const dropzoneStyles = {
 
 /** Undo last import and reset state helper. */
 export async function undoLastImport(
-  proc: GraphProcessor | CardProcessor | undefined,
+  proc: GraphProcessor | HierarchyProcessor | CardProcessor | undefined,
   clear: () => void,
 ): Promise<void> {
   if (!proc) return;

--- a/tests/boardbuilder-resize.test.ts
+++ b/tests/boardbuilder-resize.test.ts
@@ -1,0 +1,43 @@
+import { BoardBuilder } from '../src/board/board-builder';
+import { templateManager } from '../src/board/templates';
+
+describe('BoardBuilder resizeItem', () => {
+  test('updates width and height and syncs', async () => {
+    const builder = new BoardBuilder();
+    const item = { width: 1, height: 2, sync: jest.fn() } as unknown as Record<
+      string,
+      unknown
+    >;
+    await builder.resizeItem(item as any, 10, 20);
+    expect(item.width).toBe(10);
+    expect(item.height).toBe(20);
+    expect(item.sync).toHaveBeenCalled();
+  });
+
+  test('createNode applies layout size', async () => {
+    const builder = new BoardBuilder();
+    jest.spyOn(builder, 'findNode').mockResolvedValue(undefined);
+    jest
+      .spyOn(templateManager, 'getTemplate')
+      .mockReturnValue({
+        elements: [{ shape: 'rect', width: 10, height: 10 }],
+      });
+    jest
+      .spyOn(templateManager, 'createFromTemplate')
+      .mockResolvedValue({
+        type: 'shape',
+        setMetadata: jest.fn(),
+        sync: jest.fn(),
+        id: 's',
+      } as unknown as Record<string, unknown>);
+    const spy = jest.spyOn(builder, 'resizeItem').mockResolvedValue();
+    await builder.createNode(
+      { id: 'n', label: 'L', type: 'Role' } as unknown as Record<
+        string,
+        unknown
+      >,
+      { x: 0, y: 0, width: 50, height: 40 },
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/boardbuilder-resize.test.ts
+++ b/tests/boardbuilder-resize.test.ts
@@ -1,6 +1,6 @@
 import { BoardBuilder } from '../src/board/board-builder';
 import { templateManager } from '../src/board/templates';
-import type { BaseItem } from '@mirohq/websdk-types';
+import type { BaseItem, GroupableItem } from '@mirohq/websdk-types';
 
 interface GlobalWithMiro {
   miro?: { board?: Record<string, unknown> };
@@ -59,7 +59,10 @@ describe('BoardBuilder resizeItem', () => {
     } as unknown as GlobalWithMiro;
     const a = { id: 'a' } as unknown as BaseItem;
     const b = { id: 'b' } as unknown as BaseItem;
-    const group = await builder.groupItems([a, b]);
+    const group = await builder.groupItems([
+      a as unknown as GroupableItem,
+      b as unknown as GroupableItem,
+    ]);
     expect((global.miro.board.group as jest.Mock).mock.calls[0][0]).toEqual({
       items: [a, b],
     });

--- a/tests/boardbuilder-resize.test.ts
+++ b/tests/boardbuilder-resize.test.ts
@@ -1,14 +1,22 @@
 import { BoardBuilder } from '../src/board/board-builder';
 import { templateManager } from '../src/board/templates';
+import type { BaseItem } from '@mirohq/websdk-types';
+
+interface GlobalWithMiro {
+  miro?: { board?: Record<string, unknown> };
+}
+
+declare const global: GlobalWithMiro;
 
 describe('BoardBuilder resizeItem', () => {
   test('updates width and height and syncs', async () => {
     const builder = new BoardBuilder();
-    const item = { width: 1, height: 2, sync: jest.fn() } as unknown as Record<
-      string,
-      unknown
-    >;
-    await builder.resizeItem(item as any, 10, 20);
+    const item = {
+      width: 1,
+      height: 2,
+      sync: jest.fn(),
+    } as Partial<BaseItem> & { sync: jest.Mock };
+    await builder.resizeItem(item as unknown as BaseItem, 10, 20);
     expect(item.width).toBe(10);
     expect(item.height).toBe(20);
     expect(item.sync).toHaveBeenCalled();
@@ -32,12 +40,30 @@ describe('BoardBuilder resizeItem', () => {
       } as unknown as Record<string, unknown>);
     const spy = jest.spyOn(builder, 'resizeItem').mockResolvedValue();
     await builder.createNode(
-      { id: 'n', label: 'L', type: 'Role' } as unknown as Record<
-        string,
-        unknown
-      >,
+      { id: 'n', label: 'L', type: 'Role' } as {
+        id: string;
+        label: string;
+        type: string;
+      },
       { x: 0, y: 0, width: 50, height: 40 },
     );
     expect(spy).toHaveBeenCalled();
+  });
+
+  test('groupItems groups widgets together', async () => {
+    const builder = new BoardBuilder();
+    global.miro = {
+      board: {
+        group: jest.fn().mockResolvedValue({ id: 'g1', type: 'group' }),
+      },
+    } as unknown as GlobalWithMiro;
+    const a = { id: 'a' } as unknown as BaseItem;
+    const b = { id: 'b' } as unknown as BaseItem;
+    const group = await builder.groupItems([a, b]);
+    expect((global.miro.board.group as jest.Mock).mock.calls[0][0]).toEqual({
+      items: [a, b],
+    });
+    expect(group.id).toBe('g1');
+    delete global.miro;
   });
 });

--- a/tests/fixtures/sample-hier.json
+++ b/tests/fixtures/sample-hier.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "r1",
+    "label": "Root",
+    "type": "Role",
+    "children": [
+      {
+        "id": "c1",
+        "label": "Group",
+        "type": "Role",
+        "children": [
+          { "id": "g1", "label": "A", "type": "Role" },
+          { "id": "g2", "label": "B", "type": "Role" }
+        ]
+      },
+      { "id": "c2", "label": "Single", "type": "Role" }
+    ]
+  }
+]

--- a/tests/fixtures/sample-hier.json
+++ b/tests/fixtures/sample-hier.json
@@ -1,19 +1,206 @@
 [
   {
     "id": "r1",
-    "label": "Root",
+    "label": "Root 1",
     "type": "Role",
     "children": [
       {
-        "id": "c1",
-        "label": "Group",
+        "id": "r1c1",
+        "label": "Group 1.1",
         "type": "Role",
         "children": [
-          { "id": "g1", "label": "A", "type": "Role" },
-          { "id": "g2", "label": "B", "type": "Role" }
+          { "id": "r1c1g1", "label": "Item 1.1.1", "type": "Role" },
+          { "id": "r1c1g2", "label": "Item 1.1.2", "type": "Role" },
+          { "id": "r1c1g3", "label": "Item 1.1.3", "type": "Role" },
+          { "id": "r1c1g4", "label": "Item 1.1.4", "type": "Role" }
         ]
       },
-      { "id": "c2", "label": "Single", "type": "Role" }
+      {
+        "id": "r1c2",
+        "label": "Group 1.2",
+        "type": "Role",
+        "children": [
+          { "id": "r1c2g1", "label": "Item 1.2.1", "type": "Role" },
+          { "id": "r1c2g2", "label": "Item 1.2.2", "type": "Role" },
+          { "id": "r1c2g3", "label": "Item 1.2.3", "type": "Role" },
+          { "id": "r1c2g4", "label": "Item 1.2.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r1c3",
+        "label": "Group 1.3",
+        "type": "Role",
+        "children": [
+          { "id": "r1c3g1", "label": "Item 1.3.1", "type": "Role" },
+          { "id": "r1c3g2", "label": "Item 1.3.2", "type": "Role" },
+          { "id": "r1c3g3", "label": "Item 1.3.3", "type": "Role" },
+          { "id": "r1c3g4", "label": "Item 1.3.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r1c4",
+        "label": "Group 1.4",
+        "type": "Role",
+        "children": [
+          { "id": "r1c4g1", "label": "Item 1.4.1", "type": "Role" },
+          { "id": "r1c4g2", "label": "Item 1.4.2", "type": "Role" },
+          { "id": "r1c4g3", "label": "Item 1.4.3", "type": "Role" },
+          { "id": "r1c4g4", "label": "Item 1.4.4", "type": "Role" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "r2",
+    "label": "Root 2",
+    "type": "Role",
+    "children": [
+      {
+        "id": "r2c1",
+        "label": "Group 2.1",
+        "type": "Role",
+        "children": [
+          { "id": "r2c1g1", "label": "Item 2.1.1", "type": "Role" },
+          { "id": "r2c1g2", "label": "Item 2.1.2", "type": "Role" },
+          { "id": "r2c1g3", "label": "Item 2.1.3", "type": "Role" },
+          { "id": "r2c1g4", "label": "Item 2.1.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r2c2",
+        "label": "Group 2.2",
+        "type": "Role",
+        "children": [
+          { "id": "r2c2g1", "label": "Item 2.2.1", "type": "Role" },
+          { "id": "r2c2g2", "label": "Item 2.2.2", "type": "Role" },
+          { "id": "r2c2g3", "label": "Item 2.2.3", "type": "Role" },
+          { "id": "r2c2g4", "label": "Item 2.2.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r2c3",
+        "label": "Group 2.3",
+        "type": "Role",
+        "children": [
+          { "id": "r2c3g1", "label": "Item 2.3.1", "type": "Role" },
+          { "id": "r2c3g2", "label": "Item 2.3.2", "type": "Role" },
+          { "id": "r2c3g3", "label": "Item 2.3.3", "type": "Role" },
+          { "id": "r2c3g4", "label": "Item 2.3.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r2c4",
+        "label": "Group 2.4",
+        "type": "Role",
+        "children": [
+          { "id": "r2c4g1", "label": "Item 2.4.1", "type": "Role" },
+          { "id": "r2c4g2", "label": "Item 2.4.2", "type": "Role" },
+          { "id": "r2c4g3", "label": "Item 2.4.3", "type": "Role" },
+          { "id": "r2c4g4", "label": "Item 2.4.4", "type": "Role" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "r3",
+    "label": "Root 3",
+    "type": "Role",
+    "children": [
+      {
+        "id": "r3c1",
+        "label": "Group 3.1",
+        "type": "Role",
+        "children": [
+          { "id": "r3c1g1", "label": "Item 3.1.1", "type": "Role" },
+          { "id": "r3c1g2", "label": "Item 3.1.2", "type": "Role" },
+          { "id": "r3c1g3", "label": "Item 3.1.3", "type": "Role" },
+          { "id": "r3c1g4", "label": "Item 3.1.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r3c2",
+        "label": "Group 3.2",
+        "type": "Role",
+        "children": [
+          { "id": "r3c2g1", "label": "Item 3.2.1", "type": "Role" },
+          { "id": "r3c2g2", "label": "Item 3.2.2", "type": "Role" },
+          { "id": "r3c2g3", "label": "Item 3.2.3", "type": "Role" },
+          { "id": "r3c2g4", "label": "Item 3.2.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r3c3",
+        "label": "Group 3.3",
+        "type": "Role",
+        "children": [
+          { "id": "r3c3g1", "label": "Item 3.3.1", "type": "Role" },
+          { "id": "r3c3g2", "label": "Item 3.3.2", "type": "Role" },
+          { "id": "r3c3g3", "label": "Item 3.3.3", "type": "Role" },
+          { "id": "r3c3g4", "label": "Item 3.3.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r3c4",
+        "label": "Group 3.4",
+        "type": "Role",
+        "children": [
+          { "id": "r3c4g1", "label": "Item 3.4.1", "type": "Role" },
+          { "id": "r3c4g2", "label": "Item 3.4.2", "type": "Role" },
+          { "id": "r3c4g3", "label": "Item 3.4.3", "type": "Role" },
+          { "id": "r3c4g4", "label": "Item 3.4.4", "type": "Role" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "r4",
+    "label": "Root 4",
+    "type": "Role",
+    "children": [
+      {
+        "id": "r4c1",
+        "label": "Group 4.1",
+        "type": "Role",
+        "children": [
+          { "id": "r4c1g1", "label": "Item 4.1.1", "type": "Role" },
+          { "id": "r4c1g2", "label": "Item 4.1.2", "type": "Role" },
+          { "id": "r4c1g3", "label": "Item 4.1.3", "type": "Role" },
+          { "id": "r4c1g4", "label": "Item 4.1.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r4c2",
+        "label": "Group 4.2",
+        "type": "Role",
+        "children": [
+          { "id": "r4c2g1", "label": "Item 4.2.1", "type": "Role" },
+          { "id": "r4c2g2", "label": "Item 4.2.2", "type": "Role" },
+          { "id": "r4c2g3", "label": "Item 4.2.3", "type": "Role" },
+          { "id": "r4c2g4", "label": "Item 4.2.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r4c3",
+        "label": "Group 4.3",
+        "type": "Role",
+        "children": [
+          { "id": "r4c3g1", "label": "Item 4.3.1", "type": "Role" },
+          { "id": "r4c3g2", "label": "Item 4.3.2", "type": "Role" },
+          { "id": "r4c3g3", "label": "Item 4.3.3", "type": "Role" },
+          { "id": "r4c3g4", "label": "Item 4.3.4", "type": "Role" }
+        ]
+      },
+      {
+        "id": "r4c4",
+        "label": "Group 4.4",
+        "type": "Role",
+        "children": [
+          { "id": "r4c4g1", "label": "Item 4.4.1", "type": "Role" },
+          { "id": "r4c4g2", "label": "Item 4.4.2", "type": "Role" },
+          { "id": "r4c4g3", "label": "Item 4.4.3", "type": "Role" },
+          { "id": "r4c4g4", "label": "Item 4.4.4", "type": "Role" }
+        ]
+      }
     ]
   }
 ]

--- a/tests/hierarchy-processor.test.ts
+++ b/tests/hierarchy-processor.test.ts
@@ -1,0 +1,61 @@
+import { HierarchyProcessor } from '../src/core/graph/hierarchy-processor';
+import { templateManager } from '../src/board/templates';
+
+interface GlobalWithMiro {
+  miro?: { board?: Record<string, unknown> };
+}
+
+declare const global: GlobalWithMiro;
+
+describe('HierarchyProcessor', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  test('processFile loads data and delegates', async () => {
+    const proc = new HierarchyProcessor();
+    const spy = jest.spyOn(proc as any, 'processHierarchy').mockResolvedValue();
+    const file = {
+      name: 'h.json',
+      text: jest
+        .fn()
+        .mockResolvedValue('[{"id":"n","label":"L","type":"Role"}]'),
+    } as unknown as File;
+    await proc.processFile(file);
+    expect(spy).toHaveBeenCalledWith(
+      [{ id: 'n', label: 'L', type: 'Role' }],
+      {},
+    );
+  });
+
+  test('processHierarchy creates widgets and zooms', async () => {
+    global.miro = {
+      board: {
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+        viewport: {
+          get: jest
+            .fn()
+            .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+          zoomTo: jest.fn(),
+        },
+        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+      },
+    };
+    jest
+      .spyOn(templateManager, 'createFromTemplate')
+      .mockResolvedValue({
+        type: 'shape',
+        setMetadata: jest.fn(),
+        getItems: jest.fn().mockResolvedValue([]),
+        sync: jest.fn(),
+        id: 's1',
+      } as unknown);
+    const proc = new HierarchyProcessor();
+    await proc.processHierarchy([{ id: 'n', label: 'L', type: 'Role' }]);
+    expect(global.miro.board.viewport.zoomTo).toHaveBeenCalled();
+  });
+});

--- a/tests/nested-layout.test.ts
+++ b/tests/nested-layout.test.ts
@@ -1,0 +1,69 @@
+import { layoutHierarchy } from '../src/core/layout/nested-layout';
+import { templateManager } from '../src/board/templates';
+
+interface TestNode {
+  id: string;
+  label: string;
+  type: string;
+  children?: TestNode[];
+  metadata?: Record<string, unknown>;
+}
+
+describe('layoutHierarchy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('creates positions for nested nodes', () => {
+    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
+      elements: [{ width: 100, height: 60 }],
+    });
+    const data: TestNode[] = [
+      {
+        id: 'p',
+        label: 'Parent',
+        type: 'Role',
+        children: [
+          { id: 'a', label: 'A', type: 'Role' },
+          { id: 'b', label: 'B', type: 'Role' },
+        ],
+      },
+    ];
+    const result = layoutHierarchy(data);
+    expect(Object.keys(result.nodes)).toHaveLength(3);
+    const parent = result.nodes.p;
+    const childA = result.nodes.a;
+    const childB = result.nodes.b;
+    expect(childA.x).toBeLessThan(childB.x);
+    expect(parent.width).toBe(100);
+  });
+
+  test('sorts children by custom key', () => {
+    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
+      elements: [{ width: 100, height: 60 }],
+    });
+    const data: TestNode[] = [
+      {
+        id: 'p',
+        label: 'Parent',
+        type: 'Role',
+        children: [
+          { id: 'a', label: 'B', type: 'Role', metadata: { id: 2 } },
+          { id: 'b', label: 'A', type: 'Role', metadata: { id: 1 } },
+        ],
+      },
+    ];
+    const result = layoutHierarchy(data, { sortKey: 'id' });
+    const first = result.nodes.a.x < result.nodes.b.x ? 'a' : 'b';
+    expect(first).toBe('b');
+  });
+
+  test('falls back to golden ratio height', () => {
+    vi.spyOn(templateManager, 'getTemplate').mockReturnValue(
+      undefined as never,
+    );
+    const data: TestNode[] = [{ id: 'n', label: 'N', type: 'Role' }];
+    const result = layoutHierarchy(data);
+    expect(result.nodes.n.height).toBeCloseTo(160 / 1.618, 5);
+  });
+});

--- a/tests/nested-layout.test.ts
+++ b/tests/nested-layout.test.ts
@@ -1,5 +1,6 @@
 import { layoutHierarchy } from '../src/core/layout/nested-layout';
 import { templateManager } from '../src/board/templates';
+import sampleHier from './fixtures/sample-hier.json';
 
 interface TestNode {
   id: string;
@@ -65,5 +66,14 @@ describe('layoutHierarchy', () => {
     const data: TestNode[] = [{ id: 'n', label: 'N', type: 'Role' }];
     const result = layoutHierarchy(data);
     expect(result.nodes.n.height).toBeCloseTo(160 / 1.618, 5);
+  });
+
+  test('positions example dataset', () => {
+    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
+      elements: [{ width: 120, height: 80 }],
+    });
+    const result = layoutHierarchy(sampleHier as TestNode[]);
+    expect(Object.keys(result.nodes)).toHaveLength(5);
+    expect(result.nodes.c1.x).toBeLessThan(result.nodes.c2.x);
   });
 });

--- a/tests/nested-layout.test.ts
+++ b/tests/nested-layout.test.ts
@@ -1,5 +1,4 @@
 import { layoutHierarchy } from '../src/core/layout/nested-layout';
-import { templateManager } from '../src/board/templates';
 import sampleHier from './fixtures/sample-hier.json';
 
 interface TestNode {
@@ -16,9 +15,6 @@ describe('layoutHierarchy', () => {
   });
 
   test('creates positions for nested nodes', () => {
-    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
-      elements: [{ width: 100, height: 60 }],
-    });
     const data: TestNode[] = [
       {
         id: 'p',
@@ -36,13 +32,10 @@ describe('layoutHierarchy', () => {
     const childA = result.nodes.a;
     const childB = result.nodes.b;
     expect(childA.x).toBeLessThan(childB.x);
-    expect(parent.width).toBe(100);
+    expect(parent.width).toBeGreaterThan(childA.width);
   });
 
   test('sorts children by custom key', () => {
-    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
-      elements: [{ width: 100, height: 60 }],
-    });
     const data: TestNode[] = [
       {
         id: 'p',
@@ -59,21 +52,17 @@ describe('layoutHierarchy', () => {
     expect(first).toBe('b');
   });
 
-  test('falls back to golden ratio height', () => {
-    vi.spyOn(templateManager, 'getTemplate').mockReturnValue(
-      undefined as never,
-    );
+  test('assigns fixed leaf size', () => {
     const data: TestNode[] = [{ id: 'n', label: 'N', type: 'Role' }];
     const result = layoutHierarchy(data);
-    expect(result.nodes.n.height).toBeCloseTo(160 / 1.618, 5);
+    expect(result.nodes.n.width).toBe(120);
+    expect(result.nodes.n.height).toBe(30);
   });
 
   test('positions example dataset', () => {
-    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
-      elements: [{ width: 120, height: 80 }],
-    });
     const result = layoutHierarchy(sampleHier as TestNode[]);
-    expect(Object.keys(result.nodes)).toHaveLength(5);
-    expect(result.nodes.c1.x).toBeLessThan(result.nodes.c2.x);
+    expect(Object.keys(result.nodes)).toHaveLength(84);
+    expect(result.nodes['r1c1g1'].width).toBe(120);
+    expect(result.nodes['r1c1g1'].height).toBe(30);
   });
 });


### PR DESCRIPTION
## Summary
- implement `layoutHierarchy` for nested layout
- add unit tests for nested layout algorithm

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a2a0d49fc832bacc226cec7f8d830