### PR TITLE
Refactor tabs with JsonDropZone

### DIFF
--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useDropzone } from 'react-dropzone';
+import { Button, Icon, InputField, Paragraph, Text } from './legacy';
+import { getDropzoneStyle } from '../hooks/ui-utils';
+import { tokens } from '../tokens';
+
+export interface JsonDropZoneProps {
+  /** Callback invoked with selected files. */
+  onFiles: (files: File[]) => void;
+}
+
+/** Dropzone for importing JSON files. */
+export function JsonDropZone({
+  onFiles,
+}: JsonDropZoneProps): React.JSX.Element {
+  const dropzone = useDropzone({
+    accept: { 'application/json': ['.json'] },
+    maxFiles: 1,
+    onDrop: onFiles,
+  });
+
+  const style = React.useMemo(() => {
+    const state = dropzone.isDragReject
+      ? 'reject'
+      : dropzone.isDragAccept
+        ? 'accept'
+        : 'base';
+    return getDropzoneStyle(state);
+  }, [dropzone.isDragAccept, dropzone.isDragReject]);
+
+  return (
+    <>
+      <div
+        {...dropzone.getRootProps({ style })}
+        aria-label='File drop area'
+        aria-describedby='dropzone-instructions'>
+        <InputField label='JSON file'>
+          <input
+            data-testid='file-input'
+            {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
+          />
+        </InputField>
+        {dropzone.isDragAccept ? (
+          <Paragraph className='dnd-text'>Drop your JSON file here</Paragraph>
+        ) : (
+          <div style={{ padding: tokens.space.small }}>
+            <Button variant='primary'>
+              <Icon name='upload' />
+              <Text>Select JSON file</Text>
+            </Button>
+            <Paragraph className='dnd-text'>
+              Or drop your JSON file here
+            </Paragraph>
+          </div>
+        )}
+      </div>
+      <Paragraph
+        id='dropzone-instructions'
+        className='custom-visually-hidden'>
+        Press Enter to open the file picker or drop a JSON file on the area
+        above.
+      </Paragraph>
+    </>
+  );
+}

--- a/src/ui/pages/CardsTab.tsx
+++ b/src/ui/pages/CardsTab.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDropzone } from 'react-dropzone';
 import {
   Button,
   Checkbox,
@@ -8,11 +7,12 @@ import {
   Text,
   Icon,
 } from '../components/legacy';
+import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
 import { CardProcessor } from '../../board/card-processor';
 
 import { showError } from '../hooks/notifications';
-import { getDropzoneStyle, undoLastImport } from '../hooks/ui-utils';
+import { undoLastImport } from '../hooks/ui-utils';
 
 /** UI for the Cards tab. */
 export const CardsTab: React.FC = () => {
@@ -37,14 +37,10 @@ export const CardsTab: React.FC = () => {
     return () => window.removeEventListener('keydown', handler);
   }, [lastProc]);
 
-  const dropzone = useDropzone({
-    accept: { 'application/json': ['.json'] },
-    maxFiles: 1,
-    onDrop: (droppedFiles: File[]): void => {
-      const file = droppedFiles[0];
-      setFiles([file]);
-    },
-  });
+  const handleFiles = (droppedFiles: File[]): void => {
+    const file = droppedFiles[0];
+    setFiles([file]);
+  };
 
   const cardProcessor = React.useMemo(() => new CardProcessor(), []);
 
@@ -70,51 +66,9 @@ export const CardsTab: React.FC = () => {
     setFiles([]);
   };
 
-  const style = React.useMemo(() => {
-    const state = dropzone.isDragReject
-      ? 'reject'
-      : dropzone.isDragAccept
-        ? 'accept'
-        : 'base';
-    return getDropzoneStyle(state);
-  }, [dropzone.isDragAccept, dropzone.isDragReject]);
-
   return (
     <div style={{ marginTop: tokens.space.small }}>
-      <div
-        {...dropzone.getRootProps({ style })}
-        aria-label='File drop area'
-        aria-describedby='dropzone-instructions'>
-        <InputField label='JSON file'>
-          <input
-            data-testid='file-input'
-            {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
-          />
-        </InputField>
-        {dropzone.isDragAccept ? (
-          <Paragraph className='dnd-text'>Drop your JSON file here</Paragraph>
-        ) : (
-          <>
-            <div style={{ padding: tokens.space.small }}>
-              <Button variant='primary'>
-                <React.Fragment key='.0'>
-                  <Icon name='upload' />
-                  <Text>Select JSON file</Text>
-                </React.Fragment>
-              </Button>
-              <Paragraph className='dnd-text'>
-                Or drop your JSON file here
-              </Paragraph>
-            </div>
-          </>
-        )}
-      </div>
-      <Paragraph
-        id='dropzone-instructions'
-        className='custom-visually-hidden'>
-        Press Enter to open the file picker or drop a JSON file on the area
-        above.
-      </Paragraph>
+      <JsonDropZone onFiles={handleFiles} />
 
       {files.length > 0 && (
         <>

--- a/src/ui/pages/DiagramTab.tsx
+++ b/src/ui/pages/DiagramTab.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useDropzone } from 'react-dropzone';
 import {
   Button,
   Checkbox,
@@ -10,6 +9,7 @@ import {
   SelectOption,
   Text,
 } from '../components/legacy';
+import { JsonDropZone } from '../components/JsonDropZone';
 import { tokens } from '../tokens';
 import { GraphProcessor } from '../../core/graph/graph-processor';
 import { showError } from '../hooks/notifications';
@@ -28,7 +28,7 @@ import {
   UserLayoutOptions,
 } from '../../core/layout/elk-options';
 import { HierarchyProcessor } from '../../core/graph/hierarchy-processor';
-import { getDropzoneStyle, undoLastImport } from '../hooks/ui-utils';
+import { undoLastImport } from '../hooks/ui-utils';
 
 const LAYOUTS = [
   'Layered',
@@ -98,15 +98,11 @@ export const DiagramTab: React.FC = () => {
     return () => window.removeEventListener('keydown', handler);
   }, []);
 
-  const dropzone = useDropzone({
-    accept: { 'application/json': ['.json'] },
-    maxFiles: 1,
-    onDrop: (droppedFiles: File[]): void => {
-      const file = droppedFiles[0];
-      setImportQueue([file]);
-      setError(null);
-    },
-  });
+  const handleFiles = (droppedFiles: File[]): void => {
+    const file = droppedFiles[0];
+    setImportQueue([file]);
+    setError(null);
+  };
 
   const graphProcessor = React.useMemo(() => new GraphProcessor(), []);
   const hierarchyProcessor = React.useMemo(() => new HierarchyProcessor(), []);
@@ -152,51 +148,9 @@ export const DiagramTab: React.FC = () => {
     setImportQueue([]);
   };
 
-  const style = React.useMemo(() => {
-    const state = dropzone.isDragReject
-      ? 'reject'
-      : dropzone.isDragAccept
-        ? 'accept'
-        : 'base';
-    return getDropzoneStyle(state);
-  }, [dropzone.isDragAccept, dropzone.isDragReject]);
-
   return (
     <div style={{ marginTop: tokens.space.small }}>
-      <div
-        {...dropzone.getRootProps({ style })}
-        aria-label='File drop area'
-        aria-describedby='dropzone-instructions'>
-        <InputField label='JSON file'>
-          <input
-            data-testid='file-input'
-            {...dropzone.getInputProps({ 'aria-label': 'JSON file input' })}
-          />
-        </InputField>
-        {dropzone.isDragAccept ? (
-          <Paragraph className='dnd-text'>Drop your JSON file here</Paragraph>
-        ) : (
-          <>
-            <div style={{ padding: tokens.space.small }}>
-              <Button variant='primary'>
-                <React.Fragment key='.0'>
-                  <Icon name='upload' />
-                  <Text>Select JSON file</Text>
-                </React.Fragment>
-              </Button>
-              <Paragraph className='dnd-text'>
-                Or drop your JSON file here
-              </Paragraph>
-            </div>
-          </>
-        )}
-      </div>
-      <Paragraph
-        id='dropzone-instructions'
-        className='custom-visually-hidden'>
-        Press Enter to open the file picker or drop a JSON file on the area
-        above.
-      </Paragraph>
+      <JsonDropZone onFiles={handleFiles} />
 
       {importQueue.length > 0 && (
         <>

--- a/tests/json-dropzone.test.tsx
+++ b/tests/json-dropzone.test.tsx
@@ -1,0 +1,17 @@
+/** @vitest-environment jsdom */
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { JsonDropZone } from '../src/ui/components/JsonDropZone';
+
+test('invokes callback when file selected', async () => {
+  const handle = vi.fn();
+  render(<JsonDropZone onFiles={handle} />);
+  const input = screen.getByTestId('file-input');
+  const file = new File(['{}'], 'test.json', { type: 'application/json' });
+  await act(async () => {
+    fireEvent.change(input, { target: { files: [file] } });
+  });
+  expect(handle).toHaveBeenCalled();
+  expect(handle.mock.calls[0][0]).toEqual([file]);
+});


### PR DESCRIPTION
## Summary
- refactor DiagramTab and CardsTab to use new JsonDropZone component
- add JsonDropZone component for file drop handling
- cover JsonDropZone with unit test

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860f0fc05d8832bba0f62a6568b403c