### PR TITLE
Add community standards docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+Code of Conduct.
+
+We expect all participants to uphold these guidelines when interacting in issue
+trackers, discussion forums and pull requests.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by emailing <support@miro.com>.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+labels: bug
+---
+
+**Describe the bug** A clear and concise description of what the bug is.
+
+**To Reproduce** Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior** A clear and concise description of what you expected to
+happen.
+
+**Environment:**
+
+- OS: [e.g. macOS 14]
+- Node version: `node -v`
+
+**Additional context** Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.** A clear and
+concise description of what the problem is.
+
+**Describe the solution you'd like** A clear and concise description of what you
+want to happen.
+
+**Describe alternatives you've considered** A clear and concise description of
+any alternative solutions or features you've considered.
+
+**Additional context** Add any other context or screenshots about the feature
+request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Summary
+
+- [ ] Implementation adheres to [CODE_STYLE.md](docs/CODE_STYLE.md)
+- [ ] Complexity remains under eight
+- [ ] Tests provide at least 90% line and branch coverage
+- [ ] Dark-mode snapshot updated
+- [ ] Accessibility reviewed
+- [ ] CHANGELOG entry included
+
+Provide a short description of the changes introduced by this PR.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+If you discover a vulnerability in this project please report it privately. Send
+an email to <security@miro.com> with a detailed description of the issue and
+steps to reproduce. We will respond as quickly as possible and work with you to
+resolve the problem. Please do not disclose security issues publicly until they
+are fully resolved.


### PR DESCRIPTION
## Summary
- add a Contributor Covenant Code of Conduct
- include project security policy
- add issue templates for bugs and feature requests
- add a pull request template referencing coverage and complexity goals

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_685e9b96c670832b96aafa39d367e236