### PR TITLE
Add Excel import tab

### DIFF
--- a/src/core/utils/excel-loader.ts
+++ b/src/core/utils/excel-loader.ts
@@ -31,6 +31,11 @@ export class ExcelLoader {
     return this.workbook ? [...this.workbook.SheetNames] : [];
   }
 
+  /** List named table ranges from the current workbook. */
+  public listNamedTables(): string[] {
+    return this.workbook?.Workbook?.Names?.map((n) => n.Name) ?? [];
+  }
+
   /**
    * Load rows from a specific worksheet.
    *

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import {
+  Button,
+  Checkbox,
+  InputField,
+  Paragraph,
+  Select,
+  SelectOption,
+  Text,
+  Icon,
+} from '../components/legacy';
+import { tokens } from '../tokens';
+import { excelLoader, ExcelRow } from '../../core/utils/excel-loader';
+import { mapRowsToNodes, ColumnMapping } from '../../core/data-mapper';
+import { templateManager } from '../../board/templates';
+import { GraphProcessor } from '../../core/graph/graph-processor';
+import { showError } from '../hooks/notifications';
+import { getDropzoneStyle } from '../hooks/ui-utils';
+import type { TabTuple } from './tab-definitions';
+
+/** Sidebar tab for importing nodes from Excel files. */
+export const ExcelTab: React.FC = () => {
+  const [file, setFile] = React.useState<File | null>(null);
+  const [source, setSource] = React.useState('');
+  const [rows, setRows] = React.useState<ExcelRow[]>([]);
+  const [selected, setSelected] = React.useState(new Set<number>());
+  const [idColumn, setIdColumn] = React.useState('');
+  const [labelColumn, setLabelColumn] = React.useState('');
+  const [templateColumn, setTemplateColumn] = React.useState('');
+  const [template, setTemplate] = React.useState('Role');
+  const graphProcessor = React.useMemo(() => new GraphProcessor(), []);
+
+  const dropzone = useDropzone({
+    accept: {
+      'application/vnd.ms-excel': ['.xls'],
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [
+        '.xlsx',
+      ],
+    },
+    maxFiles: 1,
+    onDrop: async (files: File[]) => {
+      const f = files[0];
+      try {
+        await excelLoader.loadWorkbook(f);
+        setFile(f);
+        setSource('');
+        setRows([]);
+        setSelected(new Set());
+      } catch (e) {
+        await showError(String(e));
+      }
+    },
+  });
+
+  const columns = React.useMemo(() => Object.keys(rows[0] ?? {}), [rows]);
+
+  const loadRows = (): void => {
+    try {
+      if (source.startsWith('sheet:')) {
+        setRows(excelLoader.loadSheet(source.slice(6)));
+      } else if (source.startsWith('table:')) {
+        setRows(excelLoader.loadNamedTable(source.slice(6)));
+      }
+      setSelected(new Set());
+    } catch (e) {
+      void showError(String(e));
+    }
+  };
+
+  const toggle = (idx: number): void => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  };
+
+  const handleCreate = async (): Promise<void> => {
+    try {
+      const mapping: ColumnMapping = {
+        idColumn: idColumn || undefined,
+        labelColumn: labelColumn || undefined,
+        templateColumn: templateColumn || undefined,
+      };
+      const chosen = rows.filter((_, i) => selected.has(i));
+      const nodes = mapRowsToNodes(chosen, mapping).map((n) => ({
+        ...n,
+        type: templateColumn ? n.type : template,
+      }));
+      await graphProcessor.processGraph({ nodes, edges: [] });
+    } catch (e) {
+      await showError(String(e));
+    }
+  };
+
+  const style = React.useMemo(
+    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
+    [dropzone.isDragAccept, dropzone.isDragReject],
+  );
+
+  return (
+    <div style={{ marginTop: tokens.space.small }}>
+      <div
+        {...dropzone.getRootProps({ style })}
+        aria-label='Excel drop area'>
+        <InputField label='Excel file'>
+          <input
+            data-testid='file-input'
+            {...dropzone.getInputProps()}
+          />
+        </InputField>
+      </div>
+      {file && (
+        <>
+          <InputField label='Data source'>
+            <Select
+              value={source}
+              onChange={setSource}
+              aria-label='Data source'>
+              <SelectOption value=''>Select…</SelectOption>
+              {excelLoader.listSheets().map((s) => (
+                <SelectOption
+                  key={`s-${s}`}
+                  value={`sheet:${s}`}>
+                  Sheet: {s}
+                </SelectOption>
+              ))}
+              {excelLoader.listNamedTables().map((t) => (
+                <SelectOption
+                  key={`t-${t}`}
+                  value={`table:${t}`}>
+                  Table: {t}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputField>
+          <Button
+            onClick={loadRows}
+            variant='secondary'>
+            Load Rows
+          </Button>
+        </>
+      )}
+      {rows.length > 0 && (
+        <>
+          <InputField label='Template'>
+            <Select
+              value={template}
+              onChange={setTemplate}
+              aria-label='Template'>
+              {Object.keys(templateManager.templates).map((tpl) => (
+                <SelectOption
+                  key={tpl}
+                  value={tpl}>
+                  {tpl}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputField>
+          <InputField label='Label column'>
+            <Select
+              value={labelColumn}
+              onChange={setLabelColumn}
+              aria-label='Label column'>
+              <SelectOption value=''>None</SelectOption>
+              {columns.map((c) => (
+                <SelectOption
+                  key={`l-${c}`}
+                  value={c}>
+                  {c}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputField>
+          <InputField label='Template column'>
+            <Select
+              value={templateColumn}
+              onChange={setTemplateColumn}
+              aria-label='Template column'>
+              <SelectOption value=''>None</SelectOption>
+              {columns.map((c) => (
+                <SelectOption
+                  key={`tcol-${c}`}
+                  value={c}>
+                  {c}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputField>
+          <InputField label='ID column'>
+            <Select
+              value={idColumn}
+              onChange={setIdColumn}
+              aria-label='ID column'>
+              <SelectOption value=''>None</SelectOption>
+              {columns.map((c) => (
+                <SelectOption
+                  key={`i-${c}`}
+                  value={c}>
+                  {c}
+                </SelectOption>
+              ))}
+            </Select>
+          </InputField>
+          <ul style={{ maxHeight: 160, overflowY: 'auto' }}>
+            {rows.map((r, i) => (
+              <li key={i}>
+                <Checkbox
+                  label={`Row ${i + 1}`}
+                  value={selected.has(i)}
+                  onChange={() => toggle(i)}
+                />
+                <Paragraph>{JSON.stringify(r)}</Paragraph>
+              </li>
+            ))}
+          </ul>
+          <div className='buttons'>
+            <Button
+              onClick={handleCreate}
+              variant='primary'>
+              <React.Fragment key='.0'>
+                <Icon name='plus' />
+                <Text>Create Nodes</Text>
+              </React.Fragment>
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export const tabDef: TabTuple = [
+  6,
+  'excel',
+  'Excel',
+  'Import nodes from Excel workbooks',
+  ExcelTab,
+];

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -7,6 +7,7 @@ export type TabId =
   | 'grid'
   | 'frames'
   | 'spacing'
+  | 'excel'
   | 'dummy';
 
 export type TabTuple = readonly [

--- a/tests/excel-loader.test.ts
+++ b/tests/excel-loader.test.ts
@@ -50,6 +50,7 @@ describe('excel loader', () => {
     const loader = new ExcelLoader();
     await loader.loadWorkbook(file);
     expect(loader.listSheets()).toEqual(['Sheet1', 'Sheet2']);
+    expect(loader.listNamedTables()).toEqual(['Table1']);
   });
 
   test('loads rows from a sheet', async () => {

--- a/tests/excel-tab.test.tsx
+++ b/tests/excel-tab.test.tsx
@@ -1,0 +1,78 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ExcelTab } from '../src/ui/pages/ExcelTab';
+import { excelLoader } from '../src/core/utils/excel-loader';
+import { GraphProcessor } from '../src/core/graph/graph-processor';
+
+vi.mock('../src/core/utils/excel-loader');
+vi.mock('../src/core/graph/graph-processor');
+
+describe('ExcelTab', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).miro = { board: { ui: { on: vi.fn() } } };
+    (excelLoader.loadWorkbook as unknown as jest.Mock).mockResolvedValue(
+      undefined,
+    );
+    (excelLoader.listSheets as unknown as jest.Mock).mockReturnValue([
+      'Sheet1',
+    ]);
+    (excelLoader.listNamedTables as unknown as jest.Mock).mockReturnValue([
+      'Table1',
+    ]);
+    (excelLoader.loadSheet as unknown as jest.Mock).mockReturnValue([{ A: 1 }]);
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).miro;
+    vi.clearAllMocks();
+  });
+
+  test('shows sheet options after drop', async () => {
+    render(<ExcelTab />);
+    const input = screen.getByTestId('file-input');
+    const file = new File(['x'], 'data.xlsx');
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+    expect(
+      screen.getByRole('combobox', { name: /data source/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /sheet: sheet1/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /table: table1/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('creates nodes from selected rows', async () => {
+    const spy = vi
+      .spyOn(GraphProcessor.prototype, 'processGraph')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<ExcelTab />);
+    const file = new File(['x'], 'data.xlsx');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: /data source/i }), {
+      target: { value: 'sheet:Sheet1' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /load rows/i }));
+    });
+    fireEvent.click(screen.getByLabelText(/row 1/i));
+    fireEvent.change(screen.getByRole('combobox', { name: /label column/i }), {
+      target: { value: 'A' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create nodes/i }));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add listNamedTables helper for Excel loader
- create ExcelTab for importing nodes from spreadsheets
- document loader tests for tables
- test ExcelTab interactions
- register ExcelTab

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d5207ac74832bb543d22102d69735