### PR TITLE
Add shape caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ The app reloads templates on startup so changes are picked up automatically.
 Additional details and a sample dataset are provided in
 [`docs/TEMPLATES.md`](docs/TEMPLATES.md).
 
+When **Use existing widgets** is enabled the importer caches all basic shapes on
+the board and matches them by their text content. The cache prevents duplicates
+during placement and is cleared once processing finishes.
+
 ## Metadata Usage
 
 Nodes may include a `metadata` object with any additional information. Typical


### PR DESCRIPTION
## Summary
- cache board shapes by text to reuse existing widgets
- document new caching behaviour
- verify caching via unit tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npx prettier src/board/board-builder.ts tests/boardbuilder-cache.test.ts README.md -w`

------
https://chatgpt.com/codex/tasks/task_e_685e6f7eb5bc832bbc7c19e3430ce13a