### PR TITLE
Fix legacy component props

### DIFF
--- a/src/ui/components/JsonDropZone.tsx
+++ b/src/ui/components/JsonDropZone.tsx
@@ -4,10 +4,10 @@ import { Button, Icon, InputField, Paragraph, Text } from './legacy';
 import { getDropzoneStyle } from '../hooks/ui-utils';
 import { tokens } from '../tokens';
 
-export interface JsonDropZoneProps {
+export type JsonDropZoneProps = Readonly<{
   /** Callback invoked with selected files. */
-  readonly onFiles: (files: File[]) => void;
-}
+  onFiles: (files: File[]) => void;
+}>;
 
 /** Dropzone for importing JSON files. */
 export function JsonDropZone({

--- a/src/ui/components/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import { Button } from './legacy';
 
 export interface SegmentedOption {
-  label: string;
-  value: string;
+  readonly label: string;
+  readonly value: string;
 }
 
-interface SegmentedControlProps {
+export type SegmentedControlProps = Readonly<{
   value: string;
   onChange: (v: string) => void;
   options: SegmentedOption[];
-}
+}>;
 
 /**
  * Generic segmented control using Mirotone buttons.

--- a/src/ui/components/legacy/Button.tsx
+++ b/src/ui/components/legacy/Button.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'danger';
-}
+export type ButtonProps = Readonly<
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: 'primary' | 'secondary' | 'tertiary' | 'ghost' | 'danger';
+  }
+>;
 
 /** Basic button styled with Mirotone utility classes. */
 export function Button({

--- a/src/ui/components/legacy/Checkbox.tsx
+++ b/src/ui/components/legacy/Checkbox.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 
-export interface CheckboxProps
-  extends Omit<
-    React.InputHTMLAttributes<HTMLInputElement>,
-    'onChange' | 'value'
-  > {
-  label?: string;
-  value?: boolean;
-  onChange?: (value: boolean) => void;
-}
+export type CheckboxProps = Readonly<
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> & {
+    label?: string;
+    value?: boolean;
+    onChange?: (value: boolean) => void;
+  }
+>;
 
 /**
  * Mirotone-styled checkbox component.

--- a/src/ui/components/legacy/FormGroup.tsx
+++ b/src/ui/components/legacy/FormGroup.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type FormGroupProps = React.HTMLAttributes<HTMLDivElement>;
+export type FormGroupProps = Readonly<React.HTMLAttributes<HTMLDivElement>>;
 
 /** Wrapper for related form fields enforcing vertical rhythm. */
 export function FormGroup({

--- a/src/ui/components/legacy/Heading.tsx
+++ b/src/ui/components/legacy/Heading.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export interface HeadingProps extends React.HTMLAttributes<HTMLHeadingElement> {
-  level?: 1 | 2 | 3 | 4;
-}
+export type HeadingProps = Readonly<
+  React.HTMLAttributes<HTMLHeadingElement> & { level?: 1 | 2 | 3 | 4 }
+>;
 
 /** Simple heading element with configurable level. */
 export function Heading({

--- a/src/ui/components/legacy/Icon.tsx
+++ b/src/ui/components/legacy/Icon.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-export interface IconProps extends React.HTMLAttributes<HTMLSpanElement> {
-  name: string;
-}
+export type IconProps = Readonly<
+  React.HTMLAttributes<HTMLSpanElement> & { name: string }
+>;
 
 /** Renders a span with the Mirotone icon class. */
 export function Icon({

--- a/src/ui/components/legacy/InputField.tsx
+++ b/src/ui/components/legacy/InputField.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 
-export interface InputFieldProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
-  /** Visible label text. */
-  label: React.ReactNode;
-  /** Optional custom form control. If omitted, a text input is rendered. */
-  children?: React.ReactNode;
-  /** Class applied to the surrounding label element. */
-  wrapperClassName?: string;
-  /** Change handler returning the input value. */
-  onChange?: (value: string) => void;
-}
+export type InputFieldProps = Readonly<
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
+    /** Visible label text. */
+    label: React.ReactNode;
+    /** Optional custom form control. If omitted, a text input is rendered. */
+    children?: React.ReactNode;
+    /** Class applied to the surrounding label element. */
+    wrapperClassName?: string;
+    /** Change handler returning the input value. */
+    onChange?: (value: string) => void;
+  }
+>;
 
 /** Single component combining label and input control. */
 export function InputField({

--- a/src/ui/components/legacy/Paragraph.tsx
+++ b/src/ui/components/legacy/Paragraph.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export type ParagraphProps = React.HTMLAttributes<HTMLParagraphElement>;
+export type ParagraphProps = Readonly<
+  React.HTMLAttributes<HTMLParagraphElement>
+>;
 
 /** Paragraph element styled using Mirotone classes. */
 export function Paragraph({

--- a/src/ui/components/legacy/Select.tsx
+++ b/src/ui/components/legacy/Select.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 
-export interface SelectProps
-  extends Omit<
-    React.SelectHTMLAttributes<HTMLSelectElement>,
-    'onChange' | 'value'
-  > {
-  value?: string;
-  onChange?: (value: string) => void;
-}
+export type SelectProps = Readonly<
+  Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'onChange' | 'value'> & {
+    value?: string;
+    onChange?: (value: string) => void;
+  }
+>;
 
 /** Select dropdown styled with Mirotone classes. */
 export function Select({
@@ -31,7 +29,9 @@ export function Select({
   );
 }
 
-export type SelectOptionProps = React.OptionHTMLAttributes<HTMLOptionElement>;
+export type SelectOptionProps = Readonly<
+  React.OptionHTMLAttributes<HTMLOptionElement>
+>;
 
 /** Option element for Select. */
 export function SelectOption(props: SelectOptionProps): React.JSX.Element {

--- a/src/ui/components/legacy/Text.tsx
+++ b/src/ui/components/legacy/Text.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export type TextProps = React.HTMLAttributes<HTMLSpanElement>;
+export type TextProps = Readonly<React.HTMLAttributes<HTMLSpanElement>>;
 
 /** Span element used for button labels and inline text. */
 export function Text({


### PR DESCRIPTION
## Summary
- mark legacy React component props as readonly

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_686103ef005c832ba5f158f6b95017fe