### PR TITLE
Fix React version warning in ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,11 @@ import react from 'eslint-plugin-react';
 export default [
   { ignores: ['node_modules/**', 'dist/**'] },
   ...tseslint.configs['flat/recommended'],
-  react.configs.flat.recommended,
+  {
+    plugins: { react },
+    ...react.configs.flat.recommended,
+    settings: { react: { version: '18.2' } },
+  },
   {
     files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
@@ -15,7 +19,6 @@ export default [
       sourceType: 'module',
       parserOptions: { project: './tsconfig.json' },
     },
-    settings: { react: { version: 'detect' } },
     rules: { 'no-console': 'warn', 'react/react-in-jsx-scope': 'off' },
   },
   {

--- a/src/core/utils/file-utils.ts
+++ b/src/core/utils/file-utils.ts
@@ -32,12 +32,12 @@ export class FileUtils {
       const reader = new FileReader();
       reader.onload = (e) => {
         if (!e.target) {
-          reject('Failed to load file');
+          reject(new Error('Failed to load file'));
           return;
         }
         resolve(e.target.result as string);
       };
-      reader.onerror = () => reject('Failed to load file');
+      reader.onerror = () => reject(new Error('Failed to load file'));
       reader.readAsText(file, 'utf-8');
     });
   }

--- a/src/ui/components/TabBar.tsx
+++ b/src/ui/components/TabBar.tsx
@@ -13,13 +13,20 @@ export const TabBar: React.FC<{
     style={{ margin: tokens.space.xxsmall }}>
     <div className='tabs-header-list'>
       {tabs.map(([, id, label]) => (
-        <div
+        <button
           key={id}
+          type='button'
           role='tab'
           className={`tab ${tab === id ? 'tab-active' : ''}`}
-          onClick={() => onChange(id)}>
-          <div className='tab-text'>{label}</div>
-        </div>
+          onClick={() => onChange(id)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onChange(id);
+            }
+          }}>
+          <span className='tab-text'>{label}</span>
+        </button>
       ))}
     </div>
   </div>

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -42,26 +42,26 @@ export const ResizeTab: React.FC = () => {
       setWarning('');
     };
 
-  const copy = async (): Promise<void> => {
+  const copy = React.useCallback(async (): Promise<void> => {
     const s = await copySizeFromSelection();
     if (s) {
       setSize(s);
       setCopiedSize(s);
     }
-  };
+  }, []);
 
   const resetCopy = (): void => {
     setCopiedSize(null);
   };
 
-  const apply = async (): Promise<void> => {
+  const apply = React.useCallback(async (): Promise<void> => {
     const target = copiedSize ?? size;
     if (target.width > 10000 || target.height > 10000) {
       setWarning("That's bigger than your board viewport");
       return;
     }
     await applySizeToSelection(target);
-  };
+  }, [copiedSize, size]);
 
   React.useEffect(() => {
     const first = selection[0] as
@@ -96,7 +96,7 @@ export const ResizeTab: React.FC = () => {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  });
+  }, [copy, apply]);
 
   return (
     <div className='custom-centered'>

--- a/tests/card-load.test.ts
+++ b/tests/card-load.test.ts
@@ -97,6 +97,6 @@ describe('loadCards', () => {
     (global as { FileReader?: unknown }).FileReader = FR;
     await expect(
       cardLoader.loadCards({ name: 'bad.json' } as unknown as File),
-    ).rejects.toBe('Failed to load file');
+    ).rejects.toEqual(new Error('Failed to load file'));
   });
 });

--- a/tests/file-utils-error.test.ts
+++ b/tests/file-utils-error.test.ts
@@ -17,6 +17,6 @@ describe('FileUtils error handling', () => {
     (global as { FileReader?: unknown }).FileReader = FR;
     await expect(
       fileUtils.readFileAsText({ name: 'file.txt' } as unknown as File),
-    ).rejects.toBe('Failed to load file');
+    ).rejects.toEqual(new Error('Failed to load file'));
   });
 });

