### PR TITLE
Add metadata syncing to Excel service

### DIFF
--- a/src/core/excel-sync-service.ts
+++ b/src/core/excel-sync-service.ts
@@ -1,0 +1,192 @@
+import { mapRowsToNodes, ColumnMapping } from './data-mapper';
+import type { ExcelRow } from './utils/excel-loader';
+import { templateManager } from '../board/templates';
+import { BoardBuilder } from '../board/board-builder';
+import type { BaseItem, Group, Json } from '@mirohq/websdk-types';
+
+/** Metadata key used to store Excel row identifiers. */
+const META_KEY = 'app.miro.excel';
+
+/**
+ * Service providing two-way synchronisation between Excel workbooks
+ * and diagram widgets on the board.
+ */
+export class ExcelSyncService {
+  private rowMap: Record<string, string> = {};
+
+  constructor(private builder: BoardBuilder = new BoardBuilder()) {}
+
+  /** Clear the internal row mapping. */
+  public reset(): void {
+    this.rowMap = {};
+  }
+
+  /**
+   * Register a row-to-widget mapping.
+   *
+   * @param rowId - Identifier of the workbook row.
+   * @param widgetId - Corresponding widget identifier.
+   */
+  public registerMapping(rowId: string, widgetId: string): void {
+    this.rowMap[rowId] = widgetId;
+  }
+
+  /** Retrieve the widget identifier for the given row. */
+  public getWidgetId(rowId: string): string | undefined {
+    return this.rowMap[rowId];
+  }
+
+  /**
+   * Update existing widgets using values from the provided rows.
+   * Metadata from each row is written to the widget using
+   * {@link ColumnMapping.metadataColumns}.
+   *
+   * @param rows - Workbook rows.
+   * @param mapping - Column mapping describing identifiers and labels.
+   */
+  public async updateShapesFromExcel(
+    rows: ExcelRow[],
+    mapping: ColumnMapping,
+  ): Promise<void> {
+    const nodes = mapRowsToNodes(rows, mapping);
+    for (const def of nodes) {
+      const rowId = def.metadata?.rowId;
+      if (!rowId) continue;
+      const idStr = String(rowId);
+      const widget = await this.findWidget(idStr);
+      if (!widget) continue;
+      await this.applyTemplate(widget, def.label, def.type, {
+        ...(def.metadata ?? {}),
+        rowId: idStr,
+      });
+      this.registerMapping(idStr, widget.id ?? '');
+    }
+  }
+
+  /**
+   * Extract widget values and write them back to Excel rows.
+   * Any metadata stored under {@link META_KEY} is copied according to the
+   * {@link ColumnMapping.metadataColumns} configuration.
+   *
+   * @param rows - Workbook rows to update.
+   * @param mapping - Column mapping describing identifiers and labels.
+   * @returns Updated rows with widget text and metadata applied.
+   */
+  public async pushChangesToExcel(
+    rows: ExcelRow[],
+    mapping: ColumnMapping,
+  ): Promise<ExcelRow[]> {
+    const updated: ExcelRow[] = [];
+    const metaCols = mapping.metadataColumns ?? {};
+    for (let i = 0; i < rows.length; i++) {
+      const row = { ...rows[i] };
+      const idStr =
+        mapping.idColumn && row[mapping.idColumn] != null
+          ? String(row[mapping.idColumn])
+          : String(i);
+      const widget = await this.findWidget(idStr);
+      if (widget) {
+        const item = await this.extractItem(widget);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const content = (item as any).content as string | undefined;
+        if (mapping.labelColumn && content) {
+          row[mapping.labelColumn] = content;
+        }
+        const meta = (await item.getMetadata(META_KEY)) as
+          | Record<string, unknown>
+          | undefined;
+        if (mapping.textColumn && meta && meta.text != null) {
+          row[mapping.textColumn] = meta.text;
+        }
+        Object.keys(metaCols).forEach((key) => {
+          if (meta && meta[key] != null) {
+            row[metaCols[key]] = meta[key];
+          }
+        });
+        this.registerMapping(idStr, widget.id ?? '');
+      }
+      updated.push(row);
+    }
+    return updated;
+  }
+
+  /** Locate a widget by rowId using board metadata. */
+  private async findWidget(
+    rowId: string,
+  ): Promise<BaseItem | Group | undefined> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const board: any = miro.board;
+    const shapes = (await board.get({ type: 'shape' })) as BaseItem[];
+    const foundShape = await this.findByMetadata(shapes, rowId);
+    if (foundShape) return foundShape;
+    const groups = (await board.get({ type: 'group' })) as Group[];
+    for (const group of groups) {
+      const items = await (group as unknown as Group).getItems();
+      if (!Array.isArray(items)) continue;
+      const found = await this.findByMetadata(items as BaseItem[], rowId);
+      if (found) return group;
+    }
+    return undefined;
+  }
+
+  /**
+   * Update widget content and style based on the provided template.
+   * The metadata object is written to the widget using {@link META_KEY}.
+   */
+  private async applyTemplate(
+    widget: BaseItem | Group,
+    label: string,
+    templateName: string,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    const template = templateManager.getTemplate(templateName);
+    if (!template) return;
+    const items =
+      widget.type === 'group'
+        ? await (widget as unknown as Group).getItems()
+        : [widget];
+    template.elements.forEach((el, idx) => {
+      if (items[idx]) {
+        this.builder.applyElementToItem(items[idx] as BaseItem, el, label);
+      }
+    });
+    const meta = { ...metadata };
+    if (metadata.rowId != null) meta.rowId = String(metadata.rowId);
+    const master = template.masterElement;
+    if (widget.type === 'group') {
+      const groupItems = items as BaseItem[];
+      if (master !== undefined && groupItems[master]) {
+        await groupItems[master].setMetadata(META_KEY, meta as Json);
+      } else {
+        await Promise.all(
+          groupItems.map((i) => i.setMetadata(META_KEY, meta as Json)),
+        );
+      }
+    } else {
+      await (widget as BaseItem).setMetadata(META_KEY, meta as Json);
+    }
+  }
+
+  /** Retrieve the first item of a widget for text extraction. */
+  private async extractItem(widget: BaseItem | Group): Promise<BaseItem> {
+    if (widget.type === 'group') {
+      const items = await (widget as unknown as Group).getItems();
+      return items[0] as BaseItem;
+    }
+    return widget as BaseItem;
+  }
+
+  /** Search an item list for matching metadata. */
+  private async findByMetadata<
+    T extends { getMetadata: (k: string) => Promise<unknown> },
+  >(items: T[], rowId: string): Promise<T | undefined> {
+    const metas = await Promise.all(items.map((i) => i.getMetadata(META_KEY)));
+    for (let i = 0; i < items.length; i++) {
+      const meta = metas[i] as { rowId?: string };
+      if (meta?.rowId === rowId) {
+        return items[i];
+      }
+    }
+    return undefined;
+  }
+}

