### PR TITLE
Improve coverage for pages and utilities

### DIFF
--- a/tests/aspect-ratio.test.ts
+++ b/tests/aspect-ratio.test.ts
@@ -13,3 +13,9 @@ describe('aspect-ratio utilities', () => {
     expect(height).toBe(90);
   });
 });
+
+test('aspectRatioValue throws on unknown preset', () => {
+  expect(() => aspectRatioValue('1:1' as never)).toThrow(
+    'Unknown aspect ratio',
+  );
+});

--- a/tests/cards-tab-branches.test.tsx
+++ b/tests/cards-tab-branches.test.tsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { CardsTab } from '../src/ui/pages/CardsTab';
+import { CardProcessor } from '../src/board/card-processor';
+
+vi.mock('../src/board/card-processor');
+
+describe('CardsTab extra paths', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).miro = {
+      board: {
+        ui: { on: vi.fn() },
+        notifications: { showError: vi.fn().mockResolvedValue(undefined) },
+      },
+    };
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).miro;
+    vi.clearAllMocks();
+  });
+
+  test('creates frame with title when option enabled', async () => {
+    const spy = vi
+      .spyOn(CardProcessor.prototype, 'processFile')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<CardsTab />);
+    const file = new File(['{}'], 'cards.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    fireEvent.click(screen.getByLabelText('Wrap items in frame'));
+    fireEvent.change(screen.getByPlaceholderText('Frame title'), {
+      target: { value: 'T' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create cards/i }));
+    });
+    expect(spy).toHaveBeenCalledWith(file, {
+      createFrame: true,
+      frameTitle: 'T',
+    });
+  });
+
+  test('shows error message when processing fails', async () => {
+    vi.spyOn(CardProcessor.prototype, 'processFile').mockRejectedValue(
+      new Error('fail'),
+    );
+    render(<CardsTab />);
+    const file = new File(['{}'], 'cards.json', { type: 'application/json' });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create cards/i }));
+    });
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).miro.board.notifications.showError,
+    ).toHaveBeenCalledWith('Error: fail');
+  });
+});

--- a/tests/data-mapper-branches.test.ts
+++ b/tests/data-mapper-branches.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { mapRowsToNodes, mapRowsToCards } from '../src/core/data-mapper';
+
+describe('data-mapper branches', () => {
+  test('mapRowsToNodes uses defaults when mapping is empty', () => {
+    const rows = [{ Col: 'A' }];
+    const result = mapRowsToNodes(rows, {});
+    expect(result).toEqual([
+      { id: '0', label: '', type: 'default', metadata: { rowId: '0' } },
+    ]);
+  });
+
+  test('mapRowsToNodes ignores missing optional columns', () => {
+    const rows = [{ id: 'a', text: null }];
+    const result = mapRowsToNodes(rows, {
+      idColumn: 'id',
+      textColumn: 'text',
+      metadataColumns: { extra: 'missing' },
+    });
+    expect(result).toEqual([
+      { id: 'a', label: '', type: 'default', metadata: { rowId: 'a' } },
+    ]);
+  });
+
+  test('mapRowsToCards returns minimal card info', () => {
+    const rows = [{ X: 1 }];
+    const result = mapRowsToCards(rows, {});
+    expect(result).toEqual([{ title: '' }]);
+  });
+});

--- a/tests/excel-loader.test.ts
+++ b/tests/excel-loader.test.ts
@@ -100,4 +100,24 @@ describe('excel loader', () => {
     const rows = loader.loadNamedTable('Table1');
     expect(rows).toEqual([{ X: 5, Y: 6 }]);
   });
+
+  test('methods fail when workbook not loaded', () => {
+    const loader = new ExcelLoader();
+    expect(loader.listSheets()).toEqual([]);
+    expect(loader.listNamedTables()).toEqual([]);
+    expect(() => loader.loadSheet('Sheet1')).toThrow('Workbook not loaded');
+    expect(() => loader.loadNamedTable('Table1')).toThrow(
+      'Workbook not loaded',
+    );
+  });
+
+  test('loadNamedTable throws on missing sheet reference', async () => {
+    const loader = new ExcelLoader();
+    await loader.loadWorkbook(file);
+    const wb = (loader as unknown as { workbook: XLSX.WorkBook }).workbook!;
+    wb.Workbook = { Names: [{ Name: 'Bad', Ref: 'Missing!A1:B1' }] };
+    expect(() => loader.loadNamedTable('Bad')).toThrow(
+      'Missing sheet for table: Bad',
+    );
+  });
 });

