### PR TITLE
Implement search zoom focus callbacks

### DIFF
--- a/src/board/search-tools.ts
+++ b/src/board/search-tools.ts
@@ -174,16 +174,21 @@ export async function searchBoardContent(
  * Replace matching board content preserving formatting.
  *
  * @returns Number of replacements performed.
+ * @param onMatch - Optional callback invoked with each matched widget before
+ * applying the replacement. Useful for focusing the board on the updated
+ * item.
  */
 export async function replaceBoardContent(
   opts: ReplaceOptions,
   board?: BoardQueryLike,
+  onMatch?: (item: Record<string, unknown>) => Promise<void> | void,
 ): Promise<number> {
   const b = getBoardWithQuery(board);
   const matches = await searchBoardContent(opts, b);
   const pattern = buildRegex(opts);
   let count = 0;
   for (const { item, field } of matches) {
+    if (onMatch) await onMatch(item);
     const current = getStringAtPath(item, field);
     if (current === undefined) continue;
     const updated = current.replace(pattern, () => {

--- a/tests/search-tools.test.ts
+++ b/tests/search-tools.test.ts
@@ -178,4 +178,20 @@ describe('search-tools', () => {
     expect(items[4].content).toBe('hi <b>World</b>');
     expect(items[0].sync).toHaveBeenCalled();
   });
+
+  test('onMatch callback is invoked for each replacement', async () => {
+    const { board, items } = makeBoard();
+    const seen: unknown[] = [];
+    const count = await replaceBoardContent(
+      { query: 'hello', replacement: 'hi' },
+      board,
+      (i) => {
+        seen.push(i);
+      },
+    );
+    expect(count).toBe(4);
+    expect(seen).toEqual(
+      expect.arrayContaining([items[0], items[1], items[4], items[5]]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- update `replaceBoardContent` to invoke optional `onMatch` callback
- focus board on each replaced match via callback in `SearchTab`
- refactor `SearchTab` with `focusOnItem` helper
- test zoom behaviour for replace actions

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e84faeca0832b8074785953346b50