### PR TITLE
Add search and replace sidebar tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ The sidebar exposes extra tabs to manipulate existing widgets:
 - **Export** allows saving the board to PNG, SVG, BPMN or Markdown.
 - **Data** configures live data bindings to external sources.
 - **Comment** lists discussion threads and lets you reply inline.
+- **Search** finds text across the board and can replace all matches.
 
 ### Search Tools
 

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -2,7 +2,7 @@
 
 _Explicit UI + interaction walkthrough for every tab (June 2025)_
 
-This document narrows focus to the **nine sidebar tabs** in the
+This document narrows focus to the **ten sidebar tabs** in the
 Structured Diagramming add‑on. Each tab section specifies panel layout, visible
 controls, states, interaction flows, tool‑tips, keyboard shortcuts, and
 validation rules—so any developer can translate designs into code with zero
@@ -151,6 +151,19 @@ Polling interval slider (2 – 300 s). State `dataBindings[{boardId}]`.
 - **Filter Tabs** – All / Mine / Unresolved (Tertiary buttons).
 
 Shortcut: **Shift +C** opens comment editor on current selection.
+
+---
+
+## 10  Search Tab
+
+| Control           | Details                             |
+| ----------------- | ----------------------------------- |
+| **Find Input**    | Text to locate on the board         |
+| **Replace Input** | Replacement text applied in bulk    |
+| **Replace All**   | Calls `replaceBoardContent` utility |
+
+Flow: typing in the **Find** field debounces `searchBoardContent` by 300 ms and
+updates the match count.
 
 ---
 

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import {
+  Button,
+  InputField,
+  Paragraph,
+  Icon,
+  Text,
+} from '../components/legacy';
+import {
+  searchBoardContent,
+  replaceBoardContent,
+} from '../../board/search-tools';
+import type { TabTuple } from './tab-definitions';
+
+/**
+ * Sidebar tab providing board wide search and replace.
+ */
+export const SearchTab: React.FC = () => {
+  const [query, setQuery] = React.useState('');
+  const [replacement, setReplacement] = React.useState('');
+  const [matches, setMatches] = React.useState(0);
+
+  React.useEffect(() => {
+    const handle = setTimeout(async () => {
+      if (!query) {
+        setMatches(0);
+        return;
+      }
+      const res = await searchBoardContent({ query });
+      setMatches(res.length);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const replace = async (): Promise<void> => {
+    if (!query) return;
+    const count = await replaceBoardContent({ query, replacement });
+    setMatches(Math.max(0, matches - count));
+  };
+
+  return (
+    <div>
+      <InputField label='Find'>
+        <input
+          className='input input-small'
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder='Search board text'
+        />
+      </InputField>
+      <InputField label='Replace'>
+        <input
+          className='input input-small'
+          value={replacement}
+          onChange={(e) => setReplacement(e.target.value)}
+          placeholder='Replacement text'
+        />
+      </InputField>
+      <Paragraph data-testid='match-count'>Matches: {matches}</Paragraph>
+      <div className='buttons'>
+        <Button
+          onClick={replace}
+          variant='primary'>
+          <React.Fragment key='.0'>
+            <Icon name='arrow-right' />
+            <Text>Replace All</Text>
+          </React.Fragment>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const tabDef: TabTuple = [
+  8,
+  'search',
+  'Search',
+  'Find and replace text on the board',
+  SearchTab,
+];

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -7,6 +7,7 @@ export type TabId =
   | 'grid'
   | 'frames'
   | 'spacing'
+  | 'search'
   | 'help'
   | 'dummy';
 

--- a/tests/search-tab.test.tsx
+++ b/tests/search-tab.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SearchTab } from '../src/ui/pages/SearchTab';
+import * as searchTools from '../src/board/search-tools';
+
+vi.useFakeTimers();
+
+describe('SearchTab', () => {
+  beforeEach(() => {
+    vi.clearAllTimers();
+  });
+
+  test('debounced search updates match count', async () => {
+    vi.spyOn(searchTools, 'searchBoardContent').mockResolvedValue([
+      { item: {}, field: 't' },
+    ]);
+    render(<SearchTab />);
+    fireEvent.change(screen.getByPlaceholderText(/search board text/i), {
+      target: { value: 'hello' },
+    });
+    expect(searchTools.searchBoardContent).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(searchTools.searchBoardContent).toHaveBeenCalledWith({
+      query: 'hello',
+    });
+    expect(await screen.findByTestId('match-count')).toHaveTextContent(
+      'Matches: 1',
+    );
+  });
+
+  test('bulk replace calls replaceBoardContent', async () => {
+    vi.spyOn(searchTools, 'searchBoardContent').mockResolvedValue([
+      { item: {}, field: 't' },
+    ]);
+    const repSpy = vi
+      .spyOn(searchTools, 'replaceBoardContent')
+      .mockResolvedValue(1);
+    render(<SearchTab />);
+    fireEvent.change(screen.getByPlaceholderText(/search board text/i), {
+      target: { value: 'foo' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    fireEvent.change(screen.getByPlaceholderText(/replacement text/i), {
+      target: { value: 'bar' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText(/replace all/i));
+    });
+    expect(repSpy).toHaveBeenCalledWith({ query: 'foo', replacement: 'bar' });
+    expect(screen.getByTestId('match-count')).toHaveTextContent('Matches: 0');
+  });
+});


### PR DESCRIPTION
## Summary
- implement SearchTab with find and replace controls
- register new search tab and update TabId union
- document Search tab behaviour in README and docs/TABS.md
- test SearchTab debounced search and bulk replace

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e5f6fc150832b8d2f82144e76ae63