--- a/tests/excel-tab-branches.test.tsx
+++ b/tests/excel-tab-branches.test.tsx
@@ -1,0 +1,95 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ExcelTab } from '../src/ui/pages/ExcelTab';
+import { excelLoader } from '../src/core/utils/excel-loader';
+import { GraphProcessor } from '../src/core/graph/graph-processor';
+import * as writer from '../src/core/utils/workbook-writer';
+
+vi.mock('../src/core/utils/excel-loader');
+vi.mock('../src/core/graph/graph-processor');
+vi.mock('../src/core/utils/workbook-writer');
+
+describe('ExcelTab additional paths', () => {
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).miro = {
+      board: {
+        ui: { on: vi.fn() },
+        getSelection: vi.fn().mockResolvedValue([]),
+      },
+    };
+    (excelLoader.loadWorkbook as unknown as vi.Mock).mockResolvedValue(
+      undefined,
+    );
+    (excelLoader.listSheets as unknown as vi.Mock).mockReturnValue(['Sheet1']);
+    (excelLoader.listNamedTables as unknown as vi.Mock).mockReturnValue([
+      'Table1',
+    ]);
+    (writer.addMiroIds as vi.Mock).mockImplementation((r) => r);
+    (writer.downloadWorkbook as vi.Mock).mockImplementation(() => {});
+    (
+      GraphProcessor.prototype.getNodeIdMap as unknown as vi.Mock
+    ).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).miro;
+    vi.clearAllMocks();
+  });
+
+  test('loadRows uses named table when source starts with table:', async () => {
+    (excelLoader.loadNamedTable as unknown as vi.Mock).mockReturnValue([
+      { A: 1 },
+    ]);
+    render(<ExcelTab />);
+    const file = new File(['x'], 'data.xlsx');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: /data source/i }), {
+      target: { value: 'table:Table1' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /load rows/i }));
+    });
+    expect(excelLoader.loadNamedTable).toHaveBeenCalledWith('Table1');
+  });
+
+  test('toggle selection and create using template column', async () => {
+    (excelLoader.loadSheet as unknown as vi.Mock).mockReturnValue([
+      { Type: 'T' },
+    ]);
+    const spy = vi
+      .spyOn(GraphProcessor.prototype, 'processGraph')
+      .mockResolvedValue(undefined as unknown as void);
+    render(<ExcelTab />);
+    const file = new File(['x'], 'data.xlsx');
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('file-input'), {
+        target: { files: [file] },
+      });
+    });
+    fireEvent.change(screen.getByRole('combobox', { name: /data source/i }), {
+      target: { value: 'sheet:Sheet1' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /load rows/i }));
+    });
+    const cb = screen.getByLabelText(/row 1/i);
+    fireEvent.click(cb);
+    expect(cb).toBeChecked();
+    fireEvent.change(
+      screen.getByRole('combobox', { name: /template column/i }),
+      { target: { value: 'Type' } },
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create nodes/i }));
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/tests/file-utils-error.test.ts
+++ b/tests/file-utils-error.test.ts
@@ -19,4 +19,17 @@ describe('FileUtils error handling', () => {
       fileUtils.readFileAsText({ name: 'file.txt' } as unknown as File),
     ).rejects.toBe('Failed to load file');
   });
+  test('readFileAsText rejects when target missing', async () => {
+    class FR {
+      onload: ((e: unknown) => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsText() {
+        if (this.onload) this.onload({ target: null });
+      }
+    }
+    (global as { FileReader?: unknown }).FileReader = FR;
+    await expect(
+      fileUtils.readFileAsText({ name: 'file.txt' } as unknown as File),
+    ).rejects.toBe('Failed to load file');
+  });
 });

--- a/tests/frame-tools.test.ts
+++ b/tests/frame-tools.test.ts
@@ -53,4 +53,25 @@ describe('frame-tools', () => {
       'Miro board not available',
     );
   });
+
+  test('renameSelectedFrames returns early with no frames', async () => {
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue([{ type: 'shape' }]),
+    };
+    await renameSelectedFrames({ prefix: 'N-' }, board);
+    expect(board.getSelection).toHaveBeenCalled();
+  });
+
+  test('renameSelectedFrames sorts by y when x equal', async () => {
+    const frames = [
+      { x: 0, y: 5, title: 'a', sync: jest.fn(), type: 'frame' },
+      { x: 0, y: 1, title: 'b', sync: jest.fn(), type: 'frame' },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'Q' }, board);
+    expect(frames[0].title).toBe('Q1');
+    expect(frames[1].title).toBe('Q0');
+  });
 });

--- a/tests/workbook-utils.test.ts
+++ b/tests/workbook-utils.test.ts
@@ -33,4 +33,10 @@ describe('workbook writer', () => {
     expect(anchor.click).toHaveBeenCalled();
     expect(createSpy).toHaveBeenCalled();
   });
+
+  test('addMiroIds leaves rows unchanged when id not found', () => {
+    const rows = [{ ID: '2', Name: 'B' }];
+    const result = addMiroIds(rows, 'ID', { '1': 'w1' });
+    expect(result).toEqual([{ ID: '2', Name: 'B' }]);
+  });
 });


### PR DESCRIPTION
## Summary
- add branch tests for mapping utilities
- cover Excel loader edge cases
- extend ExcelTab behaviour tests
- test CardsTab error handling
- expand frame rename tests
- touch up workbook utils and aspect ratio tests

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e5c8ced3c832baae13f6907d2815e