### PR TITLE
Implement automatic grid layout for cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ placement.
 3. Select a `.json` file. Diagrams require `nodes` and `edges` while the cards
    option expects an object with a `cards` array.
 4. Once processed, widgets are placed on the board using the selected mode.
+   Cards are automatically arranged in a grid with a calculated number of
+   columns. Pass `columns` when invoking the importer to override this value.
 5. See [`tests/fixtures/sample-cards.json`](tests/fixtures/sample-cards.json)
    for a cards format example.
 

--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -5,7 +5,10 @@ import type { Card, CardStyle, Frame, Tag } from '@mirohq/websdk-types';
 export interface CardProcessOptions {
   createFrame?: boolean;
   frameTitle?: string;
-  /** Maximum number of cards per row when creating new cards. */
+  /**
+   * Desired number of cards per row. When omitted a square-like grid is
+   * computed automatically.
+   */
   columns?: number;
 }
 
@@ -243,7 +246,7 @@ export class CardProcessor {
    */
   private async calculateLayoutArea(
     count: number,
-    columns = count,
+    columns?: number,
   ): Promise<{
     spot: { x: number; y: number };
     startX: number;
@@ -252,7 +255,8 @@ export class CardProcessor {
     totalWidth: number;
     totalHeight: number;
   }> {
-    const cols = Math.max(1, Math.min(columns, count));
+    const autoCols = columns ?? Math.ceil(Math.sqrt(count));
+    const cols = Math.max(1, Math.min(autoCols, count));
     const rows = Math.ceil(count / cols);
     const totalWidth =
       CardProcessor.CARD_WIDTH * cols +

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -204,6 +204,20 @@ describe('CardProcessor', () => {
     expect(calls[3][0]).toEqual(expect.objectContaining({ x: 172, y: 56 }));
   });
 
+  test('defaults to a square grid layout', async () => {
+    await processor.processCards([
+      { title: 'A' },
+      { title: 'B' },
+      { title: 'C' },
+      { title: 'D' },
+    ]);
+    const calls = (global.miro.board.createCard as jest.Mock).mock.calls;
+    expect(calls[0][0]).toEqual(expect.objectContaining({ x: -172, y: -56 }));
+    expect(calls[1][0]).toEqual(expect.objectContaining({ x: 172, y: -56 }));
+    expect(calls[2][0]).toEqual(expect.objectContaining({ x: -172, y: 56 }));
+    expect(calls[3][0]).toEqual(expect.objectContaining({ x: 172, y: 56 }));
+  });
+
   test('throws on invalid input', async () => {
     await expect(
       processor.processCards(null as unknown as unknown[]),


### PR DESCRIPTION
## Summary
- improve `CardProcessOptions` docs
- auto-calculate grid columns when placing cards
- test default grid layout
- document grid behaviour in README

## Testing
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bde5b773c832b89cace882c3af5f8