### PR TITLE
Add layout mode docs and test

### DIFF
--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -160,7 +160,8 @@ export class CardProcessor {
   }
 
   /**
-   * Separate card definitions into create and update lists based on board state.
+   * Separate card definitions into create and update lists
+   * based on board state.
    */
   private partitionCards(
     cards: CardData[],

--- a/src/core/graph/layout-modes.ts
+++ b/src/core/graph/layout-modes.ts
@@ -1,6 +1,12 @@
+/** Known algorithms for nested graph layouts. */
 export const NESTED_ALGORITHMS = ['box', 'rectstacking'] as const;
+
+/** Valid nested graph algorithm names. */
 export type NestedAlgorithm = (typeof NESTED_ALGORITHMS)[number];
 
+/**
+ * Check if a string refers to a supported nested layout algorithm.
+ */
 export function isNestedAlgorithm(alg?: string | null): alg is NestedAlgorithm {
   return alg === 'box' || alg === 'rectstacking';
 }

--- a/tests/layout-modes.test.ts
+++ b/tests/layout-modes.test.ts
@@ -1,0 +1,17 @@
+import {
+  NESTED_ALGORITHMS,
+  isNestedAlgorithm,
+} from '../src/core/graph/layout-modes';
+
+describe('layout-modes', () => {
+  test('NESTED_ALGORITHMS lists supported algorithms', () => {
+    expect(NESTED_ALGORITHMS).toEqual(['box', 'rectstacking']);
+  });
+
+  test('isNestedAlgorithm validates algorithm names', () => {
+    expect(isNestedAlgorithm('box')).toBe(true);
+    expect(isNestedAlgorithm('rectstacking')).toBe(true);
+    expect(isNestedAlgorithm('force')).toBe(false);
+    expect(isNestedAlgorithm(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- document supported nested layout algorithms
- clarify partitionCards description
- test layout mode helpers

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685fdfe15230832bb07aa8d18551a74f