### PR TITLE
Update Search Tools docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ Utility helpers `searchBoardContent` and `replaceBoardContent` can query or
 update widgets by text. They support filtering by widget type, tag ID, fill
 colour, assignee, creator and last modifier. Searches may be case sensitive,
 whole-word or regular expression based and can be limited to the current
-selection.
+selection. The search tab includes **Next** to jump through results and
+**Replace** for single substitutions. During replacements the board viewport
+focuses on each matched item so you can review changes. See the
+[Search tab walkthrough](docs/TABS.md#10-search-tab) for the complete UI flow.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- document Next/Replace actions in README Search Tools
- mention viewport focusing during Replace
- link to the Search tab docs

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent README.md`


------
https://chatgpt.com/codex/tasks/task_e_685e8a04f194832ba36085e79fe2fab3