### PR TITLE
Fix layout utility and dropzone props

### DIFF
--- a/src/core/graph/graph-processor.ts
+++ b/src/core/graph/graph-processor.ts
@@ -11,7 +11,7 @@ import { UserLayoutOptions } from '../layout/elk-options';
 import { fileUtils } from '../utils/file-utils';
 import {
   computeEdgeHints,
-  boundingBox,
+  boundingBoxFromTopLeft,
   frameOffset,
 } from '../layout/layout-utils';
 import type { BaseItem, Connector, Frame, Group } from '@mirohq/websdk-types';
@@ -113,7 +113,7 @@ export class GraphProcessor {
    * Determine the bounding box for positioned nodes.
    */
   private layoutBounds(layout: LayoutResult) {
-    return boundingBox(layout.nodes);
+    return boundingBoxFromTopLeft(layout.nodes);
   }
 
   /**

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -2,7 +2,7 @@ import { BoardBuilder } from '../../board/board-builder';
 import { clearActiveFrame, registerFrame } from '../../board/frame-utils';
 import { undoWidgets, syncOrUndo } from '../../board/undo-utils';
 import { fileUtils } from '../utils/file-utils';
-import { boundingBox, frameOffset } from '../layout/layout-utils';
+import { boundingBoxFromCenter, frameOffset } from '../layout/layout-utils';
 import {
   HierNode,
   layoutHierarchy,
@@ -111,7 +111,7 @@ export class HierarchyProcessor {
    * Determine the overall bounding box of a layout result.
    */
   private computeBounds(result: NestedLayoutResult) {
-    return boundingBox(result.nodes, true);
+    return boundingBoxFromCenter(result.nodes);
   }
 
   /**

--- a/src/core/layout/layout-utils.ts
+++ b/src/core/layout/layout-utils.ts
@@ -49,42 +49,77 @@ export function computeEdgeHints(
   });
 }
 
+export interface NodePosition {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface BoundingBox {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
 /**
- * Determine the bounding box of a set of positioned nodes.
+ * Determine the bounding box of nodes positioned using their top-left corner.
  *
- * Coordinates may represent either the node center or top-left corner.
- *
- * @param nodes - Mapping of node ids to their absolute positions.
- * @param centerBased - Treat `x`/`y` as the node center when `true`.
+ * @param nodes - Mapping of node ids to absolute top-left coordinates.
  * @returns The bounding box enclosing all nodes.
  */
-export function boundingBox(
-  nodes: Record<
-    string,
-    { x: number; y: number; width: number; height: number }
-  >,
-  centerBased = false,
-): { minX: number; minY: number; maxX: number; maxY: number } {
+export function boundingBoxFromTopLeft(
+  nodes: Record<string, NodePosition>,
+): BoundingBox {
   let minX = Infinity;
   let minY = Infinity;
   let maxX = -Infinity;
   let maxY = -Infinity;
   Object.values(nodes).forEach(({ x, y, width, height }) => {
-    if (centerBased) {
-      const halfW = width / 2;
-      const halfH = height / 2;
-      minX = Math.min(minX, x - halfW);
-      minY = Math.min(minY, y - halfH);
-      maxX = Math.max(maxX, x + halfW);
-      maxY = Math.max(maxY, y + halfH);
-    } else {
-      minX = Math.min(minX, x);
-      minY = Math.min(minY, y);
-      maxX = Math.max(maxX, x + width);
-      maxY = Math.max(maxY, y + height);
-    }
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + width);
+    maxY = Math.max(maxY, y + height);
   });
   return { minX, minY, maxX, maxY };
+}
+
+/**
+ * Determine the bounding box of nodes positioned using their centre point.
+ *
+ * @param nodes - Mapping of node ids to absolute centre coordinates.
+ * @returns The bounding box enclosing all nodes.
+ */
+export function boundingBoxFromCenter(
+  nodes: Record<string, NodePosition>,
+): BoundingBox {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  Object.values(nodes).forEach(({ x, y, width, height }) => {
+    const halfW = width / 2;
+    const halfH = height / 2;
+    minX = Math.min(minX, x - halfW);
+    minY = Math.min(minY, y - halfH);
+    maxX = Math.max(maxX, x + halfW);
+    maxY = Math.max(maxY, y + halfH);
+  });
+  return { minX, minY, maxX, maxY };
+}
+
+/**
+ * @deprecated Use {@link boundingBoxFromTopLeft} or {@link boundingBoxFromCenter}.
+ * Determines the bounding box of positioned nodes.
+ */
+export function boundingBox(
+  nodes: Record<string, NodePosition>,
+  centerBased = false,
+): BoundingBox {
+  return centerBased
+    ? boundingBoxFromCenter(nodes)
+    : boundingBoxFromTopLeft(nodes);
 }
 
 /**

--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -6,7 +6,7 @@ import { tokens } from '../tokens';
 
 export interface JsonDropZoneProps {
   /** Callback invoked with selected files. */
-  onFiles: (files: File[]) => void;
+  readonly onFiles: (files: File[]) => void;
 }
 
 /** Dropzone for importing JSON files. */
@@ -20,11 +20,12 @@ export function JsonDropZone({
   });
 
   const style = React.useMemo(() => {
-    const state = dropzone.isDragReject
-      ? 'reject'
-      : dropzone.isDragAccept
-        ? 'accept'
-        : 'base';
+    let state: Parameters<typeof getDropzoneStyle>[0] = 'base';
+    if (dropzone.isDragReject) {
+      state = 'reject';
+    } else if (dropzone.isDragAccept) {
+      state = 'accept';
+    }
     return getDropzoneStyle(state);
   }, [dropzone.isDragAccept, dropzone.isDragReject]);
 

--- a/tests/layout-utils.test.ts
+++ b/tests/layout-utils.test.ts
@@ -1,7 +1,8 @@
 import {
   computeEdgeHints,
   relativePosition,
-  boundingBox,
+  boundingBoxFromCenter,
+  boundingBoxFromTopLeft,
   frameOffset,
 } from '../src/core/layout/layout-utils';
 
@@ -30,15 +31,20 @@ describe('layout-utils', () => {
     });
   });
 
-  test('boundingBox handles center coordinates', () => {
-    const box = boundingBox(
-      {
-        a: { x: 5, y: 5, width: 10, height: 10 },
-        b: { x: 15, y: 15, width: 10, height: 10 },
-      },
-      true,
-    );
+  test('boundingBoxFromCenter handles center coordinates', () => {
+    const box = boundingBoxFromCenter({
+      a: { x: 5, y: 5, width: 10, height: 10 },
+      b: { x: 15, y: 15, width: 10, height: 10 },
+    });
     expect(box).toEqual({ minX: 0, minY: 0, maxX: 20, maxY: 20 });
+  });
+
+  test('boundingBoxFromTopLeft handles absolute coordinates', () => {
+    const box = boundingBoxFromTopLeft({
+      a: { x: 0, y: 0, width: 10, height: 10 },
+      b: { x: 20, y: 20, width: 10, height: 10 },
+    });
+    expect(box).toEqual({ minX: 0, minY: 0, maxX: 30, maxY: 30 });
   });
 
   test('frameOffset computes relative translation', () => {


### PR DESCRIPTION
## Summary
- split `boundingBox` into `boundingBoxFromTopLeft` and `boundingBoxFromCenter`
- switch processors to use new helpers
- mark `JsonDropZone` props as readonly and simplify style logic
- update unit tests

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860f5be87fc832b89b3a6a2579ef5d5