### PR TITLE
Add nested layout algorithm handling

### DIFF
--- a/src/core/graph/convert.ts
+++ b/src/core/graph/convert.ts
@@ -1,0 +1,53 @@
+import { GraphData, NodeData, EdgeData } from './graph-service';
+import { HierNode } from '../layout/nested-layout';
+
+/**
+ * Transform a flat edge list into a nested hierarchy.
+ */
+export function edgesToHierarchy(graph: GraphData): HierNode[] {
+  const nodeMap = new Map(graph.nodes.map((n) => [n.id, n]));
+  const children: Record<string, string[]> = {};
+  const childSet = new Set<string>();
+  for (const edge of graph.edges) {
+    children[edge.from] = children[edge.from] || [];
+    children[edge.from].push(edge.to);
+    childSet.add(edge.to);
+  }
+  const build = (id: string): HierNode => {
+    const n = nodeMap.get(id) as NodeData;
+    const kids = children[id]?.map(build);
+    return {
+      id: n.id,
+      label: n.label,
+      type: n.type,
+      metadata: n.metadata,
+      ...(kids && kids.length ? { children: kids } : {}),
+    } as HierNode;
+  };
+  const roots = graph.nodes
+    .filter((n) => !childSet.has(n.id))
+    .map((n) => build(n.id));
+  return roots;
+}
+
+/**
+ * Flatten a hierarchy into a graph with explicit edges.
+ */
+export function hierarchyToEdges(roots: HierNode[]): GraphData {
+  const nodes: NodeData[] = [];
+  const edges: EdgeData[] = [];
+  const visit = (node: HierNode): void => {
+    nodes.push({
+      id: node.id,
+      label: node.label,
+      type: node.type,
+      metadata: node.metadata,
+    });
+    for (const child of node.children ?? []) {
+      edges.push({ from: node.id, to: child.id });
+      visit(child);
+    }
+  };
+  for (const root of roots) visit(root);
+  return { nodes, edges };
+}

--- a/src/core/graph/index.ts
+++ b/src/core/graph/index.ts
@@ -1,3 +1,5 @@
 export * from './graph-service';
 export * from './graph-processor';
 export * from './hierarchy-processor';
+export * from './convert';
+export * from './layout-modes';

--- a/src/core/graph/layout-modes.ts
+++ b/src/core/graph/layout-modes.ts
@@ -1,0 +1,6 @@
+export const NESTED_ALGORITHMS = ['box', 'rectstacking'] as const;
+export type NestedAlgorithm = (typeof NESTED_ALGORITHMS)[number];
+
+export function isNestedAlgorithm(alg?: string | null): alg is NestedAlgorithm {
+  return alg === 'box' || alg === 'rectstacking';
+}

--- a/src/core/layout/elk-options.ts
+++ b/src/core/layout/elk-options.ts
@@ -7,6 +7,7 @@ export const ALGORITHMS = [
   'layered',
   'force',
   'rectpacking',
+  'rectstacking',
   'box',
   'radial',
 ] as const;

