### PR TITLE
Fix lint issues

### DIFF
--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -130,13 +130,19 @@ export class CardProcessor {
     await undoWidgets(this.builder, this.lastCreated);
   }
 
-  /** Retrieve all tags on the board, cached for the current run. */
+  /**
+   * Retrieve all tags on the board. Uses nullish assignment to cache
+   * results so multiple calls during a run hit the board only once.
+   */
   private async getBoardTags(): Promise<Tag[]> {
     this.tagsCache ??= (await miro.board.get({ type: 'tag' })) as Tag[];
     return this.tagsCache;
   }
 
-  /** Retrieve all cards on the board, cached for the current run. */
+  /**
+   * Retrieve all cards on the board. Like {@link getBoardTags} this
+   * caches the promise result so subsequent calls avoid extra lookups.
+   */
   private async getBoardCards(): Promise<Card[]> {
     this.cardsCache ??= (await miro.board.get({ type: 'card' })) as Card[];
     return this.cardsCache;

--- a/src/board/card-processor.ts
+++ b/src/board/card-processor.ts
@@ -132,17 +132,13 @@ export class CardProcessor {
 
   /** Retrieve all tags on the board, cached for the current run. */
   private async getBoardTags(): Promise<Tag[]> {
-    if (!this.tagsCache) {
-      this.tagsCache = (await miro.board.get({ type: 'tag' })) as Tag[];
-    }
+    this.tagsCache ??= (await miro.board.get({ type: 'tag' })) as Tag[];
     return this.tagsCache;
   }
 
   /** Retrieve all cards on the board, cached for the current run. */
   private async getBoardCards(): Promise<Card[]> {
-    if (!this.cardsCache) {
-      this.cardsCache = (await miro.board.get({ type: 'card' })) as Card[];
-    }
+    this.cardsCache ??= (await miro.board.get({ type: 'card' })) as Card[];
     return this.cardsCache;
   }
 
@@ -203,7 +199,7 @@ export class CardProcessor {
     for (const name of uniqueNames) {
       let tag = tagMap.get(name);
       if (!tag) {
-        tag = (await miro.board.createTag({ title: name })) as Tag;
+        tag = await miro.board.createTag({ title: name });
         tagMap.set(name, tag);
       }
       if (tag.id) {
@@ -230,7 +226,7 @@ export class CardProcessor {
       y,
     };
     if (def.fields) createOpts.fields = def.fields;
-    const card = (await miro.board.createCard(createOpts)) as Card;
+    const card = await miro.board.createCard(createOpts);
     if (def.id) {
       await card.setMetadata(CardProcessor.META_KEY, { id: def.id });
     }

--- a/src/board/frame-tools.ts
+++ b/src/board/frame-tools.ts
@@ -29,11 +29,11 @@ export async function renameSelectedFrames(
   );
   if (!frames.length) return;
   frames.sort((a, b) => {
-    const ax = (a.x as number | undefined) ?? 0;
-    const bx = (b.x as number | undefined) ?? 0;
+    const ax = a.x ?? 0;
+    const bx = b.x ?? 0;
     if (ax === bx) {
-      const ay = (a.y as number | undefined) ?? 0;
-      const by = (b.y as number | undefined) ?? 0;
+      const ay = a.y ?? 0;
+      const by = b.y ?? 0;
       return ay - by;
     }
     return ax - bx;

--- a/src/board/spacing-tools.ts
+++ b/src/board/spacing-tools.ts
@@ -85,13 +85,13 @@ export async function applySpacingLayout(
   let position = items[0][axis] ?? 0;
   await moveWidget(items[0], axis, position);
 
-  for (let i = 1; i < items.length; i += 1) {
-    const prev = items[i - 1];
-    const curr = items[i];
+  let prev = items[0];
+  for (const curr of items.slice(1)) {
     const prevSize = getDimension(prev, sizeKey);
     const currSize = getDimension(curr, sizeKey);
     position += prevSize / 2 + opts.spacing + currSize / 2;
     await moveWidget(curr, axis, position);
+    prev = curr;
   }
 }
 

--- a/src/board/style-tools.ts
+++ b/src/board/style-tools.ts
@@ -72,11 +72,11 @@ export async function tweakFillColor(
     const fontKey = getFontKey(style);
     const fill =
       typeof style[fillKey] === 'string'
-        ? (style[fillKey] as string)
+        ? style[fillKey]
         : resolveColor(tokens.color.white, colors.white);
     const font =
       fontKey && typeof style[fontKey] === 'string'
-        ? (style[fontKey] as string)
+        ? style[fontKey]
         : resolveColor(tokens.color.primaryText, colors['gray-700']);
     const newFill = adjustColor(fill, delta);
     style[fillKey] = newFill;

--- a/src/ui/style-presets.ts
+++ b/src/ui/style-presets.ts
@@ -32,7 +32,7 @@ function templateToPreset(
   tpl: { elements?: TemplateElement[] },
 ): StylePreset {
   const el = tpl.elements?.[0];
-  const style = (el?.style ?? {}) as Record<string, unknown>;
+  const style = el?.style ?? {};
   return {
     label: name,
     fontColor: (style.fontColor as string) ?? DEFAULT_PRESET.fontColor,


### PR DESCRIPTION
## Summary
- simplify board caches and remove redundant casts
- clean up frame sort logic
- refactor spacing loop
- drop superfluous type assertions in style tools and presets

## Testing
- `npm run typecheck --silent`
- `npm test --silent`
- `npm run lint --silent`
- `npm run prettier --silent`


------
https://chatgpt.com/codex/tasks/task_e_6861125d230c832b9029d70ca5ff1dee