### PR TITLE
Expand diagram layout choices

### DIFF
--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -24,8 +24,27 @@ import {
 import { HierarchyProcessor } from '../../core/graph/hierarchy-processor';
 import { getDropzoneStyle, undoLastImport } from '../hooks/ui-utils';
 
-const LAYOUTS = ['Layered', 'Tree', 'Grid', 'Nested'] as const;
+const LAYOUTS = [
+  'Layered',
+  'Tree',
+  'Grid',
+  'Nested',
+  'Radial',
+  'Box',
+  'Rect Packing',
+] as const;
 type LayoutChoice = (typeof LAYOUTS)[number];
+
+/** Descriptions for layout choices shown inline when importing graphs. */
+const LAYOUT_DESCRIPTIONS: Record<LayoutChoice, string> = {
+  'Layered': 'Flow diagrams with layers',
+  'Tree': 'Compact hierarchical tree',
+  'Grid': 'Organic force-directed grid',
+  'Nested': 'Containers sized to fit children',
+  'Radial': 'Circular layout around a hub',
+  'Box': 'Uniform box grid',
+  'Rect Packing': 'Fits rectangles within parents',
+};
 
 /** UI for the Diagram tab. */
 export const DiagramTab: React.FC = () => {
@@ -82,10 +101,13 @@ export const DiagramTab: React.FC = () => {
         } else {
           setLastProc(graphProcessor);
           const algorithmMap: Record<LayoutChoice, ElkAlgorithm> = {
-            Layered: 'layered',
-            Tree: 'mrtree',
-            Grid: 'force',
-            Nested: 'layered',
+            'Layered': 'layered',
+            'Tree': 'mrtree',
+            'Grid': 'force',
+            'Nested': 'rectpacking',
+            'Radial': 'radial',
+            'Box': 'box',
+            'Rect Packing': 'rectpacking',
           };
           await graphProcessor.processFile(file, {
             createFrame: withFrame,
@@ -165,16 +187,12 @@ export const DiagramTab: React.FC = () => {
               ))}
             </Select>
           </InputField>
-          <Paragraph className='field-help'>
-            See{' '}
-            <a
-              href='docs/LAYOUT_OPTIONS.md'
-              target='_blank'
-              rel='noopener noreferrer'>
-              layout algorithm guide
-            </a>
-            .
-          </Paragraph>
+          <Paragraph className='field-help'>Layout options:</Paragraph>
+          <ul className='field-help'>
+            {LAYOUTS.map((l) => (
+              <li key={`desc-${l}`}>{LAYOUT_DESCRIPTIONS[l]}</li>
+            ))}
+          </ul>
           <div style={{ marginTop: tokens.space.small }}>
             <Checkbox
               label='Wrap items in frame'

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -243,8 +243,20 @@ describe('tab components', () => {
     expect(
       screen.getByRole('combobox', { name: /layout type/i }),
     ).toBeInTheDocument();
+    for (const option of [
+      'Layered',
+      'Tree',
+      'Grid',
+      'Nested',
+      'Radial',
+      'Box',
+      'Rect Packing',
+    ]) {
+      expect(screen.getByRole('option', { name: option })).toBeInTheDocument();
+    }
+    expect(screen.getByText(/layout options/i)).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /layout algorithm guide/i }),
+      screen.getByText(/circular layout around a hub/i),
     ).toBeInTheDocument();
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: /create diagram/i }));


### PR DESCRIPTION
## Summary
- add Radial, Box and Rect Packing layout choices
- default Nested layout to rectpacking
- show layout guidance inline instead of linking to docs
- update tests for new options

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685ca5ce5f9c832bb1409b94884c1c8c