### PR TITLE
Consolidate layout helpers

### DIFF
--- a/src/board/frame-utils.ts
+++ b/src/board/frame-utils.ts
@@ -1,0 +1,35 @@
+import type { BaseItem, Connector, Frame, Group } from '@mirohq/websdk-types';
+import { BoardBuilder } from './board-builder';
+
+/**
+ * Conditionally create a frame and register it for undo handling.
+ *
+ * When {@link useFrame} is `false` no frame is created and the builder
+ * clears its active frame reference.
+ *
+ * @param builder - Board builder instance used to create frames.
+ * @param registry - Collection tracking created widgets for undo.
+ * @param useFrame - Whether to create a frame.
+ * @param width - Frame width.
+ * @param height - Frame height.
+ * @param spot - Location where the frame should be centred.
+ * @param title - Optional frame title.
+ * @returns The created frame or `undefined`.
+ */
+export async function maybeCreateFrame(
+  builder: BoardBuilder,
+  registry: Array<BaseItem | Group | Connector | Frame>,
+  useFrame: boolean,
+  width: number,
+  height: number,
+  spot: { x: number; y: number },
+  title?: string,
+): Promise<Frame | undefined> {
+  if (!useFrame) {
+    builder.setFrame(undefined);
+    return undefined;
+  }
+  const frame = await builder.createFrame(width, height, spot.x, spot.y, title);
+  registry.push(frame);
+  return frame;
+}

--- a/src/board/undo-utils.ts
+++ b/src/board/undo-utils.ts
@@ -1,0 +1,43 @@
+import type { BaseItem, Connector, Frame, Group } from '@mirohq/websdk-types';
+import { BoardBuilder } from './board-builder';
+
+/**
+ * Remove widgets tracked in the registry and clear the list.
+ *
+ * @param builder - Board builder used to remove items.
+ * @param registry - Collection of widgets created in the last run.
+ */
+export async function undoWidgets(
+  builder: BoardBuilder,
+  registry: Array<BaseItem | Group | Connector | Frame>,
+): Promise<void> {
+  if (registry.length) {
+    const items = registry.slice();
+    await builder.removeItems(items);
+    registry.length = 0;
+  }
+}
+
+/**
+ * Sync widgets and roll back on failure.
+ *
+ * Delegates to {@link BoardBuilder.syncAll} but removes any created widgets
+ * via {@link undoWidgets} when an error occurs. This guarantees that partial
+ * updates do not remain on the board if syncing fails midway.
+ *
+ * @param builder - Board builder instance used for syncing and removal.
+ * @param registry - Collection of widgets created during the current run.
+ * @param items - Widgets that should be synced to the board.
+ */
+export async function syncOrUndo(
+  builder: BoardBuilder,
+  registry: Array<BaseItem | Group | Connector | Frame>,
+  items: Array<BaseItem | Group | Connector>,
+): Promise<void> {
+  try {
+    await builder.syncAll(items);
+  } catch (err) {
+    await undoWidgets(builder, registry);
+    throw err;
+  }
+}

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -1,5 +1,8 @@
 import { BoardBuilder } from '../../board/board-builder';
+import { maybeCreateFrame } from '../../board/frame-utils';
+import { undoWidgets, syncOrUndo } from '../../board/undo-utils';
 import { fileUtils } from '../utils/file-utils';
