### PR TITLE
Add Excel row inspection panel

### DIFF
--- a/src/ui/components/RowInspector.tsx
+++ b/src/ui/components/RowInspector.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { tokens } from '../tokens';
+import type { ExcelRow } from '../../core/utils/excel-loader';
+import { useRowData } from '../hooks/use-row-data';
+
+export interface RowInspectorProps {
+  /** Rows loaded from the workbook. */
+  rows: ExcelRow[];
+  /** Optional column holding unique identifiers. */
+  idColumn?: string;
+}
+
+/**
+ * Display the Excel row linked to the selected widget.
+ */
+export function RowInspector({
+  rows,
+  idColumn,
+}: RowInspectorProps): React.JSX.Element | null {
+  const row = useRowData(rows, idColumn);
+  if (!row) return null;
+
+  return (
+    <div
+      data-testid='row-inspector'
+      style={{ marginTop: tokens.space.small }}>
+      <strong>Row Values</strong>
+      <ul style={{ maxHeight: 120, overflowY: 'auto' }}>
+        {Object.entries(row).map(([k, v]) => (
+          <li key={k}>
+            <code>{k}</code>: {String(v)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -18,6 +18,7 @@ import { GraphProcessor } from '../../core/graph/graph-processor';
 import { addMiroIds, downloadWorkbook } from '../../core/utils/workbook-writer';
 import { showError } from '../hooks/notifications';
 import { getDropzoneStyle } from '../hooks/ui-utils';
+import { RowInspector } from '../components/RowInspector';
 import type { TabTuple } from './tab-definitions';
 
 /** Sidebar tab for importing nodes from Excel files. */
@@ -240,6 +241,10 @@ export const ExcelTab: React.FC = () => {
           </div>
         </>
       )}
+      <RowInspector
+        rows={rows}
+        idColumn={idColumn || undefined}
+      />
     </div>
   );
 };

--- a/tests/row-inspector.test.tsx
+++ b/tests/row-inspector.test.tsx
@@ -1,0 +1,34 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RowInspector } from '../src/ui/components/RowInspector';
+import { useRowData } from '../src/ui/hooks/use-row-data';
+
+vi.mock('../src/ui/hooks/use-row-data');
+
+describe('RowInspector', () => {
+  test('renders list of row values', () => {
+    (useRowData as unknown as vi.Mock).mockReturnValue({ ID: '1', Name: 'A' });
+    render(
+      <RowInspector
+        rows={[]}
+        idColumn='ID'
+      />,
+    );
+    expect(screen.getByTestId('row-inspector')).toBeInTheDocument();
+    expect(screen.getByText('ID')).toBeInTheDocument();
+    expect(screen.getByText(/A/)).toBeInTheDocument();
+  });
+
+  test('returns null when no row', () => {
+    (useRowData as unknown as vi.Mock).mockReturnValue(null);
+    const { container } = render(
+      <RowInspector
+        rows={[]}
+        idColumn='ID'
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/tests/use-row-data.test.ts
+++ b/tests/use-row-data.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, act } from '@testing-library/react';
+import {
+  useRowData,
+  extractRowId,
+  findRow,
+} from '../src/ui/hooks/use-row-data';
+import { useSelection } from '../src/ui/hooks/use-selection';
+import type { BaseItem, Group } from '@mirohq/websdk-types';
+
+vi.mock('../src/ui/hooks/use-selection');
+
+describe('useRowData', () => {
+  test('returns row matching selection metadata', async () => {
+    const item: BaseItem = {
+      type: 'shape',
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '2' }),
+    } as unknown as BaseItem;
+    (useSelection as unknown as vi.Mock).mockReturnValue([item]);
+    const rows = [{ ID: '1' }, { ID: '2' }];
+    const { result } = renderHook(() => useRowData(rows, 'ID'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual(rows[1]);
+  });
+
+  test('handles group selection', async () => {
+    const child1: BaseItem = {
+      getMetadata: vi.fn().mockResolvedValue({}),
+    } as unknown as BaseItem;
+    const child2: BaseItem = {
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '1' }),
+    } as unknown as BaseItem;
+    const group: Group = {
+      type: 'group',
+      getItems: vi.fn().mockResolvedValue([child1, child2]),
+    } as unknown as Group;
+    (useSelection as unknown as vi.Mock).mockReturnValue([group]);
+    const rows = [{ ID: '1' }];
+    const { result } = renderHook(() => useRowData(rows, 'ID'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual(rows[0]);
+  });
+
+  test('returns null when metadata missing', async () => {
+    const item: BaseItem = {
+      type: 'shape',
+      getMetadata: vi.fn().mockRejectedValue(new Error('fail')),
+    } as unknown as BaseItem;
+    (useSelection as unknown as vi.Mock).mockReturnValue([item]);
+    const { result } = renderHook(() => useRowData([{ ID: '1' }], 'ID'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toBeNull();
+  });
+});
+
+describe('helpers', () => {
+  test('extractRowId reads metadata from groups', async () => {
+    const a: BaseItem = {
+      getMetadata: vi.fn().mockResolvedValue({}),
+    } as unknown as BaseItem;
+    const b: BaseItem = {
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '5' }),
+    } as unknown as BaseItem;
+    const group: Group = {
+      type: 'group',
+      getItems: vi.fn().mockResolvedValue([a, b]),
+    } as unknown as Group;
+    await expect(extractRowId(group)).resolves.toBe('5');
+  });
+
+  test('findRow locates by id column or index', () => {
+    const rows = [{ ID: '1' }, { ID: '2' }];
+    expect(findRow(rows, 'ID', '2')).toEqual(rows[1]);
+    expect(findRow(rows, undefined, '1')).toEqual(rows[1]);
+    expect(findRow(rows, 'ID', '3')).toBeNull();
+  });
+
+  test('extractRowId handles simple item', async () => {
+    const item: BaseItem = {
+      type: 'shape',
+      getMetadata: vi.fn().mockResolvedValue({ rowId: '9' }),
+    } as unknown as BaseItem;
+    await expect(extractRowId(item)).resolves.toBe('9');
+  });
+});


### PR DESCRIPTION
## Summary
- add `useRowData` hook to map selected widget to its Excel row
- show row values with new `RowInspector` component
- render row inspector panel in the Excel tab
- test row inspector behaviour and row-data helpers

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e2bfd4538832ba12e14884c1fb7eb