### PR TITLE
Add frames renaming feature

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -34,6 +34,18 @@ ambiguity.
 
 ---
 
+## 2\u00a0 Frames Tab
+
+| Control           | Details                                         |
+| ----------------- | ----------------------------------------------- |
+| **Prefix Input**  | Text prefix used for renaming                   |
+| **Rename Button** | Applies prefix in left\u2011to\u2011right order |
+
+Flow: select frames, type prefix, press **Rename Frames** → titles become
+`<prefix>0`, `<prefix>1`, ...
+
+---
+
 ## 3  Resize Tab
 
 Panel split vertically **(Stack space="lg")**

--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -1,0 +1,48 @@
+import { BoardLike, getBoard } from './board';
+
+/** Options for renaming selected frames. */
+export interface RenameOptions {
+  /** Text prefix for the frame titles. */
+  prefix: string;
+}
+
+/**
+ * Rename all selected frames from left to right applying `<prefix><index>`.
+ *
+ * @param opts - Prefix configuration.
+ * @param board - Optional board API override for testing.
+ */
+export async function renameSelectedFrames(
+  opts: RenameOptions,
+  board?: BoardLike,
+): Promise<void> {
+  const b = getBoard(board);
+  const selection = await b.getSelection();
+  const frames = selection.filter(
+    (
+      i,
+    ): i is Record<string, unknown> & {
+      x?: number;
+      y?: number;
+      type?: string;
+    } => (i as { type?: string }).type === 'frame',
+  );
+  if (!frames.length) return;
+  frames.sort((a, b) => {
+    const ax = (a.x as number | undefined) ?? 0;
+    const bx = (b.x as number | undefined) ?? 0;
+    if (ax === bx) {
+      const ay = (a.y as number | undefined) ?? 0;
+      const by = (b.y as number | undefined) ?? 0;
+      return ay - by;
+    }
+    return ax - bx;
+  });
+  await Promise.all(
+    frames.map(async (frame, i) => {
+      frame.title = `${opts.prefix}${i}`;
+      const sync = (frame as { sync?: () => Promise<void> }).sync;
+      if (typeof sync === 'function') await sync();
+    }),
+  );
+}

--- a/src/ui/pages/FramesTab.tsx
+++ b/src/ui/pages/FramesTab.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Button, Icon, InputField, Text } from '../components/legacy';
+import { renameSelectedFrames } from '../../board/frame-tools';
+import type { TabTuple } from './tab-definitions';
+
+/** UI for renaming selected frames. */
+export const FramesTab: React.FC = () => {
+  const [prefix, setPrefix] = React.useState('Frame-');
+  const rename = async (): Promise<void> => {
+    await renameSelectedFrames({ prefix });
+  };
+  return (
+    <div>
+      <InputField label='Prefix'>
+        <input
+          className='input input-small'
+          value={prefix}
+          onChange={(e) => setPrefix(e.target.value)}
+          placeholder='Prefix'
+        />
+      </InputField>
+      <div className='buttons'>
+        <Button
+          onClick={rename}
+          variant='primary'>
+          <React.Fragment key='.0'>
+            <Icon name='edit' />
+            <Text>Rename Frames</Text>
+          </React.Fragment>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const tabDef: TabTuple = [
+  2,
+  'frames',
+  'Frames',
+  'Rename selected frames',
+  FramesTab,
+];

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -5,6 +5,7 @@ export type TabId =
   | 'resize'
   | 'style'
   | 'grid'
+  | 'frames'
   | 'spacing'
   | 'dummy';
 

--- a/tests/frame-tools.test.ts
+++ b/tests/frame-tools.test.ts
@@ -1,0 +1,37 @@
+import { renameSelectedFrames } from '../src/board/frame-tools';
+import { BoardLike } from '../src/board/board';
+
+describe('frame-tools', () => {
+  test('renameSelectedFrames updates titles in order', async () => {
+    const frames = [
+      { x: 20, y: 0, title: 'old', sync: jest.fn(), type: 'frame' },
+      { x: 10, y: 0, title: 'old2', sync: jest.fn(), type: 'frame' },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'F-' }, board);
+    expect(frames[1].title).toBe('F-0');
+    expect(frames[0].title).toBe('F-1');
+    expect(frames[0].sync).toHaveBeenCalled();
+  });
+
+  test('renameSelectedFrames ignores non-frames', async () => {
+    const items = [
+      { x: 0, title: 'A', sync: jest.fn(), type: 'shape' },
+      { x: 1, title: 'B', sync: jest.fn(), type: 'frame' },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(items),
+    };
+    await renameSelectedFrames({ prefix: 'X' }, board);
+    expect(items[0].title).toBe('A');
+    expect(items[1].title).toBe('X0');
+  });
+
+  test('renameSelectedFrames throws without board', async () => {
+    await expect(renameSelectedFrames({ prefix: 'P' })).rejects.toThrow(
+      'Miro board not available',
+    );
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -8,11 +8,13 @@ import { GridTab } from '../src/ui/pages/GridTab';
 import { SpacingTab } from '../src/ui/pages/SpacingTab';
 import { DiagramTab } from '../src/ui/pages/DiagramTab';
 import { CardsTab } from '../src/ui/pages/CardsTab';
+import { FramesTab } from '../src/ui/pages/FramesTab';
 import * as resizeTools from '../src/board/resize-tools';
 import * as styleTools from '../src/board/style-tools';
 import * as formatTools from '../src/board/format-tools';
 import * as gridTools from '../src/board/grid-tools';
 import * as spacingTools from '../src/board/spacing-tools';
+import * as frameTools from '../src/board/frame-tools';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
 import { CardProcessor } from '../src/board/card-processor';
 
@@ -29,6 +31,7 @@ vi.mock('../src/board/format-tools', async () => {
 });
 vi.mock('../src/board/grid-tools');
 vi.mock('../src/board/spacing-tools');
+vi.mock('../src/board/frame-tools');
 vi.mock('../src/core/graph/graph-processor');
 vi.mock('../src/board/card-processor');
 
@@ -215,6 +218,20 @@ describe('tab components', () => {
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({ axis: 'x', spacing: 20, mode: 'grow' }),
     );
+  });
+
+  test('FramesTab renames frames', async () => {
+    const spy = jest
+      .spyOn(frameTools, 'renameSelectedFrames')
+      .mockResolvedValue(undefined as unknown as void);
+    render(React.createElement(FramesTab));
+    fireEvent.change(screen.getByLabelText('Prefix'), {
+      target: { value: 'A-' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText(/rename frames/i));
+    });
+    expect(spy).toHaveBeenCalledWith({ prefix: 'A-' });
   });
 
   test('DiagramTab processes file', async () => {


### PR DESCRIPTION
## Summary
- add `renameSelectedFrames` to rename selected frames sequentially
- create `FramesTab` UI with prefix input
- document Frames tab
- include frames tab in sidebar
- test frame-tools and FramesTab

## Testing
- `npm run prettier --silent`
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b3fbf81e8832bbaef3f2546223415