+import { boundingBox, frameOffset } from '../layout/layout-utils';
 import {
   HierNode,
   layoutHierarchy,
@@ -75,9 +78,16 @@ export class HierarchyProcessor {
     const width = bounds.maxX - bounds.minX + margin * 2;
     const height = bounds.maxY - bounds.minY + margin * 2;
     const spot = await this.builder.findSpace(width, height);
-    const offsetX = spot.x - width / 2 + margin - bounds.minX;
-    const offsetY = spot.y - height / 2 + margin - bounds.minY;
-    const frame = await this.createFrame(
+    const { offsetX, offsetY } = frameOffset(
+      spot,
+      width,
+      height,
+      { minX: bounds.minX, minY: bounds.minY },
+      margin,
+    );
+    const frame = await maybeCreateFrame(
+      this.builder,
+      this.lastCreated,
       opts.createFrame !== false,
       width,
       height,
@@ -85,7 +95,8 @@ export class HierarchyProcessor {
       opts.frameTitle,
     );
     await this.createWidgets(data, result.nodes, offsetX, offsetY);
-    await this.builder.syncAll(this.lastCreated.filter((i) => i !== frame));
+    const syncItems = this.lastCreated.filter((i) => i !== frame);
+    await syncOrUndo(this.builder, this.lastCreated, syncItems);
     const target = frame
       ? frame
       : (this.lastCreated as Array<BaseItem | Group>);
@@ -96,45 +107,12 @@ export class HierarchyProcessor {
    * Determine the overall bounding box of a layout result.
    */
   private computeBounds(result: NestedLayoutResult) {
-    let minX = Infinity,
-      minY = Infinity,
-      maxX = -Infinity,
-      maxY = -Infinity;
-    Object.values(result.nodes).forEach(({ x, y, width, height }) => {
-      const halfW = width / 2;
-      const halfH = height / 2;
-      minX = Math.min(minX, x - halfW);
-      minY = Math.min(minY, y - halfH);
-      maxX = Math.max(maxX, x + halfW);
-      maxY = Math.max(maxY, y + halfH);
-    });
-    return { minX, minY, maxX, maxY };
+    return boundingBox(result.nodes, true);
   }
 
   /**
    * Optionally create a frame around the entire hierarchy.
    */
-  private async createFrame(
-    useFrame: boolean,
-    width: number,
-    height: number,
-    spot: { x: number; y: number },
-    title?: string,
-  ): Promise<Frame | undefined> {
-    if (!useFrame) {
-      this.builder.setFrame(undefined);
-      return undefined;
-    }
-    const frame = await this.builder.createFrame(
-      width,
-      height,
-      spot.x,
-      spot.y,
-      title,
-    );
-    this.lastCreated.push(frame);
-    return frame;
-  }
 
   /**
    * Recursively create widgets for a node and its children.
@@ -208,10 +186,7 @@ export class HierarchyProcessor {
    * Remove widgets created in the last run from the board.
    */
   public async undoLast(): Promise<void> {
-    if (this.lastCreated.length) {
-      await this.builder.removeItems(this.lastCreated);
-      this.lastCreated = [];
-    }
+    await undoWidgets(this.builder, this.lastCreated);
   }
 }
 

--- a/src/core/layout/layout-utils.ts
+++ b/src/core/layout/layout-utils.ts
@@ -48,3 +48,64 @@ export function computeEdgeHints(
     };
   });
 }
+
+/**
+ * Determine the bounding box of a set of positioned nodes.
+ *
+ * Coordinates may represent either the node center or top-left corner.
+ *
+ * @param nodes - Mapping of node ids to their absolute positions.
+ * @param centerBased - Treat `x`/`y` as the node center when `true`.
+ * @returns The bounding box enclosing all nodes.
+ */
+export function boundingBox(
+  nodes: Record<
+    string,
+    { x: number; y: number; width: number; height: number }
+  >,
+  centerBased = false,
+): { minX: number; minY: number; maxX: number; maxY: number } {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  Object.values(nodes).forEach(({ x, y, width, height }) => {
+    if (centerBased) {
+      const halfW = width / 2;
+      const halfH = height / 2;
+      minX = Math.min(minX, x - halfW);
+      minY = Math.min(minY, y - halfH);
+      maxX = Math.max(maxX, x + halfW);
+      maxY = Math.max(maxY, y + halfH);
+    } else {
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + width);
+      maxY = Math.max(maxY, y + height);
+    }
+  });
+  return { minX, minY, maxX, maxY };
+}
+
+/**
+ * Calculate offsets for placing nodes within a frame at a given spot.
+ *
+ * @param spot - Location of the frame centre.
+ * @param frameWidth - Total frame width including margin.
+ * @param frameHeight - Total frame height including margin.
+ * @param bounds - Bounding box of the nodes.
+ * @param margin - Margin applied around the nodes.
+ * @returns Offsets to apply to node coordinates.
+ */
+export function frameOffset(
+  spot: { x: number; y: number },
+  frameWidth: number,
+  frameHeight: number,
+  bounds: { minX: number; minY: number },
+  margin: number,
+): { offsetX: number; offsetY: number } {
+  return {
+    offsetX: spot.x - frameWidth / 2 + margin - bounds.minX,
+    offsetY: spot.y - frameHeight / 2 + margin - bounds.minY,
+  };
+}

