### PR TITLE
Add layout algorithm docs and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Miro JSON Graph Diagram App
 
 This project demonstrates how to import a JSON description of a graph and build
+
 a diagram on a Miro board. The application uses the **Eclipse Layout Kernel
 (ELK)** to arrange nodes and edges automatically. Shapes are generated from
 templates and each element can carry metadata that controls its appearance and
@@ -35,7 +36,9 @@ Omitting the `fields` property leaves the card without preview items.
 
 The layout step leverages the ELK algorithm to compute positions for all nodes.
 You can provide layout hints in each node's metadata to influence spacing or
-layering. The engine runs automatically when a graph is uploaded.
+layering. The engine runs automatically when a graph is uploaded. For an
+overview of available layout algorithms see
+[docs/LAYOUT_OPTIONS.md](docs/LAYOUT_OPTIONS.md).
 
 ## Template‑Based Shapes
 
@@ -48,12 +51,9 @@ this file or add new entries to customise the available shapes. Connector
 appearance is configured in
 [ `templates/connectorTemplates.json`](templates/connectorTemplates.json) which
 controls line colour, caps and font. The templates now include `Decision` and
-`StartEnd` shapes useful for flowcharts.
-
-To add your own templates create new entries in these JSON files and reference
-them by name in your graph metadata. The app reloads templates on startup so
-changes are picked up automatically.
-
+`StartEnd` shapes useful for flowcharts. To add your own templates create new
+entries in these JSON files and reference them by name in your graph metadata.
+The app reloads templates on startup so changes are picked up automatically.
 Additional details and a sample dataset are provided in
 [`docs/TEMPLATES.md`](docs/TEMPLATES.md).
 
@@ -210,21 +210,17 @@ scopes:
    button. Then click on `Add` as shown in the video below. <b>In the video we
    install a different app, but the process is the same regardless of the
    app.</b>
-
-> ⚠️ We recommend to install your app on a
-> [developer team](https://developers.miro.com/docs/create-a-developer-team)
-> while you are developing or testing apps.⚠️
-
-https://github.com/miroapp/app-examples/assets/10428517/1e6862de-8617-46ef-b265-97ff1cbfe8bf
-
+   > ⚠️ We recommend to install your app on a
+   > [developer team](https://developers.miro.com/docs/create-a-developer-team)
+   > while you are developing or testing apps.⚠️
+   > https://github.com/miroapp/app-examples/assets/10428517/1e6862de-8617-46ef-b265-97ff1cbfe8bf
 5. Go to your developer team, and open your boards.
 6. Click on the plus icon from the bottom section of your left sidebar. If you
    hover over it, it will say `More apps`.
 7. Search for your app `JSON Diagram` or whatever you chose to name it. Click on
    your app to use it, as shown in the video below. <b>In the video we search
    for a different app, but the process is the same regardless of the app.</b>
-
-https://github.com/horeaporutiu/app-examples-template/assets/10428517/b23d9c4c-e785-43f9-a72e-fa5d82c7b019
+   https://github.com/horeaporutiu/app-examples-template/assets/10428517/b23d9c4c-e785-43f9-a72e-fa5d82c7b019
 
 ## Testing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,7 @@ _No OAuth token or server credentials are required._
 ### 10.1 Add a New Widget Type
 
 1. Extend **GraphProcessor** schema.
-2. Provide default ELK options.
+2. Provide default ELK options (see [LAYOUT_OPTIONS.md](LAYOUT_OPTIONS.md)).
 3. Implement **BoardBuilder.createWidget**.
 4. Register inverse command in **CardProcessor** for undo.
 5. Add tests and a Storybook example.

--- a/docs/LAYOUT_OPTIONS.md
+++ b/docs/LAYOUT_OPTIONS.md
@@ -1,0 +1,24 @@
+# Layout Options
+
+The diagramming add-on uses the Eclipse Layout Kernel (ELK) to position nodes
+and edges. This document summarises the algorithms available via the Diagram
+tab.
+
+| Algorithm      | Purpose                                                           |
+| -------------- | ----------------------------------------------------------------- |
+| `mrtree`       | Arranges hierarchical data with multiple roots as a compact tree. |
+| `layered`      | Traditional Sugiyama-style layered layout for directed graphs.    |
+| `force`        | Force-directed layout that spreads nodes organically.             |
+| `rectpacking`  | Packs child nodes into parent containers for nested diagrams.     |
+| `rectstacking` | Stacks rectangles into rows or columns, useful for swimlanes.     |
+| `box`          | Simple box layout placing items in a uniform grid.                |
+| `radial`       | Positions nodes on concentric circles around a centre node.       |
+
+The quick choices in the Diagram tab map to these algorithms:
+
+- **Layered** – uses `layered`.
+- **Tree** – uses `mrtree`.
+- **Grid** – uses `force`.
+- **Nested** – uses `rectpacking` with automatic container sizing.
+
+See [TEMPLATES.md](TEMPLATES.md#3-sample-data) for a nested layout example.

--- a/docs/TEMPLATES.md
+++ b/docs/TEMPLATES.md
@@ -53,7 +53,8 @@ contains four top-level groups, each with four subgroups and four items per
 subgroup. This is useful when experimenting with the ELK-based nested layout
 algorithm. Import the JSON in the **Create** tab and choose the **Nested**
 diagram layout to see child nodes arranged inside their parents with containers
-sized automatically by the ELK engine.
+sized automatically by the ELK engine. For a description of available algorithms
+see [LAYOUT_OPTIONS.md](LAYOUT_OPTIONS.md).
 
 ---
 

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -165,6 +165,16 @@ export const DiagramTab: React.FC = () => {
               ))}
             </Select>
           </InputField>
+          <Paragraph className='field-help'>
+            See{' '}
+            <a
+              href='docs/LAYOUT_OPTIONS.md'
+              target='_blank'
+              rel='noopener noreferrer'>
+              layout algorithm guide
+            </a>
+            .
+          </Paragraph>
           <div style={{ marginTop: tokens.space.small }}>
             <Checkbox
               label='Wrap items in frame'

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -243,6 +243,9 @@ describe('tab components', () => {
     expect(
       screen.getByRole('combobox', { name: /layout type/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /layout algorithm guide/i }),
+    ).toBeInTheDocument();
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /create diagram/i }));
     });


### PR DESCRIPTION
## Summary
- document ELK layout algorithms in `docs/LAYOUT_OPTIONS.md`
- link new doc from README, Templates guide and Architecture notes
- add help link near the Diagram tab layout selector
- test for new help link

## Testing
- `npm install`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685ca21a46d0832bb4c4f7e8ae95b685