### PR TITLE
Fix React version detection for test files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,8 +19,9 @@ export default [
     rules: { 'no-console': 'warn', 'react/react-in-jsx-scope': 'off' },
   },
   {
-    files: ['tests/**/*.ts'],
+    files: ['tests/**/*.{ts,tsx}'],
     languageOptions: { parser, ecmaVersion: 'latest', sourceType: 'module' },
+    settings: { react: { version: 'detect' } },
     rules: {},
   },
 ];


### PR DESCRIPTION
## Summary
- detect React version for `tests/**/*.{ts,tsx}` in eslint config

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e95e98a98832b89942bd3057a5d9b