--- a/tests/card-processor.test.ts
+++ b/tests/card-processor.test.ts
@@ -285,41 +285,4 @@ describe('CardProcessor', () => {
     ).computeStartCoordinate(200, 400, 100);
     expect(result).toBe(200 - 400 / 2 + margin + 100 / 2);
   });
-
-  test('maybeCreateFrame creates frame when enabled', async () => {
-    const builder = {
-      createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
-      setFrame: jest.fn(),
-    } as { createFrame: jest.Mock; setFrame: jest.Mock };
-    const p = new CardProcessor(builder as unknown as unknown);
-    const dims = { width: 10, height: 20, spot: { x: 1, y: 2 } };
-    const frame = await (
-      p as unknown as {
-        maybeCreateFrame: (
-          b: boolean,
-          d: unknown,
-          t?: string,
-        ) => Promise<unknown>;
-      }
-    ).maybeCreateFrame(true, dims, 't');
-    expect(builder.createFrame).toHaveBeenCalledWith(10, 20, 1, 2, 't');
-    expect(frame).toEqual({ id: 'f' });
-  });
-
-  test('maybeCreateFrame skips frame when disabled', async () => {
-    const builder = { createFrame: jest.fn(), setFrame: jest.fn() } as {
-      createFrame: jest.Mock;
-      setFrame: jest.Mock;
-    };
-    const p = new CardProcessor(builder as unknown as unknown);
-    const dims = { width: 5, height: 5, spot: { x: 0, y: 0 } };
-    const frame = await (
-      p as unknown as {
-        maybeCreateFrame: (b: boolean, d: unknown) => Promise<unknown>;
-      }
-    ).maybeCreateFrame(false, dims);
-    expect(frame).toBeUndefined();
-    expect(builder.createFrame).not.toHaveBeenCalled();
-    expect(builder.setFrame).toHaveBeenCalledWith(undefined);
-  });
 });

