### PR TITLE
Add Graph API Excel loader

### DIFF
--- a/docs/EXCEL_IMPORT.md
+++ b/docs/EXCEL_IMPORT.md
@@ -28,15 +28,18 @@ const rows = excelLoader.loadSheet('Sheet1');
 
 ### Connecting to OneDrive/SharePoint
 
-When files reside in OneDrive or SharePoint, use `GraphExcelLoader`. First
-authenticate with Azure AD to acquire a Microsoft Graph token, then provide a
-share link or drive item ID:
+When files reside in OneDrive or SharePoint, use `GraphExcelLoader`. Begin by
+redirecting to Azure AD to acquire a Microsoft Graph token, then provide a share
+link or drive item ID:
 
 ```ts
 import { graphExcelLoader } from '../core/utils/excel-loader';
 import { graphAuth } from '../core/utils/graph-auth';
 
-graphAuth.setToken('<access token>');
+graphAuth.handleRedirect();
+if (!graphAuth.getToken()) {
+  graphAuth.login('<client id>', ['Files.Read'], window.location.href);
+}
 await graphExcelLoader.loadWorkbookFromGraph(
   'https://contoso.sharepoint.com/:x:/r/site/doc.xlsx',
 );

--- a/docs/EXCEL_IMPORT.md
+++ b/docs/EXCEL_IMPORT.md
@@ -26,6 +26,25 @@ await excelLoader.loadWorkbook(file);
 const rows = excelLoader.loadSheet('Sheet1');
 ```
 
+### Connecting to OneDrive/SharePoint
+
+When files reside in OneDrive or SharePoint, use `GraphExcelLoader`. First
+authenticate with Azure AD to acquire a Microsoft Graph token, then provide a
+share link or drive item ID:
+
+```ts
+import { graphExcelLoader } from '../core/utils/excel-loader';
+import { graphAuth } from '../core/utils/graph-auth';
+
+graphAuth.setToken('<access token>');
+await graphExcelLoader.loadWorkbookFromGraph(
+  'https://contoso.sharepoint.com/:x:/r/site/doc.xlsx',
+);
+```
+
+The loader exposes the same helpers as `ExcelLoader` so the remainder of the
+workflow is identical.
+
 ---
 
 ## 2 Column Mapping & Template Selection

