### PR TITLE
Handle duplicate card titles and reuse tags

### DIFF
--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -177,14 +177,16 @@ export class CardProcessor {
   }
 
   /**
-   * Resolve tag names to IDs, creating any missing tags on the board.
+   * Resolve tag names to IDs. Existing tags are reused and duplicate
+   * names are collapsed to avoid creating multiple identical tags.
    */
   private async ensureTagIds(
     names: string[] | undefined,
     tagMap: Map<string, Tag>,
   ): Promise<string[]> {
     const ids: string[] = [];
-    for (const name of names ?? []) {
+    const uniqueNames = new Set(names ?? []);
+    for (const name of uniqueNames) {
       let tag = tagMap.get(name);
       if (!tag) {
         tag = (await miro.board.createTag({ title: name })) as Tag;


### PR DESCRIPTION
## Summary
- avoid creating duplicate tags
- allow duplicate card titles when creating cards
- test card tag deduplication and tag reuse

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685be19a1be8832b99a461bc5eab26fb