### PR TITLE
Add Docker build and GHCR release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.git
+.vscode
+Dockerfile
+.github
+coverage

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,38 @@
+name: Docker Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Stage 1: build the application
+FROM node:24-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --silent
+COPY . .
+RUN npm run build
+
+# Stage 2: serve with nginx
+FROM nginx:stable-alpine
+COPY --from=build /app/dist/ /usr/share/nginx/html
+COPY app-manifest.yml /usr/share/nginx/html/
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -278,6 +278,20 @@ committing so code conforms to the repository guidelines.
 - [Code Style](docs/CODE_STYLE.md) outlines formatting and naming rules.
 - [UI Patterns](docs/PATTERNS.md) shows common layouts and best practices.
 
+## Docker Image
+
+The project can be packaged as a container image. Build and run using:
+
+```bash
+docker build -t miro-diagramming .
+docker run --rm -p 8080:80 miro-diagramming
+```
+
+Tagged releases push the image to the GitHub Container Registry automatically.
+The workflow builds a standard `linux/amd64` image via
+`docker/build-push-action@v5`; QEMU is unnecessary as no cross-platform
+emulation is performed.
+
 ## 🫱🏻‍🫲🏽 Contributing <a name="contributing"></a>
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -165,6 +165,19 @@ All gates and complexity budgets are defined in **ARCHITECTURE.md** (sections
 | Layout freeze      | Graph exceeds 5 000 nodes – layout timeout         |
 | Dark-mode glitch   | Token override? Confirm colours from Design System |
 
+## 11 Docker container
+
+For self-hosting the static bundle as a container image:
+
+```bash
+docker build -t miro-diagramming ..
+docker run --rm -p 8080:80 miro-diagramming
+```
+
+Tagged releases on GitHub automatically push the built image to GHCR. The
+workflow targets `linux/amd64` only, so emulation via QEMU is skipped and
+`docker/build-push-action@v5` sets up Buildx automatically.
+
 ---
 
 _End of file._


### PR DESCRIPTION
## Summary
- add Dockerfile for multi-stage build and nginx runtime
- build container on version tags and push to GHCR
- document Docker usage in README and deployment docs
- remove unnecessary QEMU/Buildx setup

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d506b0304832ba2d86318af735579