### PR TITLE
Refactor widget sync handling

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -32,6 +32,7 @@ This project enforces consistent formatting with
 
 - Mark class fields that are assigned only in the constructor as `readonly`.
 - Use optional chaining when accessing nested properties.
+- Avoid non-null assertions (`!`) and redundant casts; refine types instead.
 - Prefer semantic HTML tags like `<fieldset>` or `<details>` over generic `div`
   elements with ARIA roles.
 - Avoid using array indexes as React list keys; use stable identifiers instead.

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -33,6 +33,8 @@ This project enforces consistent formatting with
 - Mark class fields that are assigned only in the constructor as `readonly`.
 - Use optional chaining when accessing nested properties.
 - Avoid non-null assertions (`!`) and redundant casts; refine types instead.
+- Steer clear of nested ternary expressions. Prefer `if`/`else` blocks or helper
+  functions for clarity.
 - Prefer semantic HTML tags like `<fieldset>` or `<details>` over generic `div`
   elements with ARIA roles.
 - Avoid using array indexes as React list keys; use stable identifiers instead.

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -19,6 +19,7 @@ import type {
   NodeData,
   PositionedNode,
 } from '../core/graph';
+import { maybeSync } from './board';
 
 const META_KEY = 'app.miro.structgraph';
 
@@ -166,12 +167,7 @@ export class BoardBuilder {
     items: Array<BaseItem | Group | Connector>,
   ): Promise<void> {
     await Promise.all(
-      items
-        .filter(
-          (i) =>
-            typeof (i as { sync?: () => Promise<void> }).sync === 'function',
-        )
-        .map((i) => (i as { sync: () => Promise<void> }).sync()),
+      items.map((i) => maybeSync(i as { sync?: () => Promise<void> })),
     );
   }
 
@@ -375,7 +371,7 @@ export class BoardBuilder {
     };
     if (typeof target.width === 'number') target.width = width;
     if (typeof target.height === 'number') target.height = height;
-    if (typeof target.sync === 'function') await target.sync();
+    await maybeSync(target);
   }
 
   /**

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -19,7 +19,7 @@ import type {
   NodeData,
   PositionedNode,
 } from '../core/graph';
-import { maybeSync } from './board';
+import { maybeSync, Syncable } from './board';
 
 const META_KEY = 'app.miro.structgraph';
 
@@ -166,9 +166,7 @@ export class BoardBuilder {
   public async syncAll(
     items: Array<BaseItem | Group | Connector>,
   ): Promise<void> {
-    await Promise.all(
-      items.map((i) => maybeSync(i as { sync?: () => Promise<void> })),
-    );
+    await Promise.all(items.map((i) => maybeSync(i as Syncable)));
   }
 
   /** Remove the provided widgets from the board. */

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -215,10 +215,11 @@ export class BoardBuilder {
     if (!this.shapeMap) {
       this.ensureBoard();
       const shapes = (await miro.board.get({ type: 'shape' })) as Shape[];
-      this.shapeMap = new Map();
+      const map = new Map<string, BaseItem>();
       shapes
         .filter((s) => typeof s.content === 'string' && s.content.trim())
-        .forEach((s) => this.shapeMap!.set(s.content, s as BaseItem));
+        .forEach((s) => map.set(s.content, s as BaseItem));
+      this.shapeMap = map;
     }
   }
 

--- a/src/board/board-builder.ts
+++ b/src/board/board-builder.ts
@@ -19,7 +19,7 @@ import type {
   NodeData,
   PositionedNode,
 } from '../core/graph';
-import { maybeSync, Syncable } from './board';
+import { maybeSync } from './board';
 
 const META_KEY = 'app.miro.structgraph';
 