--- a/tests/graph-load.test.ts
+++ b/tests/graph-load.test.ts
@@ -83,6 +83,6 @@ describe('loadGraph', () => {
     (global as { FileReader?: unknown }).FileReader = FR;
     await expect(
       graphService.loadGraph({ name: 'bad.json' } as unknown as File),
-    ).rejects.toBe('Failed to load file');
+    ).rejects.toEqual(new Error('Failed to load file'));
   });
 });

--- a/tests/tabbar-accessibility.test.tsx
+++ b/tests/tabbar-accessibility.test.tsx
@@ -1,0 +1,29 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TabBar } from '../src/ui/components/TabBar';
+import type { TabTuple } from '../src/ui/pages/tabs';
+
+describe('TabBar accessibility', () => {
+  const tabs: TabTuple[] = [
+    [1, 'first', 'First', '', () => <div />],
+    [2, 'second', 'Second', '', () => <div />],
+  ];
+
+  test('tab elements are focusable and respond to keyboard', () => {
+    const handler = vi.fn();
+    render(
+      <TabBar
+        tabs={tabs}
+        tab='first'
+        onChange={handler}
+      />,
+    );
+    const second = screen.getByRole('tab', { name: 'Second' });
+    second.focus();
+    expect(second).toHaveFocus();
+    fireEvent.keyDown(second, { key: 'Enter' });
+    expect(handler).toHaveBeenCalledWith('second');
+  });
+});

--- a/tests/tabs.test.ts
+++ b/tests/tabs.test.ts
@@ -296,7 +296,7 @@ describe('tab auto-registration', () => {
   test('includes DummyTab in test environment', async () => {
     const prev = process.env.NODE_ENV;
     process.env.NODE_ENV = 'test';
-    const { TAB_DATA } = await import('../src/ui/pages/tabs?test');
+    const { TAB_DATA } = await import('../src/ui/pages/tabs.ts?test');
     expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(true);
     process.env.NODE_ENV = prev;
   });
@@ -304,7 +304,7 @@ describe('tab auto-registration', () => {
   test('excludes DummyTab in development', async () => {
     const prev = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
-    const { TAB_DATA } = await import('../src/ui/pages/tabs?dev');
+    const { TAB_DATA } = await import('../src/ui/pages/tabs.ts?dev');
     expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(false);
     process.env.NODE_ENV = prev;
   });
@@ -312,7 +312,7 @@ describe('tab auto-registration', () => {
   test('excludes DummyTab in production', async () => {
     const prev = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';
-    const { TAB_DATA } = await import('../src/ui/pages/tabs?prod');
+    const { TAB_DATA } = await import('../src/ui/pages/tabs.ts?prod');
     expect(TAB_DATA.some((t) => t[1] === 'dummy')).toBe(false);
     process.env.NODE_ENV = prev;
   });
@@ -322,9 +322,12 @@ describe('tab auto-registration', () => {
     for (const env of envs) {
       const prev = process.env.NODE_ENV;
       process.env.NODE_ENV = env;
-      const suffix =
-        env === 'test' ? '?test' : env === 'development' ? '?dev' : '?prod';
-      const { TAB_DATA } = await import(`../src/ui/pages/tabs${suffix}`);
+      const { TAB_DATA } =
+        env === 'test'
+          ? await import('../src/ui/pages/tabs.ts?test')
+          : env === 'development'
+            ? await import('../src/ui/pages/tabs.ts?dev')
+            : await import('../src/ui/pages/tabs.ts?prod');
       expect(TAB_DATA.some((t) => t[1] === 'help')).toBe(true);
       process.env.NODE_ENV = prev;
     }


### PR DESCRIPTION
## Summary
- update ESLint flat config so React plugin has explicit version
- memoize ResizeTab handlers so keydown listener is stable
- use Error objects when file reading fails
- make TabBar tabs keyboard-focusable and add test
- fix dynamic import paths in tab tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_685ff234f618832ba6fd842f54311652