### PR TITLE
Fix nested layout bounds

### DIFF
--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -87,10 +87,12 @@ export class HierarchyProcessor {
       maxX = -Infinity,
       maxY = -Infinity;
     Object.values(result.nodes).forEach(({ x, y, width, height }) => {
-      minX = Math.min(minX, x);
-      minY = Math.min(minY, y);
-      maxX = Math.max(maxX, x + width);
-      maxY = Math.max(maxY, y + height);
+      const halfW = width / 2;
+      const halfH = height / 2;
+      minX = Math.min(minX, x - halfW);
+      minY = Math.min(minY, y - halfH);
+      maxX = Math.max(maxX, x + halfW);
+      maxY = Math.max(maxY, y + halfH);
     });
     return { minX, minY, maxX, maxY };
   }

--- a/tests/hierarchy-bounds.test.ts
+++ b/tests/hierarchy-bounds.test.ts
@@ -1,0 +1,33 @@
+import { HierarchyProcessor } from '../src/core/graph/hierarchy-processor';
+import { layoutHierarchy } from '../src/core/layout/nested-layout';
+
+interface Node {
+  id: string;
+  label: string;
+  type: string;
+  children?: Node[];
+}
+
+describe('HierarchyProcessor computeBounds', () => {
+  test('uses center coordinates when calculating bounds', () => {
+    const roots: Node[] = [
+      { id: 'r', label: 'Root', type: 'Role' },
+      { id: 's', label: 'Second', type: 'Role' },
+    ];
+    const layout = layoutHierarchy(roots);
+    const proc = new HierarchyProcessor();
+    const bounds = (
+      proc as unknown as {
+        computeBounds: (r: unknown) => {
+          minX: number;
+          minY: number;
+          maxX: number;
+          maxY: number;
+        };
+      }
+    ).computeBounds(layout);
+    const r = layout.nodes.r;
+    expect(bounds.minX).toBeCloseTo(r.x - r.width / 2);
+    expect(bounds.maxX).toBeCloseTo(r.x + r.width / 2);
+  });
+});


### PR DESCRIPTION
## Summary
- correct bounding box calculation for hierarchical layouts
- test computeBounds with layoutHierarchy

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685b4d358b74832badba75707a70f7b8