@@ -166,7 +166,7 @@ export class BoardBuilder {
   public async syncAll(
     items: Array<BaseItem | Group | Connector>,
   ): Promise<void> {
-    await Promise.all(items.map((i) => maybeSync(i as Syncable)));
+    await Promise.all(items.map((i) => maybeSync(i)));
   }
 
   /** Remove the provided widgets from the board. */

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -79,9 +79,20 @@ export async function forEachSelection(
  *
  * Simplifies conditional sync calls across board utilities.
  */
-export async function maybeSync(item: {
+/**
+ * Widget-like type optionally exposing a `sync` method.
+ */
+export interface Syncable {
+  /** Persist property changes to the board. */
   sync?: () => Promise<void>;
-}): Promise<void> {
+}
+
+/**
+ * Invoke the `sync` method on a widget when available.
+ *
+ * Simplifies conditional sync calls across board utilities.
+ */
+export async function maybeSync(item: Syncable): Promise<void> {
   if (typeof item.sync === 'function') {
     await item.sync();
   }

--- a/src/board/board.ts
+++ b/src/board/board.ts
@@ -73,3 +73,16 @@ export async function forEachSelection(
   const selection = await b.getSelection();
   await Promise.all(selection.map((item) => cb(item)));
 }
+
+/**
+ * Invoke the `sync` method on a widget when available.
+ *
+ * Simplifies conditional sync calls across board utilities.
+ */
+export async function maybeSync(item: {
+  sync?: () => Promise<void>;
+}): Promise<void> {
+  if (typeof item.sync === 'function') {
+    await item.sync();
+  }
+}

--- a/src/board/format-tools.ts
+++ b/src/board/format-tools.ts
@@ -1,5 +1,5 @@
 import { resolveColor } from '../core/utils/color-utils';
-import { BoardLike, forEachSelection } from './board';
+import { BoardLike, forEachSelection, maybeSync } from './board';
 import type { StylePreset } from '../ui/style-presets';
 
 /** Resolved preset style attributes. */
@@ -40,8 +40,6 @@ export async function applyStylePreset(
     style.borderWidth = resolved.borderWidth;
     style.fillColor = resolved.fillColor;
     item.style = style;
-    if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-      await (item as { sync: () => Promise<void> }).sync();
-    }
+    await maybeSync(item as { sync?: () => Promise<void> });
   }, board);
 }

--- a/src/board/format-tools.ts
+++ b/src/board/format-tools.ts
@@ -1,5 +1,5 @@
 import { resolveColor } from '../core/utils/color-utils';
-import { BoardLike, forEachSelection, maybeSync } from './board';
+import { BoardLike, forEachSelection, maybeSync, Syncable } from './board';
 import type { StylePreset } from '../ui/style-presets';
 
 /** Resolved preset style attributes. */
@@ -40,6 +40,6 @@ export async function applyStylePreset(
     style.borderWidth = resolved.borderWidth;
     style.fillColor = resolved.fillColor;
     item.style = style;
-    await maybeSync(item as { sync?: () => Promise<void> });
+    await maybeSync(item as Syncable);
   }, board);
 }

