### PR TITLE
Add frame locking utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The sidebar exposes extra tabs to manipulate existing widgets:
 - **Grid** arranges widgets into a grid with options for sorting and grouping
   the result.
 - **Templates** inserts prebuilt diagrams from the templates catalog.
+- **Frames** renames or locks selected frames via helper utilities.
 - **Export** allows saving the board to PNG, SVG, BPMN or Markdown.
 - **Data** configures live data bindings to external sources.
 - **Comment** lists discussion threads and lets you reply inline.

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -40,9 +40,11 @@ ambiguity.
 | ----------------- | ----------------------------------------------- |
 | **Prefix Input**  | Text prefix used for renaming                   |
 | **Rename Button** | Applies prefix in left\u2011to\u2011right order |
+| **Lock Button**   | Locks selected frames and their contents        |
 
 Flow: select frames, type prefix, press **Rename Frames** → titles become
-`<prefix>0`, `<prefix>1`, ...
+`<prefix>0`, `<prefix>1`, ... Press **Lock Selected** to prevent modifications.
+Widgets receive the undocumented `locked` flag used by the Web‑SDK.
 
 ---
 

--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -47,25 +47,52 @@ export async function renameSelectedFrames(
   );
 }
 
+/**
+ * Subset of widget properties required for locking.
+ *
+ * The `locked` flag is not part of the public Web‑SDK type
+ * definitions yet but is present on runtime objects. It indicates
+ * whether a widget is locked from user interaction.
+ */
 interface LockableItem extends Record<string, unknown> {
+  /** `true` if the widget is locked. */
   locked?: boolean;
+  /** Persist property changes to the board. */
   sync?: () => Promise<void>;
 }
 
+/** Frame widget subset used within this module. */
 interface FrameLike extends LockableItem {
+  /** Widget type discriminator. */
   type?: string;
+  /** Retrieve child widgets contained in the frame. */
   getChildren?: () => Promise<LockableItem[]>;
 }
 
+/**
+ * Check whether a widget is a frame.
+ *
+ * @param item - Widget to test.
+ */
 function isFrame(item: Record<string, unknown>): item is FrameLike {
   return (item as { type?: string }).type === 'frame';
 }
 
+/**
+ * Lock a widget if possible.
+ *
+ * @param item - Widget to lock.
+ */
 async function lockItem(item: LockableItem): Promise<void> {
   item.locked = true;
   await item.sync?.();
 }
 
+/**
+ * Lock a frame and all of its child widgets.
+ *
+ * @param frame - Target frame widget.
+ */
 async function lockFrame(frame: FrameLike): Promise<void> {
   await lockItem(frame);
   const children = (await frame.getChildren?.()) ?? [];

--- a/tests/format-tools.test.ts
+++ b/tests/format-tools.test.ts
@@ -23,6 +23,18 @@ describe('format-tools', () => {
     expect(item.sync).toHaveBeenCalled();
   });
 
+  test('applyStylePreset handles items without style', async () => {
+    const item = { sync: jest.fn() };
+    const board = { getSelection: jest.fn().mockResolvedValue([item]) };
+    await applyStylePreset(preset, board);
+    expect(item.style).toEqual({
+      color: preset.fontColor,
+      borderColor: preset.borderColor,
+      borderWidth: preset.borderWidth,
+      fillColor: preset.fillColor,
+    });
+  });
+
   test('applyStylePreset throws without board', async () => {
     await expect(applyStylePreset(preset)).rejects.toThrow(
       'Miro board not available',

--- a/tests/frame-tools.test.ts
+++ b/tests/frame-tools.test.ts
@@ -51,6 +51,25 @@ describe('frame-tools', () => {
     expect(items[1].title).toBe('X0');
   });
 
+  test('renameSelectedFrames does nothing when selection empty', async () => {
+    const board: BoardLike = { getSelection: jest.fn().mockResolvedValue([]) };
+    await renameSelectedFrames({ prefix: 'N-' }, board);
+    expect(board.getSelection).toHaveBeenCalled();
+  });
+
+  test('renameSelectedFrames sorts by y when x equal', async () => {
+    const frames = [
+      { x: 0, y: 10, title: 'A', sync: jest.fn(), type: 'frame' },
+      { x: 0, y: 0, title: 'B', sync: jest.fn(), type: 'frame' },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'Q' }, board);
+    expect(frames[1].title).toBe('Q0');
+    expect(frames[0].title).toBe('Q1');
+  });
+
   test('renameSelectedFrames throws without board', async () => {
     await expect(renameSelectedFrames({ prefix: 'P' })).rejects.toThrow(
       'Miro board not available',
@@ -74,6 +93,21 @@ describe('frame-tools', () => {
       expect(child.locked).toBe(true);
       expect(frame.sync).toHaveBeenCalled();
       expect(child.sync).toHaveBeenCalled();
+    });
+
+    test('locks frames without children', async () => {
+      const frame = {
+        type: 'frame',
+        locked: false,
+        sync: jest.fn(),
+        getChildren: jest.fn().mockResolvedValue([]),
+      };
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([frame]),
+      };
+      await lockSelectedFrames(board);
+      expect(frame.locked).toBe(true);
+      expect(frame.sync).toHaveBeenCalled();
     });
 
     test('ignores non-frame widgets', async () => {

--- a/tests/frame-tools.test.ts
+++ b/tests/frame-tools.test.ts
@@ -70,6 +70,41 @@ describe('frame-tools', () => {
     expect(frames[0].title).toBe('Q1');
   });
 
+  test('renameSelectedFrames handles frames without sync or coordinates', async () => {
+    const frame = { title: 'A', type: 'frame' };
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue([frame]),
+    };
+    await renameSelectedFrames({ prefix: 'R-' }, board);
+    expect(frame.title).toBe('R-0');
+  });
+
+  test('renameSelectedFrames sorts frames missing coordinates', async () => {
+    const frames = [
+      { title: 'A', type: 'frame' },
+      { x: 5, y: 0, title: 'B', type: 'frame', sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'C' }, board);
+    expect(frames[0].title).toBe('C0');
+    expect(frames[1].title).toBe('C1');
+  });
+
+  test('renameSelectedFrames handles missing y for sort', async () => {
+    const frames = [
+      { x: 0, title: 'A', type: 'frame', sync: jest.fn() },
+      { x: 0, y: 2, title: 'B', type: 'frame', sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'D' }, board);
+    expect(frames[0].title).toBe('D0');
+    expect(frames[1].title).toBe('D1');
+  });
+
   test('renameSelectedFrames throws without board', async () => {
     await expect(renameSelectedFrames({ prefix: 'P' })).rejects.toThrow(
       'Miro board not available',
@@ -108,6 +143,23 @@ describe('frame-tools', () => {
       await lockSelectedFrames(board);
       expect(frame.locked).toBe(true);
       expect(frame.sync).toHaveBeenCalled();
+    });
+
+    test('locks frame even when getChildren missing', async () => {
+      const frame = { type: 'frame', locked: false };
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([frame]),
+      };
+      await lockSelectedFrames(board);
+      expect(frame.locked).toBe(true);
+    });
+
+    test('does nothing when selection empty', async () => {
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([]),
+      };
+      await lockSelectedFrames(board);
+      expect(board.getSelection).toHaveBeenCalled();
     });
 
     test('ignores non-frame widgets', async () => {


### PR DESCRIPTION
## Summary
- add `lockSelectedFrames` to lock frames and their children
- test new frame locking logic

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d55f12568832ba9037c76f3145334