--- a/tests/excel-sync-service.test.ts
+++ b/tests/excel-sync-service.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import { ExcelSyncService } from '../src/core/excel-sync-service';
+import { templateManager } from '../src/board/templates';
+import { BoardBuilder } from '../src/board/board-builder';
+
+interface GlobalWithMiro {
+  miro?: { board?: Record<string, unknown> };
+}
+
+declare const global: GlobalWithMiro;
+
+describe('ExcelSyncService', () => {
+  beforeEach(() => {
+    global.miro = { board: { get: vi.fn().mockResolvedValue([]) } };
+  });
+
+  test('registerMapping and getWidgetId round trip', () => {
+    const service = new ExcelSyncService();
+    service.registerMapping('1', 'w1');
+    expect(service.getWidgetId('1')).toBe('w1');
+  });
+
+  test('updateShapesFromExcel applies template to matching widget', async () => {
+    const shape = {
+      type: 'shape',
+      id: 's1',
+      shape: 'rectangle',
+      content: '',
+      style: {},
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '1' }),
+      setMetadata: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Record<string, unknown>;
+    (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([shape]);
+    vi.spyOn(templateManager, 'getTemplate').mockReturnValue({
+      elements: [{ text: '{{label}}' }],
+    } as never);
+    const service = new ExcelSyncService(new BoardBuilder());
+    await service.updateShapesFromExcel(
+      [{ ID: '1', Name: 'A', Type: 'Role', Notes: 'meta' }],
+      {
+        idColumn: 'ID',
+        labelColumn: 'Name',
+        templateColumn: 'Type',
+        metadataColumns: { notes: 'Notes' },
+      },
+    );
+    expect(service.getWidgetId('1')).toBe('s1');
+    expect(shape.setMetadata).toHaveBeenCalledWith(
+      'app.miro.excel',
+      expect.objectContaining({ rowId: '1', notes: 'meta' }),
+    );
+    expect(shape.content).toBe('A');
+  });
+
+  test('pushChangesToExcel writes widget text into rows', async () => {
+    const shape = {
+      type: 'shape',
+      id: 's1',
+      content: 'X',
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '1', notes: 'meta' }),
+      setMetadata: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Record<string, unknown>;
+    (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([shape]);
+    const service = new ExcelSyncService(new BoardBuilder());
+    const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
+      idColumn: 'ID',
+      labelColumn: 'Name',
+      metadataColumns: { notes: 'Notes' },
+    });
+    expect(rows[0].Name).toBe('X');
+    expect(rows[0].Notes).toBe('meta');
+  });
+
+  test('reset clears all mappings', () => {
+    const service = new ExcelSyncService();
+    service.registerMapping('1', 'w1');
+    service.reset();
+    expect(service.getWidgetId('1')).toBeUndefined();
+  });
+
+  test('pushChangesToExcel reads text column from metadata', async () => {
+    const shape = {
+      type: 'shape',
+      id: 's1',
+      content: 'X',
+      getMetadata: vi
+        .fn()
+        .mockResolvedValue({ rowId: '1', notes: 'meta', text: 'desc' }),
+    } as unknown as Record<string, unknown>;
+    (global.miro!.board!.get as vi.Mock).mockResolvedValueOnce([shape]);
+    const service = new ExcelSyncService(new BoardBuilder());
+    const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
+      idColumn: 'ID',
+      labelColumn: 'Name',
+      textColumn: 'Desc',
+      metadataColumns: { notes: 'Notes' },
+    });
+    expect(rows[0].Desc).toBe('desc');
+  });
+
+  test('findWidget locates groups by metadata', async () => {
+    const shape = {
+      type: 'shape',
+      id: 's1',
+      content: 'Y',
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '1' }),
+    } as Record<string, unknown>;
+    const group = {
+      type: 'group',
+      id: 'g1',
+      getItems: vi.fn().mockResolvedValue([shape]),
+    } as Record<string, unknown>;
+    (global.miro!.board!.get as vi.Mock)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([group]);
+    const service = new ExcelSyncService(new BoardBuilder());
+    const rows = await service.pushChangesToExcel([{ ID: '1', Name: '' }], {
+      idColumn: 'ID',
+      labelColumn: 'Name',
+    });
+    expect(rows[0].Name).toBe('Y');
+    expect(service.getWidgetId('1')).toBe('g1');
+  });
+});


### PR DESCRIPTION
## Summary
- allow ExcelSyncService to store row metadata on widgets
- pull widget metadata back into Excel rows
- update tests for metadata sync
- verify shape content updated when applying templates
- support textColumn when pushing widget changes back to Excel
- test group discovery and mapping reset

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685db271fd70832bbb2a4ed1065d84c6