### PR TITLE
Fix boolean selector params

### DIFF
--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -27,6 +27,8 @@ This project enforces consistent formatting with
 - Document exported functions with TSDoc comments.
 - Import order follows standard → vendor → local, alphabetically within each
   group.
+- Avoid boolean selector parameters. Use separate functions or enums to
+  communicate intent.
 
 ## Lint guidelines
 

--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -1,5 +1,5 @@
 import { BoardBuilder } from './board-builder';
-import { maybeCreateFrame } from './frame-utils';
+import { clearActiveFrame, registerFrame } from './frame-utils';
 import { undoWidgets, syncOrUndo } from './undo-utils';
 import { CardData, cardLoader } from '../core/utils/cards';
 import type { Card, CardStyle, Frame, Tag } from '@mirohq/websdk-types';
@@ -82,15 +82,18 @@ export class CardProcessor {
       const { spot, startX, startY, columns, totalWidth, totalHeight } =
         await this.calculateLayoutArea(toCreate.length, options.columns);
 
-      frame = await maybeCreateFrame(
-        this.builder,
-        this.lastCreated,
-        options.createFrame !== false,
-        totalWidth,
-        totalHeight,
-        spot,
-        options.frameTitle,
-      );
+      if (options.createFrame !== false) {
+        frame = await registerFrame(
+          this.builder,
+          this.lastCreated,
+          totalWidth,
+          totalHeight,
+          spot,
+          options.frameTitle,
+        );
+      } else {
+        clearActiveFrame(this.builder);
+      }
 
       created = await Promise.all(
         toCreate.map((def, i) =>
@@ -108,7 +111,7 @@ export class CardProcessor {
       );
       created.forEach((c) => frame?.add(c));
     } else {
-      this.builder.setFrame(undefined);
+      clearActiveFrame(this.builder);
     }
 
     await syncOrUndo(this.builder, this.lastCreated, [...created, ...updated]);

--- a/src/board/frame-utils.ts
+++ b/src/board/frame-utils.ts
@@ -2,34 +2,34 @@ import type { BaseItem, Connector, Frame, Group } from '@mirohq/websdk-types';
 import { BoardBuilder } from './board-builder';
 
 /**
- * Conditionally create a frame and register it for undo handling.
- *
- * When {@link useFrame} is `false` no frame is created and the builder
- * clears its active frame reference.
+ * Create a frame and register it for undo handling.
  *
  * @param builder - Board builder instance used to create frames.
  * @param registry - Collection tracking created widgets for undo.
- * @param useFrame - Whether to create a frame.
  * @param width - Frame width.
  * @param height - Frame height.
  * @param spot - Location where the frame should be centred.
  * @param title - Optional frame title.
- * @returns The created frame or `undefined`.
+ * @returns The created frame.
  */
-export async function maybeCreateFrame(
+export async function registerFrame(
   builder: BoardBuilder,
   registry: Array<BaseItem | Group | Connector | Frame>,
-  useFrame: boolean,
   width: number,
   height: number,
   spot: { x: number; y: number },
   title?: string,
-): Promise<Frame | undefined> {
-  if (!useFrame) {
-    builder.setFrame(undefined);
-    return undefined;
-  }
+): Promise<Frame> {
   const frame = await builder.createFrame(width, height, spot.x, spot.y, title);
   registry.push(frame);
   return frame;
+}
+
+/**
+ * Clear the active frame on the builder when no frame should be created.
+ *
+ * @param builder - Board builder instance whose frame is cleared.
+ */
+export function clearActiveFrame(builder: BoardBuilder): void {
+  builder.setFrame(undefined);
 }

--- a/src/core/graph/graph-processor.ts
+++ b/src/core/graph/graph-processor.ts
@@ -4,7 +4,7 @@ import { isNestedAlgorithm } from './layout-modes';
 import { HierarchyProcessor } from './hierarchy-processor';
 import type { HierNode } from '../layout/nested-layout';
 import { BoardBuilder } from '../../board/board-builder';
-import { maybeCreateFrame } from '../../board/frame-utils';
+import { clearActiveFrame, registerFrame } from '../../board/frame-utils';
 import { undoWidgets, syncOrUndo } from '../../board/undo-utils';
 import { layoutEngine, LayoutResult } from '../layout/elk-layout';
 import { UserLayoutOptions } from '../layout/elk-options';
@@ -77,16 +77,19 @@ export class GraphProcessor {
     const frameHeight = bounds.maxY - bounds.minY + margin * 2;
     const spot = await this.builder.findSpace(frameWidth, frameHeight);
 
-    const useFrame = options.createFrame !== false;
-    const frame = await maybeCreateFrame(
-      this.builder,
-      this.lastCreated,
-      useFrame,
-      frameWidth,
-      frameHeight,
-      spot,
-      options.frameTitle,
-    );
+    let frame: Frame | undefined;
+    if (options.createFrame !== false) {
+      frame = await registerFrame(
+        this.builder,
+        this.lastCreated,
+        frameWidth,
+        frameHeight,
+        spot,
+        options.frameTitle,
+      );
+    } else {
+      clearActiveFrame(this.builder);
+    }
 
     const { offsetX, offsetY } = this.calculateOffset(
       spot,

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -1,5 +1,5 @@
 import { BoardBuilder } from '../../board/board-builder';
-import { maybeCreateFrame } from '../../board/frame-utils';
+import { clearActiveFrame, registerFrame } from '../../board/frame-utils';
 import { undoWidgets, syncOrUndo } from '../../board/undo-utils';
 import { fileUtils } from '../utils/file-utils';
 import { boundingBox, frameOffset } from '../layout/layout-utils';
@@ -85,15 +85,19 @@ export class HierarchyProcessor {
       { minX: bounds.minX, minY: bounds.minY },
       margin,
     );
-    const frame = await maybeCreateFrame(
-      this.builder,
-      this.lastCreated,
-      opts.createFrame !== false,
-      width,
-      height,
-      spot,
-      opts.frameTitle,
-    );
+    let frame: Frame | undefined;
+    if (opts.createFrame !== false) {
+      frame = await registerFrame(
+        this.builder,
+        this.lastCreated,
+        width,
+        height,
+        spot,
+        opts.frameTitle,
+      );
+    } else {
+      clearActiveFrame(this.builder);
+    }
     await this.createWidgets(data, result.nodes, offsetX, offsetY);
     const syncItems = this.lastCreated.filter((i) => i !== frame);
     await syncOrUndo(this.builder, this.lastCreated, syncItems);

--- a/src/ui/hooks/ui-utils.ts
+++ b/src/ui/hooks/ui-utils.ts
@@ -30,15 +30,14 @@ export async function undoLastImport(
  * Compute the inline style for the dropzone element.
  * The border colour changes based on drag-and-drop state.
  */
-export function getDropzoneStyle(
-  accept: boolean,
-  reject: boolean,
-): React.CSSProperties {
+export type DropzoneState = 'base' | 'accept' | 'reject';
+
+export function getDropzoneStyle(state: DropzoneState): React.CSSProperties {
   let borderColor: string = tokens.color.indigoAlpha[40];
-  if (accept) {
+  if (state === 'accept') {
     borderColor = tokens.color.green[700];
   }
-  if (reject) {
+  if (state === 'reject') {
     borderColor = tokens.color.red[700];
   }
   return { ...dropzoneStyles, borderColor };

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -70,10 +70,14 @@ export const CardsTab: React.FC = () => {
     setFiles([]);
   };
 
-  const style = React.useMemo(
-    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
-    [dropzone.isDragAccept, dropzone.isDragReject],
-  );
+  const style = React.useMemo(() => {
+    const state = dropzone.isDragReject
+      ? 'reject'
+      : dropzone.isDragAccept
+        ? 'accept'
+        : 'base';
+    return getDropzoneStyle(state);
+  }, [dropzone.isDragAccept, dropzone.isDragReject]);
 
   return (
     <div style={{ marginTop: tokens.space.small }}>

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -152,10 +152,14 @@ export const DiagramTab: React.FC = () => {
     setImportQueue([]);
   };
 
-  const style = React.useMemo(
-    () => getDropzoneStyle(dropzone.isDragAccept, dropzone.isDragReject),
-    [dropzone.isDragAccept, dropzone.isDragReject],
-  );
+  const style = React.useMemo(() => {
+    const state = dropzone.isDragReject
+      ? 'reject'
+      : dropzone.isDragAccept
+        ? 'accept'
+        : 'base';
+    return getDropzoneStyle(state);
+  }, [dropzone.isDragAccept, dropzone.isDragReject]);
 
   return (
     <div style={{ marginTop: tokens.space.small }}>

--- a/tests/app-ui.test.ts
+++ b/tests/app-ui.test.ts
@@ -145,11 +145,11 @@ describe('App UI integration', () => {
   });
 
   test('getDropzoneStyle computes colours', () => {
-    const base = getDropzoneStyle(false, false);
+    const base = getDropzoneStyle('base');
     expect(base.borderColor).toBe(tokens.color.indigoAlpha[40]);
-    const accept = getDropzoneStyle(true, false);
+    const accept = getDropzoneStyle('accept');
     expect(accept.borderColor).toBe(tokens.color.green[700]);
-    const reject = getDropzoneStyle(false, true);
+    const reject = getDropzoneStyle('reject');
     expect(reject.borderColor).toBe(tokens.color.red[700]);
   });
 });

--- a/tests/frame-utils.test.ts
+++ b/tests/frame-utils.test.ts
@@ -1,18 +1,17 @@
-import { maybeCreateFrame } from '../src/board/frame-utils';
+import { registerFrame, clearActiveFrame } from '../src/board/frame-utils';
 import type { Frame } from '@mirohq/websdk-types';
 import { BoardBuilder } from '../src/board/board-builder';
 
-describe('maybeCreateFrame', () => {
-  test('creates frame when enabled', async () => {
+describe('frame-utils', () => {
+  test('registerFrame creates frame and records it', async () => {
     const builder = {
       createFrame: jest.fn().mockResolvedValue({ id: 'f' }),
       setFrame: jest.fn(),
     } as unknown as BoardBuilder;
     const list: Array<Frame> = [] as unknown as Array<Frame>;
-    const frame = await maybeCreateFrame(
+    const frame = await registerFrame(
       builder,
       list,
-      true,
       10,
       20,
       { x: 1, y: 2 },
@@ -23,18 +22,9 @@ describe('maybeCreateFrame', () => {
     expect(list).toContain(frame);
   });
 
-  test('skips frame when disabled', async () => {
-    const builder = {
-      createFrame: jest.fn(),
-      setFrame: jest.fn(),
-    } as unknown as BoardBuilder;
-    const list: Array<Frame> = [] as unknown as Array<Frame>;
-    const frame = await maybeCreateFrame(builder, list, false, 5, 5, {
-      x: 0,
-      y: 0,
-    });
-    expect(frame).toBeUndefined();
-    expect(builder.createFrame).not.toHaveBeenCalled();
+  test('clearActiveFrame resets builder state', () => {
+    const builder = { setFrame: jest.fn() } as unknown as BoardBuilder;
+    clearActiveFrame(builder);
     expect(builder.setFrame).toHaveBeenCalledWith(undefined);
   });
 });

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -3,6 +3,7 @@ import { graphService } from '../src/core/graph';
 import { templateManager } from '../src/board/templates';
 import { layoutEngine } from '../src/core/layout/elk-layout';
 import * as frameUtils from '../src/board/frame-utils';
+import type { Frame } from '@mirohq/websdk-types';
 import sample from './fixtures/sample-graph.json';
 
 interface GlobalWithMiro {
@@ -91,8 +92,9 @@ describe('GraphProcessor', () => {
   it('delegates work to helper methods', async () => {
     const gp = new GraphProcessor();
     const frameSpy = jest
-      .spyOn(frameUtils, 'maybeCreateFrame')
-      .mockResolvedValue(undefined);
+      .spyOn(frameUtils, 'registerFrame')
+      .mockResolvedValue(undefined as unknown as Frame);
+    jest.spyOn(frameUtils, 'clearActiveFrame').mockImplementation(() => {});
     const nodeSpy = jest.spyOn(gp as unknown, 'createNodes');
     const connectorSpy = jest.spyOn(gp as unknown, 'createConnectorsAndZoom');
 


### PR DESCRIPTION
## Summary
- clarify style guide to avoid boolean selectors
- add clearActiveFrame and registerFrame helpers
- replace maybeCreateFrame usage
- improve dropzone state handling
- update tests for new helpers

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860e933b208832bbdb634dd16eb7db3