### PR TITLE
Fix core defaults

### DIFF
--- a/src/core/graph/convert.ts
+++ b/src/core/graph/convert.ts
@@ -9,7 +9,7 @@ export function edgesToHierarchy(graph: GraphData): HierNode[] {
   const children: Record<string, string[]> = {};
   const childSet = new Set<string>();
   for (const edge of graph.edges) {
-    children[edge.from] = children[edge.from] || [];
+    children[edge.from] ??= [];
     children[edge.from].push(edge.to);
     childSet.add(edge.to);
   }
@@ -21,7 +21,7 @@ export function edgesToHierarchy(graph: GraphData): HierNode[] {
       label: n.label,
       type: n.type,
       metadata: n.metadata,
-      ...(kids && kids.length ? { children: kids } : {}),
+      ...(kids?.length ? { children: kids } : {}),
     } as HierNode;
   };
   const roots = graph.nodes

--- a/src/core/graph/hierarchy-processor.ts
+++ b/src/core/graph/hierarchy-processor.ts
@@ -101,9 +101,7 @@ export class HierarchyProcessor {
     await this.createWidgets(data, result.nodes, offsetX, offsetY);
     const syncItems = this.lastCreated.filter((i) => i !== frame);
     await syncOrUndo(this.builder, this.lastCreated, syncItems);
-    const target = frame
-      ? frame
-      : (this.lastCreated as Array<BaseItem | Group>);
+    const target = frame ?? (this.lastCreated as Array<BaseItem | Group>);
     await this.builder.zoomTo(target);
   }
 

--- a/src/core/layout/layout-core.ts
+++ b/src/core/layout/layout-core.ts
@@ -82,16 +82,16 @@ export async function performLayout(
   const layouted = await elk.layout(elkGraph);
   const nodes: Record<string, PositionedNode> = {};
   const edges: PositionedEdge[] = [];
-  for (const child of layouted.children || []) {
+  for (const child of layouted.children ?? []) {
     nodes[child.id] = {
       id: child.id,
-      x: child.x || 0,
-      y: child.y || 0,
-      width: child.width || DEFAULT_WIDTH,
-      height: child.height || DEFAULT_HEIGHT,
+      x: child.x ?? 0,
+      y: child.y ?? 0,
+      width: child.width ?? DEFAULT_WIDTH,
+      height: child.height ?? DEFAULT_HEIGHT,
     };
   }
-  for (const edge of layouted.edges || []) {
+  for (const edge of layouted.edges ?? []) {
     const section = edge.sections?.[0];
     if (!section) continue;
     edges.push({


### PR DESCRIPTION
## Summary
- replace fallback logical ORs with nullish coalescing
- simplify edge list conversion logic
- prefer coalescing in HierarchyProcessor

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686104230388832b8001223326205c5a