### PR TITLE
Implement search filters UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,10 @@ The sidebar exposes extra tabs to manipulate existing widgets:
 ### Search Tools
 
 Utility helpers `searchBoardContent` and `replaceBoardContent` can query or
-update widgets by text. They support filtering by widget type, tag, fill colour
-and user assignments. Searches may be case sensitive, whole-word or regular
-expression based and can be limited to the current selection.
+update widgets by text. They support filtering by widget type, tag ID, fill
+colour, assignee, creator and last modifier. Searches may be case sensitive,
+whole-word or regular expression based and can be limited to the current
+selection.
 
 ## Setup
 

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -156,11 +156,17 @@ Shortcut: **Shift +C** opens comment editor on current selection.
 
 ## 10  Search Tab
 
-| Control           | Details                             |
-| ----------------- | ----------------------------------- |
-| **Find Input**    | Text to locate on the board         |
-| **Replace Input** | Replacement text applied in bulk    |
-| **Replace All**   | Calls `replaceBoardContent` utility |
+| Control                     | Details                             |
+| --------------------------- | ----------------------------------- |
+| **Find Input**              | Text to locate on the board         |
+| **Replace Input**           | Replacement text applied in bulk    |
+| **Widget Type Checkboxes**  | Filter results by widget type       |
+| **Tag IDs Input**           | Comma separated tags to match       |
+| **Background Colour Input** | Exact fill colour filter            |
+| **Assignee ID Input**       | Filter by assigned user             |
+| **Creator ID Input**        | Filter by creator                   |
+| **Last Modified By Input**  | Filter by last modifier             |
+| **Replace All**             | Calls `replaceBoardContent` utility |
 
 Flow: typing in the **Find** field debounces `searchBoardContent` by 300 ms and
 updates the match count.

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   Button,
+  Checkbox,
   InputField,
   Paragraph,
   Icon,
@@ -9,6 +10,7 @@ import {
 import {
   searchBoardContent,
   replaceBoardContent,
+  type SearchOptions,
 } from '../../board/search-tools';
 import type { TabTuple } from './tab-definitions';
 
@@ -19,6 +21,41 @@ export const SearchTab: React.FC = () => {
   const [query, setQuery] = React.useState('');
   const [replacement, setReplacement] = React.useState('');
   const [matches, setMatches] = React.useState(0);
+  const [widgetTypes, setWidgetTypes] = React.useState<string[]>([]);
+  const [tagIds, setTagIds] = React.useState('');
+  const [backgroundColor, setBackgroundColor] = React.useState('');
+  const [assignee, setAssignee] = React.useState('');
+  const [creator, setCreator] = React.useState('');
+  const [lastModifiedBy, setLastModifiedBy] = React.useState('');
+
+  const toggleType = (type: string): void => {
+    setWidgetTypes((prev) =>
+      prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type],
+    );
+  };
+
+  const buildOptions = React.useCallback((): SearchOptions => {
+    const opts: SearchOptions = { query };
+    if (widgetTypes.length) opts.widgetTypes = widgetTypes;
+    const tags = tagIds
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (tags.length) opts.tagIds = tags;
+    if (backgroundColor) opts.backgroundColor = backgroundColor;
+    if (assignee) opts.assignee = assignee;
+    if (creator) opts.creator = creator;
+    if (lastModifiedBy) opts.lastModifiedBy = lastModifiedBy;
+    return opts;
+  }, [
+    query,
+    widgetTypes,
+    tagIds,
+    backgroundColor,
+    assignee,
+    creator,
+    lastModifiedBy,
+  ]);
 
   React.useEffect(() => {
     const handle = setTimeout(async () => {
@@ -26,15 +63,15 @@ export const SearchTab: React.FC = () => {
         setMatches(0);
         return;
       }
-      const res = await searchBoardContent({ query });
+      const res = await searchBoardContent(buildOptions());
       setMatches(res.length);
     }, 300);
     return () => clearTimeout(handle);
-  }, [query]);
+  }, [buildOptions]);
 
   const replace = async (): Promise<void> => {
     if (!query) return;
-    const count = await replaceBoardContent({ query, replacement });
+    const count = await replaceBoardContent({ ...buildOptions(), replacement });
     setMatches(Math.max(0, matches - count));
   };
 
