### PR TITLE
Remove deprecated boundingBox helper

### DIFF
--- a/src/core/layout/layout-utils.ts
+++ b/src/core/layout/layout-utils.ts
@@ -110,19 +110,6 @@ export function boundingBoxFromCenter(
 }
 
 /**
- * @deprecated Use {@link boundingBoxFromTopLeft} or {@link boundingBoxFromCenter}.
- * Determines the bounding box of positioned nodes.
- */
-export function boundingBox(
-  nodes: Record<string, NodePosition>,
-  centerBased = false,
-): BoundingBox {
-  return centerBased
-    ? boundingBoxFromCenter(nodes)
-    : boundingBoxFromTopLeft(nodes);
-}
-
-/**
  * Calculate offsets for placing nodes within a frame at a given spot.
  *
  * @param spot - Location of the frame centre.


### PR DESCRIPTION
## Summary
- drop `boundingBox` in favour of `boundingBoxFromTopLeft` and `boundingBoxFromCenter`
- keep utilities leaner by avoiding boolean selector parameters

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6860f8a051cc832b803c120fc1a72bba