### PR TITLE
Fix frame sync context

### DIFF
--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -41,8 +41,8 @@ export async function renameSelectedFrames(
   await Promise.all(
     frames.map(async (frame, i) => {
       frame.title = `${opts.prefix}${i}`;
-      const sync = (frame as { sync?: () => Promise<void> }).sync;
-      if (typeof sync === 'function') await sync();
+      await ((frame as { sync?: () => Promise<void> }).sync?.call(frame) ??
+        Promise.resolve());
     }),
   );
 }

--- a/tests/frame-tools.test.ts
+++ b/tests/frame-tools.test.ts
@@ -16,6 +16,25 @@ describe('frame-tools', () => {
     expect(frames[0].sync).toHaveBeenCalled();
   });
 
+  test('renameSelectedFrames preserves this context for sync', async () => {
+    const contexts: unknown[] = [];
+    const frame = {
+      x: 0,
+      y: 0,
+      title: 'a',
+      type: 'frame',
+      sync() {
+        contexts.push(this);
+      },
+    };
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue([frame]),
+    };
+    await renameSelectedFrames({ prefix: 'Z-' }, board);
+    expect(contexts[0]).toBe(frame);
+    expect(frame.title).toBe('Z-0');
+  });
+
   test('renameSelectedFrames ignores non-frames', async () => {
     const items = [
       { x: 0, title: 'A', sync: jest.fn(), type: 'shape' },


### PR DESCRIPTION
## Summary
- preserve `this` context when calling sync in frame-tools
- add a test for proper context handling in `renameSelectedFrames`

## Testing
- `npm run prettier --silent`
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685b47d8d1b8832ba4a400d52750c7b6