### PR TITLE
Add npm caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Prettier
@@ -40,6 +42,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: SonarCloud Scan
@@ -57,6 +61,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Build
@@ -78,6 +84,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: corepack enable
       - run: npm install --frozen-lockfile || npm install
       - name: Download artefact

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,11 +97,12 @@ Complexity limits enforced automatically by **SonarQube** gate.
 
 **Workflow** (GitHub Actions)
 
-1. Lint, type-check, unit tests (Node 24).
-2. Build Storybook and a feature-flagged bundle for staging.
-3. SonarQube analysis and budget checks.
-4. Semantic-release creates Git tag, changelog and Chrome-Store zip.
-5. Automatic rollback uses the previously published artefact (see
+1. Restore Node dependencies from cache.
+2. Lint, type-check, unit tests (Node 24).
+3. Build Storybook and a feature-flagged bundle for staging.
+4. SonarQube analysis and budget checks.
+5. Semantic-release creates Git tag, changelog and Chrome-Store zip.
+6. Automatic rollback uses the previously published artefact (see
    **DEPLOYMENT.md** for details).
 
 ---


### PR DESCRIPTION
## Summary
- enable npm caching for all CI jobs
- document caching in the architecture guide

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685fe4f0d17c832b896993c04ffd97c0