--- a/src/core/utils/graph-auth.ts
+++ b/src/core/utils/graph-auth.ts
@@ -1,0 +1,56 @@
+/**
+ * Simple OAuth helper for acquiring Microsoft Graph access tokens.
+ *
+ * The class stores the token in `sessionStorage` and redirects the
+ * browser to the Microsoft login page when no token is available.
+ */
+export class GraphAuth {
+  private static readonly KEY = 'graph.token';
+
+  /** Get the currently stored access token. */
+  public getToken(): string | null {
+    return sessionStorage.getItem(GraphAuth.KEY);
+  }
+
+  /** Manually store an access token. */
+  public setToken(token: string): void {
+    sessionStorage.setItem(GraphAuth.KEY, token);
+  }
+
+  /** Remove any stored token. */
+  public clearToken(): void {
+    sessionStorage.removeItem(GraphAuth.KEY);
+  }
+
+  /**
+   * Begin the OAuth implicit flow by redirecting the user.
+   *
+   * @param clientId - Azure application client identifier.
+   * @param scopes - Space separated list of scopes.
+   * @param redirectUri - URI configured as an app redirect.
+   */
+  public login(clientId: string, scopes: string[], redirectUri: string): void {
+    const params = new URLSearchParams({
+      client_id: clientId,
+      response_type: 'token',
+      redirect_uri: redirectUri,
+      scope: scopes.join(' '),
+    });
+    window.location.href = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`;
+  }
+
+  /**
+   * Complete the OAuth redirect by extracting the token from the hash.
+   */
+  public handleRedirect(): void {
+    if (!window.location.hash.includes('access_token')) return;
+    const data = new URLSearchParams(window.location.hash.slice(1));
+    const token = data.get('access_token');
+    if (token) {
+      this.setToken(token);
+      window.history.replaceState(null, '', window.location.pathname);
+    }
+  }
+}
+
+export const graphAuth = new GraphAuth();

--- a/src/core/utils/graph-auth.ts
+++ b/src/core/utils/graph-auth.ts
@@ -36,7 +36,9 @@ export class GraphAuth {
       redirect_uri: redirectUri,
       scope: scopes.join(' '),
     });
-    window.location.href = `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`;
+    window.location.assign(
+      `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`,
+    );
   }
 
   /**

--- a/src/core/utils/graph-client.ts
+++ b/src/core/utils/graph-client.ts
@@ -1,0 +1,30 @@
+import { GraphAuth, graphAuth } from './graph-auth';
+
+/**
+ * Fetch files from Microsoft Graph using an OAuth access token.
+ */
+export class GraphClient {
+  constructor(private auth: GraphAuth = graphAuth) {}
+
+  /**
+   * Retrieve a file as an array buffer given its share URL or drive item ID.
+   *
+   * @param identifier - File URL or item ID.
+   * @returns Raw file contents.
+   */
+  public async fetchFile(identifier: string): Promise<ArrayBuffer> {
+    const token = this.auth.getToken();
+    if (!token) throw new Error('Graph token unavailable');
+    const root = 'https://graph.microsoft.com/v1.0';
+    const url = identifier.startsWith('http')
+      ? `${root}/shares/u!${btoa(identifier).replace(/=+$/, '')}/driveItem/content`
+      : `${root}/me/drive/items/${identifier}/content`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error('Failed to fetch workbook');
+    return res.arrayBuffer();
+  }
+}
+
+export const graphClient = new GraphClient();

--- a/src/ui/pages/ExcelTab.tsx
+++ b/src/ui/pages/ExcelTab.tsx
@@ -11,7 +11,13 @@ import {
   Icon,
 } from '../components/legacy';
 import { tokens } from '../tokens';
-import { excelLoader, ExcelRow } from '../../core/utils/excel-loader';
+import {
+  excelLoader,
+  graphExcelLoader,
+  ExcelRow,
+  ExcelLoader,
+  GraphExcelLoader,
+} from '../../core/utils/excel-loader';
 import { mapRowsToNodes, ColumnMapping } from '../../core/data-mapper';
 import { templateManager } from '../../board/templates';
 import { GraphProcessor } from '../../core/graph/graph-processor';
@@ -24,6 +30,7 @@ import type { TabTuple } from './tab-definitions';
 /** Sidebar tab for importing nodes from Excel files. */
 export const ExcelTab: React.FC = () => {
   const [file, setFile] = React.useState<File | null>(null);
+  const [remote, setRemote] = React.useState('');
   const [source, setSource] = React.useState('');
   const [rows, setRows] = React.useState<ExcelRow[]>([]);
   const [selected, setSelected] = React.useState(new Set<number>());
@@ -32,6 +39,9 @@ export const ExcelTab: React.FC = () => {
   const [templateColumn, setTemplateColumn] = React.useState('');
   const [template, setTemplate] = React.useState('Role');
   const graphProcessor = React.useMemo(() => new GraphProcessor(), []);
+  const [loader, setLoader] = React.useState<ExcelLoader | GraphExcelLoader>(
+    excelLoader,
+  );
 
   const dropzone = useDropzone({
     accept: {
@@ -45,6 +55,7 @@ export const ExcelTab: React.FC = () => {
       const f = files[0];
       try {
         await excelLoader.loadWorkbook(f);
+        setLoader(excelLoader);
         setFile(f);
         setSource('');
         setRows([]);
@@ -55,14 +66,27 @@ export const ExcelTab: React.FC = () => {
     },
   });
 
+  const fetchRemote = async (): Promise<void> => {
+    try {
+      await graphExcelLoader.loadWorkbookFromGraph(remote);
+      setLoader(graphExcelLoader);
+      setFile(null);
+      setSource('');
+      setRows([]);
+      setSelected(new Set());
+    } catch (e) {
+      await showError(String(e));
+    }
+  };
+
   const columns = React.useMemo(() => Object.keys(rows[0] ?? {}), [rows]);
 
   const loadRows = (): void => {
     try {
       if (source.startsWith('sheet:')) {
-        setRows(excelLoader.loadSheet(source.slice(6)));
+        setRows(loader.loadSheet(source.slice(6)));
       } else if (source.startsWith('table:')) {
-        setRows(excelLoader.loadNamedTable(source.slice(6)));
+        setRows(loader.loadNamedTable(source.slice(6)));
       }
       setSelected(new Set());
     } catch (e) {
@@ -132,7 +156,19 @@ export const ExcelTab: React.FC = () => {
           />
         </InputField>
       </div>
-      {file && (
+      <InputField label='OneDrive/SharePoint file'>
+        <input
+          value={remote}
+          onChange={(e) => setRemote(e.target.value)}
+          aria-label='graph file'
+        />
+      </InputField>
+      <Button
+        onClick={fetchRemote}
+        variant='secondary'>
+        Fetch File
+      </Button>
+      {loader.listSheets().length > 0 && (
         <>
           <InputField label='Data source'>
             <Select
@@ -140,14 +176,14 @@ export const ExcelTab: React.FC = () => {
               onChange={setSource}
               aria-label='Data source'>
               <SelectOption value=''>Select…</SelectOption>
-              {excelLoader.listSheets().map((s) => (
+              {loader.listSheets().map((s) => (
                 <SelectOption
                   key={`s-${s}`}
                   value={`sheet:${s}`}>
                   Sheet: {s}
                 </SelectOption>
               ))}
-              {excelLoader.listNamedTables().map((t) => (
+              {loader.listNamedTables().map((t) => (
                 <SelectOption
                   key={`t-${t}`}
                   value={`table:${t}`}>

--- a/tests/excel-tab-branches.test.tsx
+++ b/tests/excel-tab-branches.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ExcelTab } from '../src/ui/pages/ExcelTab';
-import { excelLoader } from '../src/core/utils/excel-loader';
+import { excelLoader, graphExcelLoader } from '../src/core/utils/excel-loader';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
 import * as writer from '../src/core/utils/workbook-writer';
 
@@ -27,6 +27,9 @@ describe('ExcelTab additional paths', () => {
     (excelLoader.listNamedTables as unknown as vi.Mock).mockReturnValue([
       'Table1',
     ]);
+    (
+      graphExcelLoader.loadWorkbookFromGraph as unknown as vi.Mock
+    ).mockResolvedValue(undefined);
     (writer.addMiroIds as vi.Mock).mockImplementation((r) => r);
     (writer.downloadWorkbook as vi.Mock).mockImplementation(() => {});
     (
@@ -91,5 +94,16 @@ describe('ExcelTab additional paths', () => {
       fireEvent.click(screen.getByRole('button', { name: /create nodes/i }));
     });
     expect(spy).toHaveBeenCalled();
+  });
+
+  test('fetchRemote triggers graph loader', async () => {
+    render(<ExcelTab />);
+    fireEvent.change(screen.getByLabelText('graph file'), {
+      target: { value: 'x' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /fetch file/i }));
+    });
+    expect(graphExcelLoader.loadWorkbookFromGraph).toHaveBeenCalledWith('x');
   });
 });

--- a/tests/excel-tab.test.tsx
+++ b/tests/excel-tab.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ExcelTab } from '../src/ui/pages/ExcelTab';
-import { excelLoader } from '../src/core/utils/excel-loader';
+import { excelLoader, graphExcelLoader } from '../src/core/utils/excel-loader';
 import { GraphProcessor } from '../src/core/graph/graph-processor';
 import * as writer from '../src/core/utils/workbook-writer';
 
@@ -30,6 +30,9 @@ describe('ExcelTab', () => {
       'Table1',
     ]);
     (excelLoader.loadSheet as unknown as jest.Mock).mockReturnValue([{ A: 1 }]);
+    (
+      graphExcelLoader.loadWorkbookFromGraph as unknown as jest.Mock
+    ).mockResolvedValue(undefined);
     (writer.addMiroIds as jest.Mock).mockImplementation((r) => r);
     (writer.downloadWorkbook as jest.Mock).mockImplementation(() => {});
     (
@@ -86,5 +89,16 @@ describe('ExcelTab', () => {
       fireEvent.click(screen.getByRole('button', { name: /create nodes/i }));
     });
     expect(spy).toHaveBeenCalled();
+  });
+
+  test('fetches workbook from graph', async () => {
+    render(<ExcelTab />);
+    fireEvent.change(screen.getByLabelText('graph file'), {
+      target: { value: 'url' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /fetch file/i }));
+    });
+    expect(graphExcelLoader.loadWorkbookFromGraph).toHaveBeenCalledWith('url');
   });
 });

--- a/tests/graph-auth.test.ts
+++ b/tests/graph-auth.test.ts
@@ -1,0 +1,21 @@
+import { GraphAuth } from '../src/core/utils/graph-auth';
+
+describe('GraphAuth', () => {
+  test('set, get and clear token', () => {
+    const auth = new GraphAuth();
+    auth.setToken('abc');
+    expect(auth.getToken()).toBe('abc');
+    auth.clearToken();
+    expect(auth.getToken()).toBeNull();
+  });
+
+  test('handleRedirect extracts token', () => {
+    const auth = new GraphAuth();
+    const origHash = window.location.hash;
+    window.location.hash = '#access_token=xyz';
+    auth.handleRedirect();
+    expect(auth.getToken()).toBe('xyz');
+    expect(window.location.hash).toBe('');
+    window.location.hash = origHash;
+  });
+});

--- a/tests/graph-auth.test.ts
+++ b/tests/graph-auth.test.ts
@@ -18,4 +18,17 @@ describe('GraphAuth', () => {
     expect(window.location.hash).toBe('');
     window.location.hash = origHash;
   });
+
+  test('login redirects to Microsoft', () => {
+    const auth = new GraphAuth();
+    const original = window.location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = { assign: vi.fn() } as any;
+    auth.login('id', ['Files.Read'], 'https://app');
+    expect(window.location.assign).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = original;
+  });
 });

--- a/tests/graph-client.test.ts
+++ b/tests/graph-client.test.ts
@@ -1,0 +1,44 @@
+import { GraphClient } from '../src/core/utils/graph-client';
+import { GraphAuth } from '../src/core/utils/graph-auth';
+
+vi.stubGlobal('fetch', vi.fn());
+
+describe('GraphClient', () => {
+  const auth = new GraphAuth();
+  const client = new GraphClient(auth);
+
+  beforeEach(() => {
+    (fetch as unknown as vi.Mock).mockReset();
+    auth.setToken('token');
+  });
+
+  test('builds url from id', async () => {
+    (fetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(1)),
+    });
+    await client.fetchFile('123');
+    expect((fetch as vi.Mock).mock.calls[0][0]).toMatch(
+      /me\/drive\/items\/123\/content/,
+    );
+    expect((fetch as vi.Mock).mock.calls[0][1].headers.Authorization).toBe(
+      'Bearer token',
+    );
+  });
+
+  test('builds url from share link', async () => {
+    (fetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(1)),
+    });
+    await client.fetchFile('https://x');
+    expect((fetch as vi.Mock).mock.calls[0][0]).toMatch(/shares\/u!/);
+  });
+
+  test('throws on error', async () => {
+    (fetch as unknown as vi.Mock).mockResolvedValue({ ok: false });
+    await expect(client.fetchFile('id')).rejects.toThrow(
+      'Failed to fetch workbook',
+    );
+  });
+});

--- a/tests/graph-excel-loader.test.ts
+++ b/tests/graph-excel-loader.test.ts
@@ -1,0 +1,20 @@
+import { GraphExcelLoader } from '../src/core/utils/excel-loader';
+import { GraphClient } from '../src/core/utils/graph-client';
+import * as XLSX from 'xlsx';
+
+vi.mock('../src/core/utils/graph-client');
+
+const wb = XLSX.utils.book_new();
+XLSX.utils.book_append_sheet(wb, XLSX.utils.aoa_to_sheet([[1]]), 'Sheet1');
+const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+
+describe('GraphExcelLoader', () => {
+  test('loads workbook via client', async () => {
+    const client = new GraphClient();
+    (client.fetchFile as unknown as vi.Mock).mockResolvedValue(buf);
+    const loader = new GraphExcelLoader(client);
+    await loader.loadWorkbookFromGraph('id');
+    expect(loader.listSheets()).toEqual(['Sheet1']);
+    expect(client.fetchFile).toHaveBeenCalledWith('id');
+  });
+});


### PR DESCRIPTION
## Summary
- support OAuth token management via `GraphAuth`
- add `GraphClient` to fetch files from Microsoft Graph
- extend `ExcelLoader` with `GraphExcelLoader` for OneDrive/SharePoint
- update `ExcelTab` to load workbooks from OneDrive/SharePoint
- document OneDrive/SharePoint setup for Excel imports
- add unit tests for new modules and update existing tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e72ad3bac832b88a1e29b1a6b881e