--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -1,4 +1,4 @@
-import { BoardLike, getBoard } from './board';
+import { BoardLike, getBoard, maybeSync } from './board';
 
 /** Options for renaming selected frames. */
 export interface RenameOptions {
@@ -41,8 +41,7 @@ export async function renameSelectedFrames(
   await Promise.all(
     frames.map(async (frame, i) => {
       frame.title = `${opts.prefix}${i}`;
-      await ((frame as { sync?: () => Promise<void> }).sync?.call(frame) ??
-        Promise.resolve());
+      await maybeSync(frame as { sync?: () => Promise<void> });
     }),
   );
 }
@@ -85,7 +84,7 @@ function isFrame(item: Record<string, unknown>): item is FrameLike {
  */
 async function lockItem(item: LockableItem): Promise<void> {
   item.locked = true;
-  await item.sync?.();
+  await maybeSync(item);
 }
 
 /**

--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -1,4 +1,4 @@
-import { BoardLike, getBoard, maybeSync } from './board';
+import { BoardLike, getBoard, maybeSync, Syncable } from './board';
 
 /** Options for renaming selected frames. */
 export interface RenameOptions {
@@ -41,7 +41,7 @@ export async function renameSelectedFrames(
   await Promise.all(
     frames.map(async (frame, i) => {
       frame.title = `${opts.prefix}${i}`;
-      await maybeSync(frame as { sync?: () => Promise<void> });
+      await maybeSync(frame as Syncable);
     }),
   );
 }

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -23,7 +23,7 @@ export interface Position {
  * Minimal abstraction of the board API used for selection and grouping.
  * Allows injection of a mock implementation in tests.
  */
-import { BoardLike, getBoard } from './board';
+import { BoardLike, getBoard, maybeSync } from './board';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {
@@ -109,9 +109,7 @@ export async function applyGridLayout(
     items.map(async (item: Record<string, unknown>, i: number) => {
       item.x = first.x + positions[i].x;
       item.y = first.y + positions[i].y;
-      if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-        await (item as { sync: () => Promise<void> }).sync();
-      }
+      await maybeSync(item as { sync?: () => Promise<void> });
     }),
   );
   if (opts.groupResult && typeof b.group === 'function') {

--- a/src/board/grid-tools.ts
+++ b/src/board/grid-tools.ts
@@ -23,7 +23,7 @@ export interface Position {
  * Minimal abstraction of the board API used for selection and grouping.
  * Allows injection of a mock implementation in tests.
  */
-import { BoardLike, getBoard, maybeSync } from './board';
+import { BoardLike, getBoard, maybeSync, Syncable } from './board';
 
 /** Extract a name field from a widget for sorting purposes. */
 function getName(item: Record<string, unknown>): string {
@@ -109,7 +109,7 @@ export async function applyGridLayout(
     items.map(async (item: Record<string, unknown>, i: number) => {
       item.x = first.x + positions[i].x;
       item.y = first.y + positions[i].y;
-      await maybeSync(item as { sync?: () => Promise<void> });
+      await maybeSync(item as Syncable);
     }),
   );
   if (opts.groupResult && typeof b.group === 'function') {

--- a/src/board/resize-tools.ts
+++ b/src/board/resize-tools.ts
@@ -11,7 +11,7 @@ export interface Size {
   height: number;
 }
 
-import { BoardLike, forEachSelection, getBoard } from './board';
+import { BoardLike, forEachSelection, getBoard, maybeSync } from './board';
 
 /**
  * Retrieve the width and height of the first selected widget.
@@ -53,9 +53,7 @@ export async function applySizeToSelection(
     if (typeof item.width === 'number' && typeof item.height === 'number') {
       item.width = size.width;
       item.height = size.height;
-      if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-        await (item as { sync: () => Promise<void> }).sync();
-      }
+      await maybeSync(item as { sync?: () => Promise<void> });
     }
   }, board);
 }

--- a/src/board/resize-tools.ts
+++ b/src/board/resize-tools.ts
@@ -11,7 +11,13 @@ export interface Size {
   height: number;
 }
 
-import { BoardLike, forEachSelection, getBoard, maybeSync } from './board';
+import {
+  BoardLike,
+  forEachSelection,
+  getBoard,
+  maybeSync,
+  Syncable,
+} from './board';
 
 /**
  * Retrieve the width and height of the first selected widget.
@@ -53,7 +59,7 @@ export async function applySizeToSelection(
     if (typeof item.width === 'number' && typeof item.height === 'number') {
       item.width = size.width;
       item.height = size.height;
-      await maybeSync(item as { sync?: () => Promise<void> });
+      await maybeSync(item as Syncable);
     }
   }, board);
 }

--- a/src/board/search-tools.ts
+++ b/src/board/search-tools.ts
@@ -1,4 +1,9 @@
-import { getBoardWithQuery, BoardQueryLike, maybeSync } from './board';
+import {
+  getBoardWithQuery,
+  BoardQueryLike,
+  maybeSync,
+  Syncable,
+} from './board';
 
 /** Search configuration. */
 export interface SearchOptions {
@@ -217,7 +222,7 @@ export async function replaceBoardContent(
     });
     if (updated !== current) {
       setStringAtPath(item, field, updated);
-      await maybeSync(item as { sync?: () => Promise<void> });
+      await maybeSync(item as Syncable);
     }
   }
   return count;

--- a/src/board/search-tools.ts
+++ b/src/board/search-tools.ts
@@ -1,4 +1,4 @@
-import { getBoardWithQuery, BoardQueryLike } from './board';
+import { getBoardWithQuery, BoardQueryLike, maybeSync } from './board';
 
 /** Search configuration. */
 export interface SearchOptions {
@@ -217,8 +217,7 @@ export async function replaceBoardContent(
     });
     if (updated !== current) {
       setStringAtPath(item, field, updated);
-      await ((item as { sync?: () => Promise<void> }).sync?.call(item) ??
-        Promise.resolve());
+      await maybeSync(item as { sync?: () => Promise<void> });
     }
   }
   return count;

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -1,4 +1,4 @@
-import { BoardLike, getBoard } from './board';
+import { BoardLike, getBoard, maybeSync } from './board';
 
 /** Options for spacing layout. */
 export interface SpacingOptions {
@@ -76,7 +76,7 @@ export async function applySpacingLayout(
       items.map(async (item, i) => {
         item[sizeKey] = plan.size;
         item[axis] = plan.positions[i];
-        await item.sync?.();
+        await maybeSync(item);
       }),
     );
     return;
@@ -126,5 +126,5 @@ async function moveWidget(
   position: number,
 ): Promise<void> {
   item[axis] = position;
-  await item.sync?.();
+  await maybeSync(item);
 }

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -82,18 +82,12 @@ export async function applySpacingLayout(
     return;
   }
 
-  let position = (items[0] as Record<string, number>)[axis] ?? 0;
-  await moveWidget(
-    items[0] as Record<string, number> & Syncable,
-    axis,
-    position,
-  );
+  let position = items[0][axis] ?? 0;
+  await moveWidget(items[0], axis, position);
 
   for (let i = 1; i < items.length; i += 1) {
-    const prev = items[i - 1] as Record<string, number>;
-    const curr = items[i] as Record<string, number> & {
-      sync?: () => Promise<void>;
-    };
+    const prev = items[i - 1];
+    const curr = items[i];
     const prevSize = getDimension(prev, sizeKey);
     const currSize = getDimension(curr, sizeKey);
     position += prevSize / 2 + opts.spacing + currSize / 2;

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -1,4 +1,4 @@
-import { BoardLike, getBoard, maybeSync } from './board';
+import { BoardLike, getBoard, maybeSync, Syncable } from './board';
 
 /** Options for spacing layout. */
 export interface SpacingOptions {
@@ -68,7 +68,7 @@ export async function applySpacingLayout(
     (a, b) =>
       ((a as Record<string, number>)[axis] ?? 0) -
       ((b as Record<string, number>)[axis] ?? 0),
-  ) as Array<Record<string, number> & { sync?: () => Promise<void> }>;
+  ) as Array<Record<string, number> & Syncable>;
   const mode = opts.mode ?? 'move';
   if (mode === 'grow') {
     const plan = calculateGrowthPlan(items, axis, opts.spacing);
@@ -84,7 +84,7 @@ export async function applySpacingLayout(
 
   let position = (items[0] as Record<string, number>)[axis] ?? 0;
   await moveWidget(
-    items[0] as Record<string, number> & { sync?: () => Promise<void> },
+    items[0] as Record<string, number> & Syncable,
     axis,
     position,
   );
@@ -121,7 +121,7 @@ function getDimension(item: Record<string, number>, key: string): number {
  * @param position - New coordinate value.
  */
 async function moveWidget(
-  item: Record<string, number> & { sync?: () => Promise<void> },
+  item: Record<string, number> & Syncable,
   axis: 'x' | 'y',
   position: number,
 ): Promise<void> {

--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -8,7 +8,7 @@ import {
   ensureContrast,
   resolveColor,
 } from '../core/utils/color-utils';
-import { BoardLike, forEachSelection, getBoard } from './board';
+import { BoardLike, forEachSelection, getBoard, maybeSync } from './board';
 
 /** Retrieve the property name used for widget fill colour. */
 function getFillKey(
@@ -78,9 +78,7 @@ export async function tweakFillColor(
       style[fontKey] = ensureContrast(newFill, font);
     }
     item.style = style;
-    if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-      await (item as { sync: () => Promise<void> }).sync();
-    }
+    await maybeSync(item as { sync?: () => Promise<void> });
   }, board);
 }
 
@@ -138,9 +136,7 @@ export async function tweakOpacity(
     next = Math.max(0, Math.min(1, next));
     style[key] = next;
     item.style = style;
-    if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-      await (item as { sync: () => Promise<void> }).sync();
-    }
+    await maybeSync(item as { sync?: () => Promise<void> });
   }, board);
 }
 
@@ -166,8 +162,6 @@ export async function tweakBorderWidth(
     const next = Math.max(0, current + delta);
     style[key] = next;
     item.style = style;
-    if (typeof (item as { sync?: () => Promise<void> }).sync === 'function') {
-      await (item as { sync: () => Promise<void> }).sync();
-    }
+    await maybeSync(item as { sync?: () => Promise<void> });
   }, board);
 }

--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -8,7 +8,13 @@ import {
   ensureContrast,
   resolveColor,
 } from '../core/utils/color-utils';
-import { BoardLike, forEachSelection, getBoard, maybeSync } from './board';
+import {
+  BoardLike,
+  forEachSelection,
+  getBoard,
+  maybeSync,
+  Syncable,
+} from './board';
 
 /** Retrieve the property name used for widget fill colour. */
 function getFillKey(
@@ -78,7 +84,7 @@ export async function tweakFillColor(
       style[fontKey] = ensureContrast(newFill, font);
     }
     item.style = style;
-    await maybeSync(item as { sync?: () => Promise<void> });
+    await maybeSync(item as Syncable);
   }, board);
 }
 
@@ -136,7 +142,7 @@ export async function tweakOpacity(
     next = Math.max(0, Math.min(1, next));
     style[key] = next;
     item.style = style;
-    await maybeSync(item as { sync?: () => Promise<void> });
+    await maybeSync(item as Syncable);
   }, board);
 }
 
