### PR TITLE
Add board search and replace tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ The sidebar exposes extra tabs to manipulate existing widgets:
 - **Data** configures live data bindings to external sources.
 - **Comment** lists discussion threads and lets you reply inline.
 
+### Search Tools
+
+Utility helpers `searchBoardContent` and `replaceBoardContent` can query or
+update widgets by text. They support filtering by widget type, tag, fill colour
+and user assignments. Searches may be case sensitive, whole-word or regular
+expression based and can be limited to the current selection.
+
 ## Setup
 
 - [Miro Web SDK](https://developers.miro.com/docs/web-sdk-reference)

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -15,12 +15,20 @@ export interface BoardLike {
   ui?: BoardUILike;
 }
 
+export interface BoardQueryLike extends BoardLike {
+  get(opts: { type: string }): Promise<Array<Record<string, unknown>>>;
+}
+
 export function getBoard(board?: BoardLike): BoardLike {
   const b =
     board ??
     (globalThis as unknown as { miro?: { board?: BoardLike } }).miro?.board;
   if (!b) throw new Error('Miro board not available');
   return b;
+}
+
+export function getBoardWithQuery(board?: BoardQueryLike): BoardQueryLike {
+  return getBoard(board) as BoardQueryLike;
 }
 
 /**

--- a/src/board/search-tools.ts
+++ b/src/board/search-tools.ts
@@ -1,0 +1,200 @@
+import { getBoardWithQuery, BoardQueryLike } from './board';
+
+/** Search configuration. */
+export interface SearchOptions {
+  /** Text to search for. */
+  query: string;
+  /** Require exact case match. */
+  caseSensitive?: boolean;
+  /** Match whole words only. */
+  wholeWord?: boolean;
+  /** Treat query as regular expression. */
+  regex?: boolean;
+  /** Restrict search to specific widget types. */
+  widgetTypes?: string[];
+  /** Only include widgets tagged with one of these IDs. */
+  tagIds?: string[];
+  /** Restrict by exact background or fill colour. */
+  backgroundColor?: string;
+  /** Filter by assignee ID. */
+  assignee?: string;
+  /** Filter by creator ID. */
+  creator?: string;
+  /** Filter by last modifier ID. */
+  lastModifiedBy?: string;
+  /** Limit search to the current selection. */
+  inSelection?: boolean;
+}
+
+/** Result describing the matching widget and field. */
+export interface SearchResult {
+  /** Widget that matched. */
+  item: Record<string, unknown>;
+  /** Property path containing the text. */
+  field: string;
+}
+
+/** Options for replacing board content. */
+export interface ReplaceOptions extends SearchOptions {
+  /** Replacement text. */
+  replacement: string;
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildRegex(opts: SearchOptions): RegExp {
+  const src = opts.regex ? opts.query : escapeRegExp(opts.query);
+  const pattern = opts.wholeWord ? `\\b${src}\\b` : src;
+  const flags = opts.caseSensitive ? 'g' : 'gi';
+  return new RegExp(pattern, flags);
+}
+
+function getTextFields(item: Record<string, unknown>): Array<[string, string]> {
+  const fields: Array<[string, string]> = [];
+  if (typeof item.title === 'string') fields.push(['title', item.title]);
+  if (typeof item.content === 'string') fields.push(['content', item.content]);
+  if (typeof item.plainText === 'string')
+    fields.push(['plainText', item.plainText]);
+  if (typeof item.description === 'string')
+    fields.push(['description', item.description]);
+  if (typeof item.text === 'string') fields.push(['text', item.text]);
+  else if (item.text && typeof item.text === 'object') {
+    const txt = item.text as Record<string, unknown>;
+    if (typeof txt.plainText === 'string')
+      fields.push(['text.plainText', txt.plainText]);
+    if (typeof txt.content === 'string')
+      fields.push(['text.content', txt.content]);
+  }
+  return fields;
+}
+
+function getStringAtPath(
+  item: Record<string, unknown>,
+  path: string,
+): string | undefined {
+  const parts = path.split('.');
+  let ref: unknown = item;
+  for (const p of parts) {
+    if (!ref || typeof ref !== 'object') return undefined;
+    ref = (ref as Record<string, unknown>)[p];
+  }
+  return typeof ref === 'string' ? ref : undefined;
+}
+
+function setStringAtPath(
+  item: Record<string, unknown>,
+  path: string,
+  value: string,
+): void {
+  const parts = path.split('.');
+  let ref: unknown = item;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    if (!ref || typeof ref !== 'object') return;
+    ref = (ref as Record<string, unknown>)[parts[i]];
+  }
+  if (ref && typeof ref === 'object') {
+    (ref as Record<string, unknown>)[parts[parts.length - 1]] = value;
+  }
+}
+
+function applyFilters(
+  item: Record<string, unknown>,
+  opts: SearchOptions,
+): boolean {
+  const filters = [
+    opts.widgetTypes &&
+      ((i: Record<string, unknown>) =>
+        opts.widgetTypes!.includes((i as { type?: string }).type ?? '')),
+    opts.tagIds &&
+      ((i: Record<string, unknown>) => {
+        const tags = (i as { tagIds?: string[] }).tagIds;
+        return (
+          Array.isArray(tags) && opts.tagIds!.some((id) => tags.includes(id))
+        );
+      }),
+    opts.backgroundColor &&
+      ((i: Record<string, unknown>) => {
+        const style = (i.style ?? {}) as Record<string, unknown>;
+        const fill = (style.fillColor ?? style.backgroundColor) as
+          | string
+          | undefined;
+        return (
+          typeof fill === 'string' &&
+          fill.toLowerCase() === opts.backgroundColor!.toLowerCase()
+        );
+      }),
+    opts.assignee &&
+      ((i: Record<string, unknown>) => {
+        const assignee =
+          (i as { assignee?: string; assigneeId?: string }).assignee ??
+          (i as { assigneeId?: string }).assigneeId;
+        return assignee === opts.assignee;
+      }),
+    opts.creator &&
+      ((i: Record<string, unknown>) =>
+        (i as { createdBy?: string }).createdBy === opts.creator),
+    opts.lastModifiedBy &&
+      ((i: Record<string, unknown>) =>
+        (i as { lastModifiedBy?: string }).lastModifiedBy ===
+        opts.lastModifiedBy),
+  ].filter(Boolean) as Array<(i: Record<string, unknown>) => boolean>;
+  return filters.every((fn) => fn(item));
+}
+
+/**
+ * Search widgets on the board matching the provided options.
+ */
+export async function searchBoardContent(
+  opts: SearchOptions,
+  board?: BoardQueryLike,
+): Promise<SearchResult[]> {
+  const b = getBoardWithQuery(board);
+  let items: Record<string, unknown>[] = [];
+  if (opts.inSelection) {
+    items = await b.getSelection();
+  } else {
+    const types = opts.widgetTypes?.length ? opts.widgetTypes : ['widget'];
+    for (const t of types) items.push(...(await b.get({ type: t })));
+  }
+  const pattern = buildRegex(opts);
+  const results: SearchResult[] = [];
+  for (const item of items) {
+    if (!applyFilters(item, opts)) continue;
+    for (const [field, text] of getTextFields(item)) {
+      pattern.lastIndex = 0;
+      if (pattern.test(text)) results.push({ item, field });
+    }
+  }
+  return results;
+}
+
+/**
+ * Replace matching board content preserving formatting.
+ *
+ * @returns Number of replacements performed.
+ */
+export async function replaceBoardContent(
+  opts: ReplaceOptions,
+  board?: BoardQueryLike,
+): Promise<number> {
+  const b = getBoardWithQuery(board);
+  const matches = await searchBoardContent(opts, b);
+  const pattern = buildRegex(opts);
+  let count = 0;
+  for (const { item, field } of matches) {
+    const current = getStringAtPath(item, field);
+    if (current === undefined) continue;
+    const updated = current.replace(pattern, () => {
+      count += 1;
+      return opts.replacement;
+    });
+    if (updated !== current) {
+      setStringAtPath(item, field, updated);
+      await ((item as { sync?: () => Promise<void> }).sync?.call(item) ??
+        Promise.resolve());
+    }
+  }
+  return count;
+}

--- a/tests/search-tools.test.ts
+++ b/tests/search-tools.test.ts
@@ -1,0 +1,181 @@
+import {
+  searchBoardContent,
+  replaceBoardContent,
+} from '../src/board/search-tools';
+import { BoardQueryLike } from '../src/board/board';
+
+const makeBoard = () => {
+  const items = [
+    {
+      type: 'shape',
+      text: 'Hello world',
+      tagIds: ['t1'],
+      style: { fillColor: '#fff' },
+      assigneeId: 'u1',
+      createdBy: 'c1',
+      lastModifiedBy: 'm1',
+      sync: jest.fn(),
+    },
+    {
+      type: 'card',
+      title: 'hello there',
+      tagIds: ['t2'],
+      style: { backgroundColor: '#000' },
+      assignee: 'u2',
+      createdBy: 'c2',
+      lastModifiedBy: 'm2',
+      sync: jest.fn(),
+    },
+    {
+      type: 'sticky_note',
+      plainText: 'Foo Bar',
+      tagIds: ['t1', 't2'],
+      style: { fillColor: '#00f' },
+      createdBy: 'c3',
+      lastModifiedBy: 'm3',
+      sync: jest.fn(),
+    },
+    {
+      type: 'shape',
+      text: { plainText: 'hxllo test' },
+      style: { fillColor: '#0f0' },
+      createdBy: 'c1',
+      lastModifiedBy: 'm2',
+      sync: jest.fn(),
+    },
+    {
+      type: 'text',
+      content: 'Hello <b>World</b>',
+      style: { backgroundColor: '#fff' },
+      createdBy: 'c1',
+      lastModifiedBy: 'm3',
+      sync: jest.fn(),
+    },
+    {
+      type: 'shape',
+      plainText: 'ahellob',
+      tagIds: ['t3'],
+      style: { fillColor: '#123' },
+      assigneeId: 'u1',
+      createdBy: 'c4',
+      lastModifiedBy: 'm1',
+      sync: jest.fn(),
+    },
+  ];
+  const board: BoardQueryLike = {
+    getSelection: jest.fn().mockResolvedValue(items.slice(0, 2)),
+    get: jest.fn(async ({ type }) => {
+      return type === 'widget' ? items : items.filter((i) => i.type === type);
+    }),
+  } as unknown as BoardQueryLike;
+  return { board, items };
+};
+
+describe('search-tools', () => {
+  test('search across item types', async () => {
+    const { board, items } = makeBoard();
+    const res = await searchBoardContent({ query: 'hello' }, board);
+    expect(res.map((r) => r.item)).toEqual(
+      expect.arrayContaining([items[0], items[1], items[4], items[5]]),
+    );
+  });
+
+  test('widget type filter', async () => {
+    const { board, items } = makeBoard();
+    const res = await searchBoardContent(
+      { query: 'hello', widgetTypes: ['card'] },
+      board,
+    );
+    expect(res).toHaveLength(1);
+    expect(res[0].item).toBe(items[1]);
+  });
+
+  test('tag, colour and assignee filters', async () => {
+    const { board, items } = makeBoard();
+    const byTag = await searchBoardContent(
+      { query: 'foo', tagIds: ['t2'] },
+      board,
+    );
+    expect(byTag).toHaveLength(1);
+    expect(byTag[0].item).toBe(items[2]);
+    const byColour = await searchBoardContent(
+      { query: 'hello', backgroundColor: '#fff' },
+      board,
+    );
+    expect(byColour.map((r) => r.item)).toEqual(
+      expect.arrayContaining([items[0], items[4]]),
+    );
+    const byAssignee = await searchBoardContent(
+      { query: 'hello', assignee: 'u2' },
+      board,
+    );
+    expect(byAssignee).toHaveLength(1);
+    expect(byAssignee[0].item).toBe(items[1]);
+  });
+
+  test('creator and modifier filters', async () => {
+    const { board, items } = makeBoard();
+    const byCreator = await searchBoardContent(
+      { query: 'hello', creator: 'c4' },
+      board,
+    );
+    expect(byCreator).toHaveLength(1);
+    expect(byCreator[0].item).toBe(items[5]);
+    const byModifier = await searchBoardContent(
+      { query: 'hello', lastModifiedBy: 'm1' },
+      board,
+    );
+    expect(byModifier.map((r) => r.item)).toEqual(
+      expect.arrayContaining([items[0], items[5]]),
+    );
+  });
+
+  test('regex and whole-word options', async () => {
+    const { board, items } = makeBoard();
+    const regex = await searchBoardContent(
+      { query: 'h.llo', regex: true, widgetTypes: ['shape'] },
+      board,
+    );
+    expect(regex.map((r) => r.item)).toEqual(
+      expect.arrayContaining([items[0], items[3], items[5]]),
+    );
+    const whole = await searchBoardContent(
+      { query: 'hello', wholeWord: true, widgetTypes: ['shape'] },
+      board,
+    );
+    expect(whole.map((r) => r.item)).not.toContain(items[5]);
+  });
+
+  test('case sensitivity and selection only', async () => {
+    const { board, items } = makeBoard();
+    const cs = await searchBoardContent(
+      { query: 'Hello', caseSensitive: true, widgetTypes: ['shape'] },
+      board,
+    );
+    expect(cs).toHaveLength(1);
+    expect(cs[0].item).toBe(items[0]);
+    (board.get as jest.Mock).mockClear();
+    const sel = await searchBoardContent(
+      { query: 'hello', inSelection: true },
+      board,
+    );
+    expect(board.getSelection).toHaveBeenCalled();
+    expect(board.get).not.toHaveBeenCalled();
+    expect(sel.map((r) => r.item)).toEqual(
+      expect.arrayContaining([items[0], items[1]]),
+    );
+  });
+
+  test('bulk replace preserves formatting', async () => {
+    const { board, items } = makeBoard();
+    const count = await replaceBoardContent(
+      { query: 'hello', replacement: 'hi' },
+      board,
+    );
+    expect(count).toBe(4);
+    expect(items[0].text).toBe('hi world');
+    expect(items[1].title).toBe('hi there');
+    expect(items[4].content).toBe('hi <b>World</b>');
+    expect(items[0].sync).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `BoardQueryLike` with query helper
- implement search and replace helpers with extensive filters
- document new search utilities
- test search and replace functionality

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e57132504832ba08b0e32411127bf