### PR TITLE
Fix Graph base64 encoding

### DIFF
--- a/src/core/utils/base64.ts
+++ b/src/core/utils/base64.ts
@@ -1,11 +1,11 @@
 /**
- * Encode a string as Base64 in a UTF-8 safe manner.
+ * Encode a string as Base64URL in a UTF-8 safe manner.
  *
  * Uses `Buffer` when running in Node and falls back to
  * `btoa(unescape(encodeURIComponent()))` in the browser.
  *
  * @param input - Raw string to encode.
- * @returns Base64 encoded representation.
+ * @returns Base64URL encoded representation.
  */
 export function encodeBase64(input: string): string {
   const base64 =
@@ -13,5 +13,5 @@ export function encodeBase64(input: string): string {
     (typeof window === 'undefined' || typeof window.btoa !== 'function')
       ? Buffer.from(input, 'utf8').toString('base64')
       : btoa(unescape(encodeURIComponent(input)));
-  return base64.replace(/=+$/, '');
+  return base64.replace(/=+$/, '').replace(/\+/g, '-').replace(/\//g, '_');
 }

--- a/tests/graph-client.test.ts
+++ b/tests/graph-client.test.ts
@@ -45,12 +45,31 @@ describe('GraphClient', () => {
     const link = 'https://миру';
     const encoded = Buffer.from(link, 'utf8')
       .toString('base64')
-      .replace(/=+$/, '');
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
     await client.fetchFile(link);
     expect((fetch as vi.Mock).mock.calls[0][0]).toBe(
       `https://graph.microsoft.com/v1.0/shares/u!${encoded}/driveItem/content`,
     );
     (globalThis as { btoa?: (s: string) => string }).btoa = orig;
+  });
+
+  test('encodes special characters in share link', async () => {
+    (fetch as unknown as vi.Mock).mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(1)),
+    });
+    const link = 'https://example.com/тест+file/?q=a/b+c';
+    const encoded = Buffer.from(link, 'utf8')
+      .toString('base64')
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+    await client.fetchFile(link);
+    expect((fetch as vi.Mock).mock.calls[0][0]).toBe(
+      `https://graph.microsoft.com/v1.0/shares/u!${encoded}/driveItem/content`,
+    );
   });
 
   test('throws on error', async () => {


### PR DESCRIPTION
## Summary
- update `encodeBase64` to output base64url
- update GraphClient tests for base64url handling
- add test for share links with special characters

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e9a6339f0832ba04fa1c17e038958