--- a/tests/frame-utils.test.ts
+++ b/tests/frame-utils.test.ts
@@ -1,0 +1,40 @@
+import { maybeCreateFrame } from '../src/board/frame-utils';
+import type { Frame } from '@mirohq/websdk-types';
+import { BoardBuilder } from '../src/board/board-builder';
+
+describe('maybeCreateFrame', () => {
+  test('creates frame when enabled', async () => {
+    const builder = {
+      createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
+      setFrame: jest.fn(),
+    } as unknown as BoardBuilder;
+    const list: Array<Frame> = [] as unknown as Array<Frame>;
+    const frame = await maybeCreateFrame(
+      builder,
+      list,
+      true,
+      10,
+      20,
+      { x: 1, y: 2 },
+      't',
+    );
+    expect(builder.createFrame).toHaveBeenCalledWith(10, 20, 1, 2, 't');
+    expect(frame).toEqual({ id: 'f' });
+    expect(list).toContain(frame);
+  });
+
+  test('skips frame when disabled', async () => {
+    const builder = {
+      createFrame: jest.fn(),
+      setFrame: jest.fn(),
+    } as unknown as BoardBuilder;
+    const list: Array<Frame> = [] as unknown as Array<Frame>;
+    const frame = await maybeCreateFrame(builder, list, false, 5, 5, {
+      x: 0,
+      y: 0,
+    });
+    expect(frame).toBeUndefined();
+    expect(builder.createFrame).not.toHaveBeenCalled();
+    expect(builder.setFrame).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/tests/layout-utils.test.ts
+++ b/tests/layout-utils.test.ts
@@ -1,6 +1,8 @@
 import {
   computeEdgeHints,
   relativePosition,
+  boundingBox,
+  frameOffset,
 } from '../src/core/layout/layout-utils';
 
 describe('layout-utils', () => {
@@ -26,5 +28,27 @@ describe('layout-utils', () => {
       startPosition: { x: 0.1, y: 0.2 },
       endPosition: { x: 0.5, y: 0.8 },
     });
+  });
+
+  test('boundingBox handles center coordinates', () => {
+    const box = boundingBox(
+      {
+        a: { x: 5, y: 5, width: 10, height: 10 },
+        b: { x: 15, y: 15, width: 10, height: 10 },
+      },
+      true,
+    );
+    expect(box).toEqual({ minX: 0, minY: 0, maxX: 20, maxY: 20 });
+  });
+
+  test('frameOffset computes relative translation', () => {
+    const off = frameOffset(
+      { x: 50, y: 50 },
+      20,
+      20,
+      { minX: 10, minY: 10 },
+      5,
+    );
+    expect(off).toEqual({ offsetX: 35, offsetY: 35 });
   });
 });

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -2,6 +2,7 @@ import { GraphProcessor } from '../src/core/graph/graph-processor';
 import { graphService } from '../src/core/graph';
 import { templateManager } from '../src/board/templates';
 import { layoutEngine } from '../src/core/layout/elk-layout';
+import * as frameUtils from '../src/board/frame-utils';
 import sample from './fixtures/sample-graph.json';
 
 interface GlobalWithMiro {
@@ -89,7 +90,9 @@ describe('GraphProcessor', () => {
 
   it('delegates work to helper methods', async () => {
     const gp = new GraphProcessor();
-    const frameSpy = jest.spyOn(gp as unknown, 'createFrame');
+    const frameSpy = jest
+      .spyOn(frameUtils, 'maybeCreateFrame')
+      .mockResolvedValue(undefined);
     const nodeSpy = jest.spyOn(gp as unknown, 'createNodes');
     const connectorSpy = jest.spyOn(gp as unknown, 'createConnectorsAndZoom');
 

--- a/tests/undo-utils.test.ts
+++ b/tests/undo-utils.test.ts
@@ -1,0 +1,48 @@
+import { undoWidgets, syncOrUndo } from '../src/board/undo-utils';
+import { BoardBuilder } from '../src/board/board-builder';
+import type { Frame } from '@mirohq/websdk-types';
+
+describe('undoWidgets', () => {
+  test('removes items when registry populated', async () => {
+    const builder = { removeItems: jest.fn() } as unknown as BoardBuilder;
+    const list: Array<Frame> = [{} as Frame];
+    const orig = [...list];
+    await undoWidgets(builder, list);
+    const callArg = (builder.removeItems as jest.Mock).mock.calls[0][0];
+    expect(callArg).toEqual(orig);
+    expect(list.length).toBe(0);
+  });
+
+  test('skips removal when registry empty', async () => {
+    const builder = { removeItems: jest.fn() } as unknown as BoardBuilder;
+    const list: Array<Frame> = [];
+    await undoWidgets(builder, list);
+    expect(builder.removeItems).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncOrUndo', () => {
+  test('rolls back when sync fails', async () => {
+    const builder = {
+      syncAll: jest.fn().mockRejectedValue(new Error('fail')),
+      removeItems: jest.fn(),
+    } as unknown as BoardBuilder;
+    const reg: Array<Frame> = [{} as Frame];
+    await expect(
+      syncOrUndo(builder, reg, [reg[0] as unknown as Frame]),
+    ).rejects.toThrow('fail');
+    expect(builder.removeItems).toHaveBeenCalled();
+    expect(reg).toHaveLength(0);
+  });
+
+  test('leaves items intact when sync succeeds', async () => {
+    const builder = {
+      syncAll: jest.fn(),
+      removeItems: jest.fn(),
+    } as unknown as BoardBuilder;
+    const reg: Array<Frame> = [{} as Frame];
+    await syncOrUndo(builder, reg, [reg[0] as unknown as Frame]);
+    expect(builder.removeItems).not.toHaveBeenCalled();
+    expect(reg).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- share bounding box and offset calculations across processors
- refactor `GraphProcessor` and `HierarchyProcessor` to use shared helpers
- cover new helpers with unit tests
- centralise undo logic in a reusable helper
- roll back widget creations when sync fails

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860de4c3d68832b9519ce9093804cba