### PR TITLE
Fix nested layout absolute positioning

### DIFF
--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -64,6 +64,8 @@ export class NestedLayouter {
   private collectPositions(
     node: ElkNode,
     map: Record<string, PositionedNode>,
+    offsetX = 0,
+    offsetY = 0,
   ): void {
     if (
       node.id !== 'root' &&
@@ -74,14 +76,16 @@ export class NestedLayouter {
     ) {
       map[node.id] = {
         id: node.id,
-        x: node.x,
-        y: node.y,
+        x: offsetX + node.x,
+        y: offsetY + node.y,
         width: node.width,
         height: node.height,
       };
     }
     for (const child of node.children || []) {
-      this.collectPositions(child, map);
+      const childX = typeof node.x === 'number' ? offsetX + node.x : offsetX;
+      const childY = typeof node.y === 'number' ? offsetY + node.y : offsetY;
+      this.collectPositions(child, map, childX, childY);
     }
   }
 

--- a/tests/nested-layout.test.ts
+++ b/tests/nested-layout.test.ts
@@ -65,4 +65,32 @@ describe('layoutHierarchy', () => {
     expect(result.nodes['r1c1g1'].width).toBe(120);
     expect(result.nodes['r1c1g1'].height).toBe(30);
   });
+
+  test('computes absolute positions for deep nodes', async () => {
+    const data: TestNode[] = [
+      {
+        id: 'root',
+        label: 'Root',
+        type: 'Role',
+        children: [
+          {
+            id: 'child',
+            label: 'Child',
+            type: 'Role',
+            children: [
+              { id: 'g1', label: 'G1', type: 'Role' },
+              { id: 'g2', label: 'G2', type: 'Role' },
+            ],
+          },
+        ],
+      },
+    ];
+    const result = await layoutHierarchy(data);
+    const g1 = result.nodes.g1;
+    const g2 = result.nodes.g2;
+    const child = result.nodes.child;
+    expect(g1.x === g2.x && g1.y === g2.y).toBe(false);
+    expect(g1.x).toBeGreaterThan(child.x);
+    expect(g2.x).toBeGreaterThan(child.x);
+  });
 });


### PR DESCRIPTION
## Summary
- accumulate parent offsets in nested layout so deep nodes keep relative spacing
- add regression test to ensure deep nodes are positioned uniquely

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685be14a514c832b95cec9a2222d683d