### PR TITLE
Add TSDoc comments for board helpers

### DIFF
--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -19,6 +19,15 @@ export interface BoardQueryLike extends BoardLike {
   get(opts: { type: string }): Promise<Array<Record<string, unknown>>>;
 }
 
+/**
+ * Resolve the active board instance.
+ *
+ * Returns the provided board if given, otherwise falls back to the global
+ * `miro.board` reference. Throws an error when no board API is available.
+ *
+ * @param board - Optional board object used primarily for testing.
+ * @returns The board API instance.
+ */
 export function getBoard(board?: BoardLike): BoardLike {
   const b =
     board ??
@@ -27,6 +36,15 @@ export function getBoard(board?: BoardLike): BoardLike {
   return b;
 }
 
+/**
+ * Retrieve a board instance capable of widget queries.
+ *
+ * Wraps {@link getBoard} and casts the result to include the `get` method used
+ * by board search utilities.
+ *
+ * @param board - Optional board override that implements `get`.
+ * @returns Board API exposing query capabilities.
+ */
 export function getBoardWithQuery(board?: BoardQueryLike): BoardQueryLike {
   return getBoard(board) as BoardQueryLike;
 }


### PR DESCRIPTION
## Summary
- document `getBoard` and `getBoardWithQuery` with TSDoc

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e5cec6e04832b8b2e22e13b0ee78e