### PR TITLE
Add next+replace navigation

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -166,10 +166,14 @@ Shortcut: **Shift +C** opens comment editor on current selection.
 | **Assignee ID Input**       | Filter by assigned user             |
 | **Creator ID Input**        | Filter by creator                   |
 | **Last Modified By Input**  | Filter by last modifier             |
+| **Next Button**             | Scrolls board to next match         |
+| **Replace Button**          | Replace the highlighted match only  |
 | **Replace All**             | Calls `replaceBoardContent` utility |
 
 Flow: typing in the **Find** field debounces `searchBoardContent` by 300 ms and
-updates the match count.
+updates the match count. The **Next** button cycles through results and zooms
+the board to each widget. **Replace** updates just the current item via
+`replaceBoardContent` with `inSelection` pointing to that widget.
 
 ---
 


### PR DESCRIPTION
## Summary
- extend search tab with Next and Replace navigation
- allow single-item replace via `inSelection`
- document next/replace actions
- test navigation and single replacement

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e83496dc4832bae45c40cc0a6e6e8