### PR TITLE
Add TSDoc for BoardQueryLike

### DIFF
--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -15,6 +15,13 @@ export interface BoardLike {
   ui?: BoardUILike;
 }
 
+/**
+ * Board API that supports querying widgets by type.
+ *
+ * This extends {@link BoardLike} with a `get` method, mirroring the
+ * `miro.board.get()` call. Search utilities rely on this method to gather
+ * candidate widgets when scanning the board.
+ */
 export interface BoardQueryLike extends BoardLike {
   get(opts: { type: string }): Promise<Array<Record<string, unknown>>>;
 }


### PR DESCRIPTION
## Summary
- document the BoardQueryLike interface in board utilities

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e8787db90832ba8ef079bb8fa38ff