### PR TITLE
Add board command for metadata modal

### DIFF
--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -166,6 +166,14 @@ Shortcut: **Shift +C** opens comment editor on current selection.
 
 ---
 
+## Board Actions
+
+| Action        | Location                    | Result                                                |
+| ------------- | --------------------------- | ----------------------------------------------------- |
+| Edit Metadata | Context menu or app command | Opens the Edit Metadata modal for the selected widget |
+
+---
+
 ## Validation & Error Summary
 
 1. **File type** – Only .json/.csv/.mmd accepted; else toast “Unsupported file

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -19,7 +19,10 @@ export const App: React.FC = () => {
   const [idColumn, setIdColumn] = React.useState('');
   const [labelColumn, setLabelColumn] = React.useState('');
   const [templateColumn, setTemplateColumn] = React.useState('');
-  const [showMeta, setShowMeta] = React.useState(false);
+  const [showMeta, setShowMeta] = React.useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    return params.get('command') === 'edit-metadata';
+  });
   const tabIds = React.useMemo(() => TAB_DATA.map((t) => t[1]), []);
   React.useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/app/diagram-app.ts
+++ b/src/app/diagram-app.ts
@@ -22,5 +22,8 @@ export class DiagramApp {
     miro.board.ui.on('icon:click', async () => {
       await miro.board.ui.openPanel({ url: 'app.html' });
     });
+    miro.board.ui.on('edit-metadata', async () => {
+      await miro.board.ui.openPanel({ url: 'app.html?command=edit-metadata' });
+    });
   }
 }

--- a/tests/diagram-app.test.ts
+++ b/tests/diagram-app.test.ts
@@ -21,13 +21,19 @@ describe('DiagramApp', () => {
     expect(app1).toBe(app2);
   });
 
-  test('init registers click handler and opens panel', async () => {
+  test('init registers handlers and opens panel for commands', async () => {
     const openPanel = jest.fn().mockResolvedValue(undefined);
-    const on = jest.fn((_e: string, cb: () => Promise<void>) => cb());
+    const on = jest.fn((e: string, cb: () => Promise<void>) => {
+      if (e === 'icon:click' || e === 'edit-metadata') cb();
+    });
     global.miro = { board: { ui: { on, openPanel } } };
     await DiagramApp.getInstance().init();
     expect(on).toHaveBeenCalledWith('icon:click', expect.any(Function));
+    expect(on).toHaveBeenCalledWith('edit-metadata', expect.any(Function));
     expect(openPanel).toHaveBeenCalledWith({ url: 'app.html' });
+    expect(openPanel).toHaveBeenCalledWith({
+      url: 'app.html?command=edit-metadata',
+    });
   });
 
   test('init throws when miro is undefined', async () => {

--- a/tests/metadata-command.test.tsx
+++ b/tests/metadata-command.test.tsx
@@ -48,6 +48,21 @@ describe('Edit Metadata command', () => {
     expect(svc.updateShapesFromExcel).toHaveBeenCalled();
   });
 
+  test('query parameter opens EditMetadataModal on load', () => {
+    const original = window.location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = {
+      ...original,
+      search: '?command=edit-metadata',
+    } as Location;
+    render(<App />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = original;
+  });
+
   test('EditMetadataModal returns null without context', () => {
     render(
       <EditMetadataModal


### PR DESCRIPTION
## Summary
- register `edit-metadata` board action
- open EditMetadataModal when the command query parameter is present
- document new board action
- test board action handler and modal startup

## Testing
- `npm run lint --silent`
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run prettier --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e8b50e8f8832ba7a846e4829809c8