### PR TITLE
Add regex error tests for board search tools

### DIFF
--- a/tests/search-tools.test.ts
+++ b/tests/search-tools.test.ts
@@ -221,4 +221,21 @@ describe('search-tools', () => {
     expect(items[0].sync).not.toHaveBeenCalled();
     expect(items[1].plainText).toBe('hi');
   });
+
+  test('searchBoardContent rejects invalid regex patterns', async () => {
+    const { board } = makeBoard();
+    await expect(
+      searchBoardContent({ query: '*foo', regex: true }, board),
+    ).rejects.toThrow(SyntaxError);
+  });
+
+  test('replaceBoardContent rejects invalid regex patterns', async () => {
+    const { board } = makeBoard();
+    await expect(
+      replaceBoardContent(
+        { query: '*foo', replacement: 'bar', regex: true },
+        board,
+      ),
+    ).rejects.toThrow(SyntaxError);
+  });
 });


### PR DESCRIPTION
## Summary
- cover invalid regex handling in `searchBoardContent` and `replaceBoardContent`

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e970e1e10832b869f37a766a4f26c