### PR TITLE
Fix lint issues and improve accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,10 @@ npm run prettier --silent
 These commands perform TypeScript type checking, execute the **Vitest** suite
 with coverage enabled, run ESLint and format files with Prettier. Aim for at
 least 90 % line and branch coverage and keep cyclomatic complexity under eight
-(see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). Run these checks before
-committing so code conforms to the repository guidelines.
+(see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)). ESLint enforces additional
+Sonar rules such as using `readonly` class fields, optional chaining, semantic
+HTML tags and stable React keys. Run these checks before committing so code
+conforms to the repository guidelines.
 
 ## 🗂️ Folder structure <a name="folder"></a>
 

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -28,4 +28,12 @@ This project enforces consistent formatting with
 - Import order follows standard → vendor → local, alphabetically within each
   group.
 
+## Lint guidelines
+
+- Mark class fields that are assigned only in the constructor as `readonly`.
+- Use optional chaining when accessing nested properties.
+- Prefer semantic HTML tags like `<fieldset>` or `<details>` over generic `div`
+  elements with ARIA roles.
+- Avoid using array indexes as React list keys; use stable identifiers instead.
+
 For additional architectural guidelines see [ARCHITECTURE.md](ARCHITECTURE.md).

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -151,9 +151,7 @@ export class BoardBuilder {
         const to = nodeMap[edge.to];
         if (!from || !to) return undefined;
         const templateName =
-          edge.metadata &&
-          'template' in edge.metadata &&
-          typeof edge.metadata.template === 'string'
+          typeof edge.metadata?.template === 'string'
             ? edge.metadata.template
             : 'default';
         const template = templateManager.getConnectorTemplate(templateName);

--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -34,7 +34,7 @@ export class CardProcessor {
   /** Cached board tags when processing updates. */
   private tagsCache: Tag[] | undefined;
 
-  constructor(private builder: BoardBuilder = new BoardBuilder()) {}
+  constructor(private readonly builder: BoardBuilder = new BoardBuilder()) {}
 
   /** Load cards from a file and create them on the board. */
   public async processFile(

--- a/src/core/graph/graph-processor.ts
+++ b/src/core/graph/graph-processor.ts
@@ -27,7 +27,9 @@ export interface ProcessOptions {
 export class GraphProcessor {
   private lastCreated: Array<BaseItem | Group | Connector | Frame> = [];
 
-  constructor(private builder: BoardBuilder = graphService.getBuilder()) {}
+  constructor(
+    private readonly builder: BoardBuilder = graphService.getBuilder(),
+  ) {}
 
   /**
    * Load a JSON graph file and process it.

--- a/src/core/graph/graph-service.ts
+++ b/src/core/graph/graph-service.ts
@@ -35,7 +35,7 @@ export interface EdgeHint {
 
 export class GraphService {
   private static instance: GraphService;
-  private builder = new BoardBuilder();
+  private readonly builder = new BoardBuilder();
 
   private constructor() {}
 

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -36,7 +36,7 @@ export class HierarchyProcessor {
     return this.lastCreated;
   }
 
-  constructor(private builder: BoardBuilder = new BoardBuilder()) {}
+  constructor(private readonly builder: BoardBuilder = new BoardBuilder()) {}
 
   /**
    * Load a hierarchical JSON file and create the corresponding diagram.

--- a/src/core/layout/nested-layout.ts
+++ b/src/core/layout/nested-layout.ts
@@ -35,8 +35,9 @@ import type { ElkNode } from 'elkjs/lib/elk-api';
  */
 export class NestedLayouter {
   private sortValue(node: HierNode, key?: string): string {
-    if (key && node.metadata && key in node.metadata) {
-      return String(node.metadata[key]);
+    const metaValue = key ? node.metadata?.[key] : undefined;
+    if (metaValue !== undefined) {
+      return String(metaValue);
     }
     return node.label ?? node.id;
   }

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -21,10 +21,8 @@ export function SegmentedControl({
   options,
 }: SegmentedControlProps): React.JSX.Element {
   return (
-    <div
-      role='group'
-      aria-label='Layout type'
-      className='segmented-control'>
+    <fieldset className='segmented-control'>
+      <legend className='custom-visually-hidden'>Layout type</legend>
       {options.map((opt) => (
         <Button
           key={opt.value}
@@ -33,6 +31,6 @@ export function SegmentedControl({
           {opt.label}
         </Button>
       ))}
-    </div>
+    </fieldset>
   );
 }

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -115,8 +115,8 @@ export const CardsTab: React.FC = () => {
       {files.length > 0 && (
         <>
           <ul className='custom-dropped-files'>
-            {files.map((file, i) => (
-              <li key={i}>{file.name}</li>
+            {files.map((file) => (
+              <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
             ))}
           </ul>
           <div style={{ marginTop: tokens.space.small }}>

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -197,8 +197,8 @@ export const DiagramTab: React.FC = () => {
       {importQueue.length > 0 && (
         <>
           <ul className='custom-dropped-files'>
-            {importQueue.map((file, i) => (
-              <li key={i}>{file.name}</li>
+            {importQueue.map((file) => (
+              <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
             ))}
           </ul>
           <InputField label='Layout type'>


### PR DESCRIPTION
## Summary
- mark builder fields as readonly
- use optional chaining in nested layouts and board builder
- replace a `div` using `role="group"` with `fieldset`
- avoid React key indexes for dropped files

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686087202300832b8b5c8bfd240215d7