@@ -162,6 +168,6 @@ export async function tweakBorderWidth(
     const next = Math.max(0, current + delta);
     style[key] = next;
     item.style = style;
-    await maybeSync(item as { sync?: () => Promise<void> });
+    await maybeSync(item as Syncable);
   }, board);
 }

--- a/src/ui/pages/ResizeTab.tsx
+++ b/src/ui/pages/ResizeTab.tsx
@@ -27,6 +27,13 @@ import {
   AspectRatioId,
 } from '../../core/utils/aspect-ratio';
 
+/** Predefined button sizes used by the quick presets. */
+const PRESET_SIZES: Record<'S' | 'M' | 'L', Size> = {
+  S: { width: 100, height: 100 },
+  M: { width: 200, height: 150 },
+  L: { width: 400, height: 300 },
+};
+
 /** UI for the Resize tab. */
 export const ResizeTab: React.FC = () => {
   const selection = useSelection();
@@ -147,18 +154,10 @@ export const ResizeTab: React.FC = () => {
         </Select>
       </InputField>
       <div>
-        {['S', 'M', 'L'].map((p) => (
+        {(['S', 'M', 'L'] as const).map((p) => (
           <Button
             key={p}
-            onClick={() =>
-              setSize(
-                p === 'S'
-                  ? { width: 100, height: 100 }
-                  : p === 'M'
-                    ? { width: 200, height: 150 }
-                    : { width: 400, height: 300 },
-              )
-            }
+            onClick={() => setSize(PRESET_SIZES[p])}
             variant='secondary'>
             {p}
           </Button>

--- a/tests/board-utils.test.ts
+++ b/tests/board-utils.test.ts
@@ -1,4 +1,4 @@
-import { forEachSelection } from '../src/board/board';
+import { forEachSelection, maybeSync } from '../src/board/board';
 
 describe('forEachSelection', () => {
   describe('callback invocation', () => {
@@ -22,5 +22,17 @@ describe('forEachSelection', () => {
         }, board),
       ).rejects.toThrow('fail');
     });
+  });
+});
+
+describe('maybeSync', () => {
+  test('invokes sync when present', async () => {
+    const item = { sync: jest.fn() };
+    await maybeSync(item);
+    expect(item.sync).toHaveBeenCalled();
+  });
+
+  test('resolves when sync missing', async () => {
+    await expect(maybeSync({})).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add `maybeSync` helper for optional sync calls
- use `maybeSync` across board utilities
- test `maybeSync` behaviour

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860cb339c38832bac627bfdefb6a223