### PR TITLE
Add search mode checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,11 @@ Utility helpers `searchBoardContent` and `replaceBoardContent` can query or
 update widgets by text. They support filtering by widget type, tag ID, fill
 colour, assignee, creator and last modifier. Searches may be case sensitive,
 whole-word or regular expression based and can be limited to the current
-selection. The search tab includes **Next** to jump through results and
-**Replace** for single substitutions. During replacements the board viewport
-focuses on each matched item so you can review changes. See the
-[Search tab walkthrough](docs/TABS.md#10-search-tab) for the complete UI flow.
+selection. The search tab exposes checkboxes for these modes alongside **Next**
+to jump through results and **Replace** for single substitutions. During
+replacements the board viewport focuses on each matched item so you can review
+changes. See the [Search tab walkthrough](docs/TABS.md#10-search-tab) for the
+complete UI flow.
 
 ## Setup
 

--- a/docs/TABS.md
+++ b/docs/TABS.md
@@ -160,6 +160,9 @@ Shortcut: **Shift +C** opens comment editor on current selection.
 | --------------------------- | ----------------------------------- |
 | **Find Input**              | Text to locate on the board         |
 | **Replace Input**           | Replacement text applied in bulk    |
+| **Case Sensitive Checkbox** | Match exact letter case             |
+| **Whole Word Checkbox**     | Skip partial-word matches           |
+| **Regex Checkbox**          | Treat query as regular expression   |
 | **Widget Type Checkboxes**  | Filter results by widget type       |
 | **Tag IDs Input**           | Comma separated tags to match       |
 | **Background Colour Input** | Exact fill colour filter            |

--- a/src/ui/pages/SearchTab.tsx
+++ b/src/ui/pages/SearchTab.tsx
@@ -29,6 +29,9 @@ export const SearchTab: React.FC = () => {
   const [assignee, setAssignee] = React.useState('');
   const [creator, setCreator] = React.useState('');
   const [lastModifiedBy, setLastModifiedBy] = React.useState('');
+  const [caseSensitive, setCaseSensitive] = React.useState(false);
+  const [wholeWord, setWholeWord] = React.useState(false);
+  const [regex, setRegex] = React.useState(false);
 
   const focusOnItem = React.useCallback(
     async (item: unknown): Promise<void> => {
@@ -65,6 +68,9 @@ export const SearchTab: React.FC = () => {
     if (assignee) opts.assignee = assignee;
     if (creator) opts.creator = creator;
     if (lastModifiedBy) opts.lastModifiedBy = lastModifiedBy;
+    if (caseSensitive) opts.caseSensitive = true;
+    if (wholeWord) opts.wholeWord = true;
+    if (regex) opts.regex = true;
     return opts;
   }, [
     query,
@@ -74,6 +80,9 @@ export const SearchTab: React.FC = () => {
     assignee,
     creator,
     lastModifiedBy,
+    caseSensitive,
+    wholeWord,
+    regex,
   ]);
 
   React.useEffect(() => {
@@ -146,6 +155,23 @@ export const SearchTab: React.FC = () => {
           placeholder='Replacement text'
         />
       </InputField>
+      <div className='form-group-small'>
+        <Checkbox
+          label='Case sensitive'
+          value={caseSensitive}
+          onChange={setCaseSensitive}
+        />
+        <Checkbox
+          label='Whole word'
+          value={wholeWord}
+          onChange={setWholeWord}
+        />
+        <Checkbox
+          label='Regex'
+          value={regex}
+          onChange={setRegex}
+        />
+      </div>
       <div className='form-group-small'>
         <label>Widget Types</label>
         <div>

--- a/tests/search-tab.test.tsx
+++ b/tests/search-tab.test.tsx
@@ -52,6 +52,8 @@ describe('SearchTab', () => {
       target: { value: 'foo' },
     });
     fireEvent.click(screen.getByRole('checkbox', { name: 'shape' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /case sensitive/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /regex/i }));
     await act(async () => {
       vi.advanceTimersByTime(300);
     });
@@ -66,6 +68,8 @@ describe('SearchTab', () => {
       query: 'foo',
       widgetTypes: ['shape'],
       replacement: 'bar',
+      caseSensitive: true,
+      regex: true,
     });
     expect(repSpy.mock.calls[0][2]).toBeInstanceOf(Function);
     expect(zoomSpy).toHaveBeenCalledWith(match.item);
@@ -97,6 +101,9 @@ describe('SearchTab', () => {
     fireEvent.change(screen.getByLabelText(/last modified by/i), {
       target: { value: 'm1' },
     });
+    fireEvent.click(screen.getByRole('checkbox', { name: /case sensitive/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /whole word/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /regex/i }));
     await act(async () => {
       vi.advanceTimersByTime(300);
     });
@@ -108,6 +115,9 @@ describe('SearchTab', () => {
       assignee: 'u1',
       creator: 'c1',
       lastModifiedBy: 'm1',
+      caseSensitive: true,
+      wholeWord: true,
+      regex: true,
     });
   });
 


### PR DESCRIPTION
## Summary
- update the Search tab with case sensitive, whole word and regex checkboxes
- pass new options to `searchBoardContent` and `replaceBoardContent`
- extend tests for new options
- document the new inputs in the search tab docs and README

## Testing
- `npm run typecheck --silent`
- `npm run lint --silent`
- `npm run prettier --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e8e948870832bbed66ffd0730ad40