### PR TITLE
Switch nested layout to ELK

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ A small example is provided in
 ## Nested Layouts
 
 Hierarchical data where children are contained within parent shapes can be
-visualised using the **Nested** layout option in the Diagram tab. Nodes are
-sorted alphabetically by default or via a custom metadata key. A three‑level
-sample dataset is available at
+visualised using the **Nested** layout option in the Diagram tab. The positions
+are computed by the ELK engine for consistent spacing. Nodes are sorted
+alphabetically by default or via a custom metadata key. A three‑level sample
+dataset is available at
 [tests/fixtures/sample-hier.json](tests/fixtures/sample-hier.json). Simply
 select **Nested** and import this file to see parent widgets sized to fit their
 children. If a standard flat graph is supplied instead, the importer will raise

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -48,9 +48,9 @@ value.
 A three-level hierarchical dataset can be found in
 [`tests/fixtures/sample-hier.json`](../tests/fixtures/sample-hier.json). It
 contains four top-level groups, each with four subgroups and four items per
-subgroup. This is useful when experimenting with the nested layout algorithm.
-Import the JSON in the **Create** tab and choose the **Nested** diagram layout
-to see child nodes arranged inside their parents.
+subgroup. This is useful when experimenting with the ELK-based nested layout
+algorithm. Import the JSON in the **Create** tab and choose the **Nested**
+diagram layout to see child nodes arranged inside their parents.
 
 ---
 

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -55,7 +55,7 @@ export class HierarchyProcessor {
   ): Promise<void> {
     if (!Array.isArray(roots)) throw new Error('Invalid hierarchy');
     this.lastCreated = [];
-    const result = layoutHierarchy(roots, { sortKey: opts.sortKey });
+    const result = await layoutHierarchy(roots, { sortKey: opts.sortKey });
     const bounds = this.computeBounds(result);
     const margin = 40;
     const width = bounds.maxX - bounds.minX + margin * 2;

--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -23,29 +23,17 @@ export interface NestedLayoutResult {
   nodes: Record<string, PositionedNode>;
 }
 
-const GOLDEN_RATIO = 1.618;
 const LEAF_WIDTH = 120;
 const LEAF_HEIGHT = 30;
 const PADDING = 20;
 
+import { performLayout } from './layout-core';
+import type { GraphData } from '../graph';
+
 /**
- * Helper class that positions hierarchical nodes using an intrinsic grid
- * computed from the golden ratio. Children are sorted alphabetically unless a
- * specific metadata key is provided.
+ * Layout hierarchical data using the ELK engine and compute container sizes.
  */
 export class NestedLayouter {
-  /** Cache of measured node sizes. */
-  private sizes: Record<string, { width: number; height: number }> = {};
-
-  /** Sorted child order for each node. */
-  private order: Record<string, HierNode[]> = {};
-
-  /** Determine a leaf node's size. */
-  private leafSize(): { width: number; height: number } {
-    return { width: LEAF_WIDTH, height: LEAF_HEIGHT };
-  }
-
-  /** Retrieve the sort value for a node. */
   private sortValue(node: HierNode, key?: string): string {
     if (key && node.metadata && key in node.metadata) {
       return String(node.metadata[key]);
@@ -53,85 +41,87 @@ export class NestedLayouter {
     return node.label ?? node.id;
   }
 
-  /**
-   * Measure a node and its children, recording sizes in {@link sizes}.
-   */
-  private measure(
-    node: HierNode,
-    opts: NestedLayoutOptions,
-  ): { width: number; height: number } {
-    const children = node.children;
-    if (!children?.length) {
-      const size = this.leafSize();
-      this.sizes[node.id] = size;
-      return size;
-    }
+  private buildGraph(roots: HierNode[], sortKey?: string): GraphData {
+    const nodes: GraphData['nodes'] = [];
+    const edges: GraphData['edges'] = [];
 
-    const sorted = [...children].sort((a, b) =>
-      this.sortValue(a, opts.sortKey).localeCompare(
-        this.sortValue(b, opts.sortKey),
-      ),
-    );
-    this.order[node.id] = sorted;
-    const childSizes = sorted.map((child) => this.measure(child, opts));
-    const maxW = Math.max(...childSizes.map((s) => s.width));
-    const maxH = Math.max(...childSizes.map((s) => s.height));
-    const cols = Math.ceil(Math.sqrt(sorted.length * GOLDEN_RATIO));
-    const rows = Math.ceil(sorted.length / cols);
-    const width = cols * maxW + PADDING * 2;
-    const height = rows * maxH + PADDING * 2;
-    this.sizes[node.id] = { width, height };
-    return { width, height };
+    const visit = (node: HierNode, parent?: HierNode): void => {
+      nodes.push({
+        id: node.id,
+        label: node.label,
+        type: node.type,
+        metadata: { width: LEAF_WIDTH, height: LEAF_HEIGHT },
+      });
+      if (parent) edges.push({ from: parent.id, to: node.id });
+      const children = node.children;
+      if (!children?.length) return;
+      const sorted = [...children].sort((a, b) =>
+        this.sortValue(a, sortKey).localeCompare(this.sortValue(b, sortKey)),
+      );
+      for (const child of sorted) visit(child, node);
+    };
+
+    roots.forEach((r) => visit(r));
+    return { nodes, edges };
   }
 
-  /**
-   * Recursively position a node and its children.
-   */
-  private place(
+  private computeContainers(
     node: HierNode,
-    centerX: number,
-    centerY: number,
     map: Record<string, PositionedNode>,
-  ): void {
-    const { width, height } = this.sizes[node.id];
-    map[node.id] = { id: node.id, x: centerX, y: centerY, width, height };
-    const children = this.order[node.id];
-    if (!children?.length) return;
-    const cols = Math.ceil(Math.sqrt(children.length * GOLDEN_RATIO));
-    const childSizes = children.map((c) => this.sizes[c.id]);
-    const maxW = Math.max(...childSizes.map((s) => s.width));
-    const maxH = Math.max(...childSizes.map((s) => s.height));
-    const x0 = centerX - width / 2 + PADDING + maxW / 2;
-    const y0 = centerY - height / 2 + PADDING + maxH / 2;
-    children.forEach((child, i) => {
-      const col = i % cols;
-      const row = Math.floor(i / cols);
-      const cx = x0 + col * maxW;
-      const cy = y0 + row * maxH;
-      this.place(child, cx, cy, map);
-    });
+  ): { minX: number; minY: number; maxX: number; maxY: number } {
+    const pos = map[node.id];
+    if (!node.children?.length) {
+      return {
+        minX: pos.x - pos.width / 2,
+        minY: pos.y - pos.height / 2,
+        maxX: pos.x + pos.width / 2,
+        maxY: pos.y + pos.height / 2,
+      };
+    }
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const child of node.children) {
+      const b = this.computeContainers(child, map);
+      minX = Math.min(minX, b.minX);
+      minY = Math.min(minY, b.minY);
+      maxX = Math.max(maxX, b.maxX);
+      maxY = Math.max(maxY, b.maxY);
+    }
+    const width = maxX - minX + PADDING * 2;
+    const height = maxY - minY + PADDING * 2;
+    const cx = (minX + maxX) / 2;
+    const cy = (minY + maxY) / 2;
+    map[node.id] = { id: node.id, x: cx, y: cy, width, height };
+    return {
+      minX: cx - width / 2,
+      minY: cy - height / 2,
+      maxX: cx + width / 2,
+      maxY: cy + height / 2,
+    };
   }
 
   /**
-   * Compute a nested layout where child nodes are contained within their
-   * parent.
+   * Compute a nested layout using ELK for positioning.
    */
-  public layoutHierarchy(
+  public async layoutHierarchy(
     roots: HierNode[],
     opts: NestedLayoutOptions = {},
-  ): NestedLayoutResult {
-    this.sizes = {};
-    this.order = {};
+  ): Promise<NestedLayoutResult> {
+    const graph = this.buildGraph(roots, opts.sortKey);
+    const layout = await performLayout(graph);
     const nodes: Record<string, PositionedNode> = {};
-    roots.forEach((root) => this.measure(root, opts));
-    let offsetY = 0;
-    const gap = 40;
-    roots.forEach((root) => {
-      const size = this.sizes[root.id];
-      const y = offsetY + size.height / 2;
-      this.place(root, size.width / 2, y, nodes);
-      offsetY += size.height + gap;
+    Object.entries(layout.nodes).forEach(([id, n]) => {
+      nodes[id] = {
+        id,
+        x: n.x + n.width / 2,
+        y: n.y + n.height / 2,
+        width: n.width,
+        height: n.height,
+      };
     });
+    roots.forEach((r) => this.computeContainers(r, nodes));
     return { nodes };
   }
 }
@@ -145,6 +135,6 @@ export const nestedLayouter = new NestedLayouter();
 export function layoutHierarchy(
   roots: HierNode[],
   opts: NestedLayoutOptions = {},
-): NestedLayoutResult {
+): Promise<NestedLayoutResult> {
   return nestedLayouter.layoutHierarchy(roots, opts);
 }

--- a/tests/hierarchy-bounds.test.ts
+++ b/tests/hierarchy-bounds.test.ts
@@ -9,12 +9,12 @@ interface Node {
 }
 
 describe('HierarchyProcessor computeBounds', () => {
-  test('uses center coordinates when calculating bounds', () => {
+  test('uses center coordinates when calculating bounds', async () => {
     const roots: Node[] = [
       { id: 'r', label: 'Root', type: 'Role' },
       { id: 's', label: 'Second', type: 'Role' },
     ];
-    const layout = layoutHierarchy(roots);
+    const layout = await layoutHierarchy(roots);
     const proc = new HierarchyProcessor();
     const bounds = (
       proc as unknown as {

--- a/tests/nested-layout.test.ts
+++ b/tests/nested-layout.test.ts
@@ -14,7 +14,7 @@ describe('layoutHierarchy', () => {
     vi.restoreAllMocks();
   });
 
-  test('creates positions for nested nodes', () => {
+  test('creates positions for nested nodes', async () => {
     const data: TestNode[] = [
       {
         id: 'p',
@@ -26,7 +26,7 @@ describe('layoutHierarchy', () => {
         ],
       },
     ];
-    const result = layoutHierarchy(data);
+    const result = await layoutHierarchy(data);
     expect(Object.keys(result.nodes)).toHaveLength(3);
     const parent = result.nodes.p;
     const childA = result.nodes.a;
@@ -35,7 +35,7 @@ describe('layoutHierarchy', () => {
     expect(parent.width).toBeGreaterThan(childA.width);
   });
 
-  test('sorts children by custom key', () => {
+  test('sorts children by custom key', async () => {
     const data: TestNode[] = [
       {
         id: 'p',
@@ -47,20 +47,20 @@ describe('layoutHierarchy', () => {
         ],
       },
     ];
-    const result = layoutHierarchy(data, { sortKey: 'id' });
+    const result = await layoutHierarchy(data, { sortKey: 'id' });
     const first = result.nodes.a.x < result.nodes.b.x ? 'a' : 'b';
     expect(first).toBe('b');
   });
 
-  test('assigns fixed leaf size', () => {
+  test('assigns fixed leaf size', async () => {
     const data: TestNode[] = [{ id: 'n', label: 'N', type: 'Role' }];
-    const result = layoutHierarchy(data);
+    const result = await layoutHierarchy(data);
     expect(result.nodes.n.width).toBe(120);
     expect(result.nodes.n.height).toBe(30);
   });
 
-  test('positions example dataset', () => {
-    const result = layoutHierarchy(sampleHier as TestNode[]);
+  test('positions example dataset', async () => {
+    const result = await layoutHierarchy(sampleHier as TestNode[]);
     expect(Object.keys(result.nodes)).toHaveLength(84);
     expect(result.nodes['r1c1g1'].width).toBe(120);
     expect(result.nodes['r1c1g1'].height).toBe(30);


### PR DESCRIPTION
## Summary
- replace custom nested layout algorithm with ELK engine
- update hierarchy processor to await layout
- adapt tests for async layout
- document ELK usage in README and templates guide

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685b51811ad8832b876f5543624b1ac7