### PR TITLE
Improve branch coverage for ExcelTab and hooks

### DIFF
--- a/tests/useSelection.test.ts
+++ b/tests/useSelection.test.ts
@@ -42,4 +42,23 @@ describe('useSelection', () => {
     unmount();
     expect(board.ui.off).toHaveBeenCalledWith('selection:update', cb);
   });
+
+  test('returns empty array when board missing', async () => {
+    const { result } = renderHook(() => useSelection());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual([]);
+  });
+
+  test('works with board lacking ui API', async () => {
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue([{ id: 3 }]),
+    };
+    const { result } = renderHook(() => useSelection(board));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current).toEqual([{ id: 3 }]);
+  });
 });


### PR DESCRIPTION
## Summary
- expand ExcelTab branches test coverage
- test selection hook edge cases

## Testing
- `npm run typecheck --silent`
- `npm run prettier --silent`
- `npm run lint --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e8ce006c4832b9a7527bebae36c2e