@@ -54,6 +91,59 @@ export const SearchTab: React.FC = () => {
           value={replacement}
           onChange={(e) => setReplacement(e.target.value)}
           placeholder='Replacement text'
+        />
+      </InputField>
+      <div className='form-group-small'>
+        <label>Widget Types</label>
+        <div>
+          {['shape', 'card', 'sticky_note', 'text'].map((t) => (
+            <Checkbox
+              key={t}
+              label={t}
+              value={widgetTypes.includes(t)}
+              onChange={() => toggleType(t)}
+            />
+          ))}
+        </div>
+      </div>
+      <InputField label='Tag IDs'>
+        <input
+          className='input input-small'
+          value={tagIds}
+          onChange={(e) => setTagIds(e.target.value)}
+          placeholder='Comma separated'
+        />
+      </InputField>
+      <InputField label='Background colour'>
+        <input
+          className='input input-small'
+          value={backgroundColor}
+          onChange={(e) => setBackgroundColor(e.target.value)}
+          placeholder='CSS colour'
+        />
+      </InputField>
+      <InputField label='Assignee ID'>
+        <input
+          className='input input-small'
+          value={assignee}
+          onChange={(e) => setAssignee(e.target.value)}
+          placeholder='User ID'
+        />
+      </InputField>
+      <InputField label='Creator ID'>
+        <input
+          className='input input-small'
+          value={creator}
+          onChange={(e) => setCreator(e.target.value)}
+          placeholder='User ID'
+        />
+      </InputField>
+      <InputField label='Last modified by'>
+        <input
+          className='input input-small'
+          value={lastModifiedBy}
+          onChange={(e) => setLastModifiedBy(e.target.value)}
+          placeholder='User ID'
         />
       </InputField>
       <Paragraph data-testid='match-count'>Matches: {matches}</Paragraph>

--- a/tests/search-tab.test.tsx
+++ b/tests/search-tab.test.tsx
@@ -43,6 +43,7 @@ describe('SearchTab', () => {
     fireEvent.change(screen.getByPlaceholderText(/search board text/i), {
       target: { value: 'foo' },
     });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'shape' }));
     await act(async () => {
       vi.advanceTimersByTime(300);
     });
@@ -52,7 +53,50 @@ describe('SearchTab', () => {
     await act(async () => {
       fireEvent.click(screen.getByText(/replace all/i));
     });
-    expect(repSpy).toHaveBeenCalledWith({ query: 'foo', replacement: 'bar' });
+    expect(repSpy).toHaveBeenCalledWith({
+      query: 'foo',
+      widgetTypes: ['shape'],
+      replacement: 'bar',
+    });
     expect(screen.getByTestId('match-count')).toHaveTextContent('Matches: 0');
+  });
+
+  test('filters are passed to search utilities', async () => {
+    const searchSpy = vi
+      .spyOn(searchTools, 'searchBoardContent')
+      .mockResolvedValue([]);
+    vi.spyOn(searchTools, 'replaceBoardContent').mockResolvedValue(0);
+    render(<SearchTab />);
+    fireEvent.change(screen.getByPlaceholderText(/search board text/i), {
+      target: { value: 'test' },
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'shape' }));
+    fireEvent.change(screen.getByLabelText(/tag ids/i), {
+      target: { value: 't1,t2' },
+    });
+    fireEvent.change(screen.getByLabelText(/background colour/i), {
+      target: { value: '#fff' },
+    });
+    fireEvent.change(screen.getByLabelText(/assignee id/i), {
+      target: { value: 'u1' },
+    });
+    fireEvent.change(screen.getByLabelText(/creator id/i), {
+      target: { value: 'c1' },
+    });
+    fireEvent.change(screen.getByLabelText(/last modified by/i), {
+      target: { value: 'm1' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(searchSpy).toHaveBeenCalledWith({
+      query: 'test',
+      widgetTypes: ['shape'],
+      tagIds: ['t1', 't2'],
+      backgroundColor: '#fff',
+      assignee: 'u1',
+      creator: 'c1',
+      lastModifiedBy: 'm1',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- extend search UI with advanced filter inputs
- pass selected filters to board search and replace utilities
- cover filters with unit tests
- document advanced search controls

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e8159a214832ba0ec0bbc5d56adc6