### PR TITLE
Add ELK algorithms

### DIFF
--- a/src/core/layout/elk-options.ts
+++ b/src/core/layout/elk-options.ts
@@ -1,6 +1,18 @@
-export const ALGORITHMS = ['mrtree', 'layered', 'force'] as const;
+/**
+ * Supported ELK layout algorithms. Extend when enabling additional
+ * algorithms in the layout engine.
+ */
+export const ALGORITHMS = [
+  'mrtree',
+  'layered',
+  'force',
+  'rectpacking',
+  'box',
+  'radial',
+] as const;
 export type ElkAlgorithm = (typeof ALGORITHMS)[number];
 
+/** Allowed primary layout directions used by ELK. */
 export const DIRECTIONS = ['DOWN', 'UP', 'LEFT', 'RIGHT'] as const;
 export type ElkDirection = (typeof DIRECTIONS)[number];
 

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -11,7 +11,6 @@ import {
   Text,
 } from '../components/legacy';
 import { tokens } from '../tokens';
-import { SegmentedControl } from '../components/SegmentedControl';
 import { GraphProcessor } from '../../core/graph/graph-processor';
 import { showError } from '../hooks/notifications';
 import {
@@ -153,11 +152,19 @@ export const DiagramTab: React.FC = () => {
               <li key={i}>{file.name}</li>
             ))}
           </ul>
-          <SegmentedControl
-            value={layoutChoice}
-            onChange={(v) => setLayoutChoice(v as LayoutChoice)}
-            options={LAYOUTS.map((l) => ({ label: l, value: l }))}
-          />
+          <InputField label='Layout type'>
+            <Select
+              value={layoutChoice}
+              onChange={(value) => setLayoutChoice(value as LayoutChoice)}>
+              {LAYOUTS.map((l) => (
+                <SelectOption
+                  key={l}
+                  value={l}>
+                  {l}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputField>
           <div style={{ marginTop: tokens.space.small }}>
             <Checkbox
               label='Wrap items in frame'

--- a/tests/elk-options.test.ts
+++ b/tests/elk-options.test.ts
@@ -24,4 +24,11 @@ describe('validateLayoutOptions', () => {
       spacing: 50,
     });
   });
+
+  for (const alg of ['rectpacking', 'box', 'radial'] as const) {
+    test(`supports ${alg} algorithm`, () => {
+      const result = validateLayoutOptions({ algorithm: alg });
+      expect(result.algorithm).toBe(alg);
+    });
+  }
 });

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -241,7 +241,7 @@ describe('tab components', () => {
       fireEvent.change(input, { target: { files: [file] } });
     });
     expect(
-      screen.getByRole('group', { name: /layout type/i }),
+      screen.getByRole('combobox', { name: /layout type/i }),
     ).toBeInTheDocument();
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /create diagram/i }));


### PR DESCRIPTION
## Summary
- support `rectpacking`, `box` and `radial` algorithms
- show Layout type as a select dropdown
- test layout select and algorithm validation

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685c9a790fb8832b988098fc4072fee1