### PR TITLE
Resolve merge conflicts

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,7 +29,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64

--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -46,3 +46,67 @@ export async function renameSelectedFrames(
     }),
   );
 }
+
+/**
+ * Subset of widget properties required for locking.
+ *
+ * The `locked` flag is not part of the public Web‑SDK type
+ * definitions yet but is present on runtime objects. It indicates
+ * whether a widget is locked from user interaction.
+ */
+interface LockableItem extends Record<string, unknown> {
+  /** `true` if the widget is locked. */
+  locked?: boolean;
+  /** Persist property changes to the board. */
+  sync?: () => Promise<void>;
+}
+
+/** Frame widget subset used within this module. */
+interface FrameLike extends LockableItem {
+  /** Widget type discriminator. */
+  type?: string;
+  /** Retrieve child widgets contained in the frame. */
+  getChildren?: () => Promise<LockableItem[]>;
+}
+
+/**
+ * Check whether a widget is a frame.
+ *
+ * @param item - Widget to test.
+ */
+function isFrame(item: Record<string, unknown>): item is FrameLike {
+  return (item as { type?: string }).type === 'frame';
+}
+
+/**
+ * Lock a widget if possible.
+ *
+ * @param item - Widget to lock.
+ */
+async function lockItem(item: LockableItem): Promise<void> {
+  item.locked = true;
+  await item.sync?.();
+}
+
+/**
+ * Lock a frame and all of its child widgets.
+ *
+ * @param frame - Target frame widget.
+ */
+async function lockFrame(frame: FrameLike): Promise<void> {
+  await lockItem(frame);
+  const children = (await frame.getChildren?.()) ?? [];
+  await Promise.all(children.map((child) => lockItem(child)));
+}
+
+/**
+ * Lock all selected frames and their contents.
+ *
+ * @param board - Optional board API override for testing.
+ */
+export async function lockSelectedFrames(board?: BoardLike): Promise<void> {
+  const b = getBoard(board);
+  const selection = await b.getSelection();
+  const frames = selection.filter(isFrame);
+  await Promise.all(frames.map((frame) => lockFrame(frame)));
+}

--- a/src/ui/pages/tab-definitions.ts
+++ b/src/ui/pages/tab-definitions.ts
@@ -9,6 +9,7 @@ export type TabId =
   | 'frames'
   | 'spacing'
   | 'excel'
+  | 'help'
   | 'dummy';
 
 export type TabTuple = readonly [

--- a/tests/frame-tools.test.ts
+++ b/tests/frame-tools.test.ts
@@ -1,4 +1,7 @@
-import { renameSelectedFrames } from '../src/board/frame-tools';
+import {
+  renameSelectedFrames,
+  lockSelectedFrames,
+} from '../src/board/frame-tools';
 import { BoardLike } from '../src/board/board';
 
 describe('frame-tools', () => {
@@ -48,6 +51,60 @@ describe('frame-tools', () => {
     expect(items[1].title).toBe('X0');
   });
 
+  test('renameSelectedFrames does nothing when selection empty', async () => {
+    const board: BoardLike = { getSelection: jest.fn().mockResolvedValue([]) };
+    await renameSelectedFrames({ prefix: 'N-' }, board);
+    expect(board.getSelection).toHaveBeenCalled();
+  });
+
+  test('renameSelectedFrames sorts by y when x equal', async () => {
+    const frames = [
+      { x: 0, y: 10, title: 'A', sync: jest.fn(), type: 'frame' },
+      { x: 0, y: 0, title: 'B', sync: jest.fn(), type: 'frame' },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'Q' }, board);
+    expect(frames[1].title).toBe('Q0');
+    expect(frames[0].title).toBe('Q1');
+  });
+
+  test('renameSelectedFrames handles frames without sync or coordinates', async () => {
+    const frame = { title: 'A', type: 'frame' };
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue([frame]),
+    };
+    await renameSelectedFrames({ prefix: 'R-' }, board);
+    expect(frame.title).toBe('R-0');
+  });
+
+  test('renameSelectedFrames sorts frames missing coordinates', async () => {
+    const frames = [
+      { title: 'A', type: 'frame' },
+      { x: 5, y: 0, title: 'B', type: 'frame', sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'C' }, board);
+    expect(frames[0].title).toBe('C0');
+    expect(frames[1].title).toBe('C1');
+  });
+
+  test('renameSelectedFrames handles missing y for sort', async () => {
+    const frames = [
+      { x: 0, title: 'A', type: 'frame', sync: jest.fn() },
+      { x: 0, y: 2, title: 'B', type: 'frame', sync: jest.fn() },
+    ];
+    const board: BoardLike = {
+      getSelection: jest.fn().mockResolvedValue(frames),
+    };
+    await renameSelectedFrames({ prefix: 'D' }, board);
+    expect(frames[0].title).toBe('D0');
+    expect(frames[1].title).toBe('D1');
+  });
+
   test('renameSelectedFrames throws without board', async () => {
     await expect(renameSelectedFrames({ prefix: 'P' })).rejects.toThrow(
       'Miro board not available',
@@ -73,5 +130,73 @@ describe('frame-tools', () => {
     await renameSelectedFrames({ prefix: 'Q' }, board);
     expect(frames[0].title).toBe('Q1');
     expect(frames[1].title).toBe('Q0');
+  });
+
+  describe('lockSelectedFrames', () => {
+    test('locks frames and children', async () => {
+      const child = { locked: false, sync: jest.fn() };
+      const frame = {
+        type: 'frame',
+        locked: false,
+        sync: jest.fn(),
+        getChildren: jest.fn().mockResolvedValue([child]),
+      };
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([frame]),
+      };
+      await lockSelectedFrames(board);
+      expect(frame.locked).toBe(true);
+      expect(child.locked).toBe(true);
+      expect(frame.sync).toHaveBeenCalled();
+      expect(child.sync).toHaveBeenCalled();
+    });
+
+    test('locks frames without children', async () => {
+      const frame = {
+        type: 'frame',
+        locked: false,
+        sync: jest.fn(),
+        getChildren: jest.fn().mockResolvedValue([]),
+      };
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([frame]),
+      };
+      await lockSelectedFrames(board);
+      expect(frame.locked).toBe(true);
+      expect(frame.sync).toHaveBeenCalled();
+    });
+
+    test('locks frame even when getChildren missing', async () => {
+      const frame = { type: 'frame', locked: false };
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([frame]),
+      };
+      await lockSelectedFrames(board);
+      expect(frame.locked).toBe(true);
+    });
+
+    test('does nothing when selection empty', async () => {
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([]),
+      };
+      await lockSelectedFrames(board);
+      expect(board.getSelection).toHaveBeenCalled();
+    });
+
+    test('ignores non-frame widgets', async () => {
+      const item = { type: 'shape', locked: false, sync: jest.fn() };
+      const board: BoardLike = {
+        getSelection: jest.fn().mockResolvedValue([item]),
+      };
+      await lockSelectedFrames(board);
+      expect(item.locked).toBe(false);
+      expect(item.sync).not.toHaveBeenCalled();
+    });
+
+    test('throws without board', async () => {
+      await expect(lockSelectedFrames()).rejects.toThrow(
+        'Miro board not available',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- resolve merge conflicts in docker workflow, tab definitions and frame tools tests
- ensure frame locking utility is present

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e9adb227c832bba12cef9bb8538d2