--- a/tests/graph-convert.test.ts
+++ b/tests/graph-convert.test.ts
@@ -1,0 +1,262 @@
+import { edgesToHierarchy, hierarchyToEdges } from '../src/core/graph/convert';
+import { GraphProcessor } from '../src/core/graph/graph-processor';
+import { HierarchyProcessor } from '../src/core/graph/hierarchy-processor';
+import { layoutEngine } from '../src/core/layout/elk-layout';
+import * as nestedLayout from '../src/core/layout/nested-layout';
+import { templateManager } from '../src/board/templates';
+
+interface GlobalWithMiro {
+  miro?: { board?: Record<string, unknown> };
+}
+
+declare const global: GlobalWithMiro;
+
+describe('graph conversion helpers', () => {
+  test('edgesToHierarchy builds nested structure', () => {
+    const graph = {
+      nodes: [
+        { id: 'p', label: 'P', type: 'Role' },
+        { id: 'c', label: 'C', type: 'Role' },
+      ],
+      edges: [{ from: 'p', to: 'c' }],
+    };
+    const result = edgesToHierarchy(graph);
+    expect(result).toEqual([
+      {
+        id: 'p',
+        label: 'P',
+        type: 'Role',
+        children: [{ id: 'c', label: 'C', type: 'Role' }],
+      },
+    ]);
+  });
+
+  test('hierarchyToEdges flattens hierarchy', () => {
+    const roots = [
+      {
+        id: 'p',
+        label: 'P',
+        type: 'Role',
+        children: [{ id: 'c', label: 'C', type: 'Role' }],
+      },
+    ];
+    const graph = hierarchyToEdges(roots);
+    expect(graph.nodes.map((n) => n.id)).toEqual(['p', 'c']);
+    expect(graph.edges).toEqual([{ from: 'p', to: 'c' }]);
+  });
+});
+
+describe('processor conversions', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete global.miro;
+  });
+
+  test('GraphProcessor converts hierarchy input', async () => {
+    global.miro = {
+      board: {
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+        viewport: {
+          get: jest
+            .fn()
+            .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+          zoomTo: jest.fn(),
+          set: jest.fn(),
+        },
+        createConnector: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 'c1',
+          }),
+        createShape: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 's1',
+            type: 'shape',
+          }),
+        createText: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 't1',
+            type: 'text',
+          }),
+        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+        group: jest
+          .fn()
+          .mockResolvedValue({
+            type: 'group',
+            getItems: jest.fn().mockResolvedValue([]),
+            setMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 'g1',
+          }),
+      },
+    } as unknown as GlobalWithMiro;
+    const gp = new GraphProcessor();
+    const hierarchy = [
+      {
+        id: 'p',
+        label: 'P',
+        type: 'Role',
+        children: [{ id: 'c', label: 'C', type: 'Role' }],
+      },
+    ];
+    const spy = jest
+      .spyOn(layoutEngine, 'layoutGraph')
+      .mockResolvedValue({
+        nodes: {
+          p: { x: 0, y: 0, width: 10, height: 10 },
+          c: { x: 10, y: 0, width: 10, height: 10 },
+        },
+        edges: [],
+      } as unknown);
+    await gp.processGraph(
+      hierarchy as unknown as Parameters<typeof gp.processGraph>[0],
+    );
+    expect(spy).toHaveBeenCalled();
+    const arg = (spy.mock.calls[0] as unknown[])[0] as {
+      nodes: unknown[];
+      edges: unknown[];
+    };
+    expect(arg.nodes).toHaveLength(2);
+    expect(arg.edges).toEqual([{ from: 'p', to: 'c' }]);
+  });
+
+  test('GraphProcessor uses nested layout for box algorithm', async () => {
+    global.miro = {
+      board: {
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+        viewport: {
+          get: jest
+            .fn()
+            .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+          zoomTo: jest.fn(),
+          set: jest.fn(),
+        },
+        createShape: jest
+          .fn()
+          .mockResolvedValue({
+            id: 's1',
+            type: 'shape',
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+          }),
+        createText: jest
+          .fn()
+          .mockResolvedValue({
+            id: 't1',
+            type: 'text',
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+          }),
+        group: jest
+          .fn()
+          .mockResolvedValue({
+            id: 'g1',
+            type: 'group',
+            getItems: jest.fn().mockResolvedValue([]),
+            setMetadata: jest.fn(),
+            sync: jest.fn(),
+          }),
+        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+      },
+    } as unknown as GlobalWithMiro;
+
+    const gp = new GraphProcessor();
+    const layoutSpy = jest
+      .spyOn(nestedLayout, 'layoutHierarchy')
+      .mockResolvedValue({
+        nodes: { p: { x: 0, y: 0, width: 10, height: 10 } },
+      });
+    const hierSpy = jest.spyOn(layoutEngine, 'layoutGraph');
+    const graph = { nodes: [{ id: 'p', label: 'P', type: 'Role' }], edges: [] };
+    await gp.processGraph(graph as Parameters<typeof gp.processGraph>[0], {
+      layout: { algorithm: 'box' },
+    });
+    expect(layoutSpy).toHaveBeenCalled();
+    expect(hierSpy).not.toHaveBeenCalled();
+  });
+
+  test('HierarchyProcessor converts graph input', async () => {
+    global.miro = {
+      board: {
+        get: jest.fn().mockResolvedValue([]),
+        findEmptySpace: jest
+          .fn()
+          .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+        viewport: {
+          get: jest
+            .fn()
+            .mockResolvedValue({ x: 0, y: 0, width: 100, height: 100 }),
+          zoomTo: jest.fn(),
+        },
+        createFrame: jest.fn().mockResolvedValue({ add: jest.fn(), id: 'f1' }),
+        group: jest.fn().mockResolvedValue({ id: 'g1', type: 'group' }),
+        createShape: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 's1',
+            type: 'shape',
+          }),
+        createText: jest
+          .fn()
+          .mockResolvedValue({
+            setMetadata: jest.fn(),
+            getMetadata: jest.fn(),
+            sync: jest.fn(),
+            id: 't1',
+            type: 'text',
+          }),
+      },
+    } as unknown as GlobalWithMiro;
+    jest
+      .spyOn(templateManager, 'createFromTemplate')
+      .mockResolvedValue({
+        type: 'shape',
+        setMetadata: jest.fn(),
+        getItems: jest.fn().mockResolvedValue([]),
+        sync: jest.fn(),
+        id: 's1',
+      } as unknown);
+    const proc = new HierarchyProcessor();
+    const graph = {
+      nodes: [
+        { id: 'p', label: 'P', type: 'Role' },
+        { id: 'c', label: 'C', type: 'Role' },
+      ],
+      edges: [{ from: 'p', to: 'c' }],
+    };
+    const spy = jest
+      .spyOn(nestedLayout, 'layoutHierarchy')
+      .mockResolvedValue({
+        nodes: {
+          p: { x: 0, y: 0, width: 10, height: 10 },
+          c: { x: 10, y: 0, width: 10, height: 10 },
+        },
+      } as ReturnType<typeof nestedLayout.layoutHierarchy>);
+    await proc.processHierarchy(
+      graph as unknown as Parameters<typeof proc.processHierarchy>[0],
+    );
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- treat `box` and `rectstacking` algorithms as nested layouts
- expose created items from `HierarchyProcessor`
- allow re-use of nested layout logic from `GraphProcessor`
- export layout mode helpers and extend algorithm list
- test nested layout selection

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685c9d0ebdd4832bbac59ee176636069