### PR TITLE
Add Help tab

### DIFF
--- a/src/ui/pages/HelpTab.tsx
+++ b/src/ui/pages/HelpTab.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Heading, Paragraph } from '../components/legacy';
+import type { TabTuple } from './tab-definitions';
+
+/** Static help page summarising diagram options and tools. */
+export const HelpTab: React.FC = () => (
+  <div data-testid='help-tab'>
+    <Heading level={3}>Getting Started</Heading>
+    <Paragraph>
+      Use the Create tab to import diagrams or cards from a JSON file. Nodes may
+      define templates, labels and ELK options to influence placement.
+    </Paragraph>
+    <Heading level={3}>Diagram Layout Options</Heading>
+    <ul className='list'>
+      <li>
+        <strong>Layered</strong> – Flow diagrams with layers
+      </li>
+      <li>
+        <strong>Tree</strong> – Compact hierarchical tree
+      </li>
+      <li>
+        <strong>Grid</strong> – Organic force-directed grid
+      </li>
+      <li>
+        <strong>Nested</strong> – Containers sized to fit children
+      </li>
+      <li>
+        <strong>Radial</strong> – Circular layout around a hub
+      </li>
+      <li>
+        <strong>Box</strong> – Uniform box grid
+      </li>
+      <li>
+        <strong>Rect Packing</strong> – Fits rectangles within parents
+      </li>
+    </ul>
+    <Heading level={3}>Other Tools</Heading>
+    <ul className='list'>
+      <li>Resize – adjust widget size or copy from selection.</li>
+      <li>Frames – rename selected frames.</li>
+      <li>Colours – modify fill colours.</li>
+      <li>Grid – arrange widgets into a grid.</li>
+      <li>Spacing – distribute items evenly.</li>
+    </ul>
+  </div>
+);
+
+export const tabDef: TabTuple = [
+  6,
+  'help',
+  'Help',
+  'Overview of diagram options and tools',
+  HelpTab,
+];

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -7,6 +7,7 @@ export type TabId =
   | 'grid'
   | 'frames'
   | 'spacing'
+  | 'help'
   | 'dummy';
 
 export type TabTuple = readonly [

--- a/tests/help-tab.test.tsx
+++ b/tests/help-tab.test.tsx
@@ -1,0 +1,15 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { HelpTab } from '../src/ui/pages/HelpTab';
+
+describe('HelpTab', () => {
+  test('lists diagram options', () => {
+    render(<HelpTab />);
+    expect(
+      screen.getByRole('heading', { name: /diagram layout options/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/compact hierarchical tree/i)).toBeInTheDocument();
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -316,4 +316,17 @@ describe('tab auto-registration', () => {
     expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(false);
     process.env.NODE_ENV = prev;
   });
+
+  test('includes HelpTab in all environments', async () => {
+    const envs = ['test', 'development', 'production'] as const;
+    for (const env of envs) {
+      const prev = process.env.NODE_ENV;
+      process.env.NODE_ENV = env;
+      const suffix =
+        env === 'test' ? '?test' : env === 'development' ? '?dev' : '?prod';
+      const { TAB_DATA } = await import(`../src/ui/pages/tabs${suffix}`);
+      expect(TAB_DATA.some((t) => t[1] === 'help')).toBe(true);
+      process.env.NODE_ENV = prev;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add new Help tab describing available features and layouts
- document help feature in tab definitions
- test Help tab rendering and auto-registration

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d53b3dad8832b913459f348bba021